### PR TITLE
Verilator Install Location | Re-add HTIF arg parsing | Pass Errors Correctly in *.out

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -76,7 +76,7 @@ verilog: $(sim_vsrcs)
 # helper rules to run simulator
 #########################################################################################
 run-binary: $(sim)
-	$(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(PERMISSIVE_OFF) $(BINARY) 3>&1 1>&2 2>&3 | spike-dasm > $(sim_out_name).out
+	(set -o pipefail && $(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(PERMISSIVE_OFF) $(BINARY) 3>&1 1>&2 2>&3 | spike-dasm > $(sim_out_name).out)
 
 #########################################################################################
 # run assembly/benchmarks rules
@@ -89,7 +89,7 @@ $(output_dir)/%.run: $(output_dir)/% $(sim)
 	$(sim) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(PERMISSIVE_OFF) $< && touch $@
 
 $(output_dir)/%.out: $(output_dir)/% $(sim)
-	$(sim) $(PERMISSIVE_ON) +verbose +max-cycles=$(timeout_cycles) $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $@
+	(set -o pipefail && $(sim) $(PERMISSIVE_ON) +verbose +max-cycles=$(timeout_cycles) $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $@)
 
 #########################################################################################
 # include build/project specific makefrags made from the generator

--- a/generators/utilities/src/main/resources/csrc/emulator.cc
+++ b/generators/utilities/src/main/resources/csrc/emulator.cc
@@ -121,6 +121,7 @@ int main(int argc, char** argv)
   FILE * vcdfile = NULL;
   uint64_t start = 0;
 #endif
+  char ** htif_argv = NULL;
   int verilog_plusargs_legal = 1;
 
   while (1) {
@@ -242,6 +243,10 @@ done_processing:
     usage(argv[0]);
     return 1;
   }
+  int htif_argc = 1 + argc - optind;
+  htif_argv = (char **) malloc((htif_argc) * sizeof (char *));
+  htif_argv[0] = argv[0];
+  for (int i = 1; optind < argc;) htif_argv[i++] = argv[optind++];
 
   if (verbose)
     fprintf(stderr, "using random seed %u\n", random_seed);
@@ -264,8 +269,8 @@ done_processing:
 #endif
 
   jtag = new remote_bitbang_t(rbb_port);
-  dtm = new dtm_t(argc, argv);
-  tsi = new tsi_t(argc, argv);
+  dtm = new dtm_t(htif_argc, htif_argv);
+  tsi = new tsi_t(htif_argc, htif_argv);
 
   signal(SIGTERM, handle_sigterm);
 
@@ -346,5 +351,6 @@ done_processing:
   if (tsi) delete tsi;
   if (jtag) delete jtag;
   if (tile) delete tile;
+  if (htif_argv) free(htif_argv);
   return ret;
 }

--- a/sims/verisim/Makefile
+++ b/sims/verisim/Makefile
@@ -84,7 +84,7 @@ $(sim_debug): $(model_mk_debug)
 # helper rules to run simulator with debug
 #########################################################################################
 run-binary-debug: $(sim_debug)
-	$(sim_debug) $(SIM_FLAGS) -v$(sim_out_name).vcd $(BINARY) 3>&1 1>&2 2>&3 | spike-dasm > $(sim_out_name).out
+	(set -o pipefail && $(sim_debug) $(SIM_FLAGS) -v$(sim_out_name).vcd $(BINARY) 3>&1 1>&2 2>&3 | spike-dasm > $(sim_out_name).out)
 
 #########################################################################################
 # create a verisim vpd rule

--- a/sims/verisim/verilator.mk
+++ b/sims/verisim/verilator.mk
@@ -5,9 +5,10 @@
 #########################################################################################
 # verilator version, binary, and path
 #########################################################################################
-VERILATOR_VERSION=4.016
-VERILATOR_SRCDIR=verilator/src/verilator-$(VERILATOR_VERSION)
-INSTALLED_VERILATOR=$(abspath verilator/install/bin/verilator)
+VERILATOR_VERSION      = 4.016
+VERILATOR_INSTALL_DIR ?= verilator
+VERILATOR_SRCDIR       = $(VERILATOR_INSTALL_DIR)/src/verilator-$(VERILATOR_VERSION)
+INSTALLED_VERILATOR    = $(abspath $(VERILATOR_INSTALL_DIR)/install/bin/verilator)
 
 #########################################################################################
 # build and install our own verilator to work around versioning issues
@@ -25,15 +26,15 @@ $(VERILATOR_SRCDIR)/bin/verilator: $(VERILATOR_SRCDIR)/Makefile
 
 $(VERILATOR_SRCDIR)/Makefile: $(VERILATOR_SRCDIR)/configure
 	mkdir -p $(dir $@)
-	cd $(dir $@) && ./configure --prefix=$(abspath verilator/install)
+	cd $(dir $@) && ./configure --prefix=$(abspath $(VERILATOR_INSTALL_DIR)/install)
 
-$(VERILATOR_SRCDIR)/configure: verilator/verilator-$(VERILATOR_VERSION).tar.gz
+$(VERILATOR_SRCDIR)/configure: $(VERILATOR_INSTALL_DIR)/verilator-$(VERILATOR_VERSION).tar.gz
 	rm -rf $(dir $@)
 	mkdir -p $(dir $@)
 	cat $^ | tar -xz --strip-components=1 -C $(dir $@)
 	touch $@
 
-verilator/verilator-$(VERILATOR_VERSION).tar.gz:
+$(VERILATOR_INSTALL_DIR)/verilator-$(VERILATOR_VERSION).tar.gz:
 	mkdir -p $(dir $@)
 	wget http://www.veripool.org/ftp/verilator-$(VERILATOR_VERSION).tgz -O $@
 

--- a/sims/vsim/Makefile
+++ b/sims/vsim/Makefile
@@ -90,7 +90,7 @@ $(sim_debug) : $(sim_vsrcs) $(sim_dotf)
 # helper rules to run simulator with debug
 #########################################################################################
 run-binary-debug: $(sim_debug)
-	$(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) +vcdplusfile=$(sim_out_name).vpd $(PERMISSIVE_OFF) $(BINARY) 3>&1 1>&2 2>&3 | spike-dasm > $(sim_out_name).out
+	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) +vcdplusfile=$(sim_out_name).vpd $(PERMISSIVE_OFF) $(BINARY) 3>&1 1>&2 2>&3 | spike-dasm > $(sim_out_name).out)
 
 #########################################################################################
 # create a vcs vpd rule


### PR DESCRIPTION
Added support to change the Verilator install location. Should help with CI efforts.