### PR TITLE
remove duplicate blackbox files | general grep

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -55,7 +55,7 @@ $(VERILOG_FILE) $(SMEMS_CONF) $(TOP_ANNO) $(TOP_FIR) $(sim_top_blackboxes): $(FI
 
 $(HARNESS_FILE) $(HARNESS_ANNO) $(HARNESS_FIR) $(sim_harness_blackboxes): $(FIRRTL_FILE) $(ANNO_FILE) $(sim_top_blackboxes)
 	cd $(base_dir) && $(SBT) "project tapeout" "runMain barstools.tapeout.transforms.GenerateHarness -o $(HARNESS_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(VLOG_MODEL) -faf $(ANNO_FILE) -thaof $(HARNESS_ANNO) -thf $(HARNESS_FIR) $(HARNESS_REPL_SEQ_MEM) -td $(build_dir)"
-	grep -v "SimSerial.cc\|SimDTM.cc\|SimJTAG.cc" $(build_dir)/firrtl_black_box_resource_files.f > $(sim_harness_blackboxes)
+	grep -v ".*\.cc" $(build_dir)/firrtl_black_box_resource_files.f > $(sim_harness_blackboxes)
 
 # This file is for simulation only. VLSI flows should replace this file with one containing hard SRAMs
 MACROCOMPILER_MODE ?= --mode synflops

--- a/sims/vsim/Makefile
+++ b/sims/vsim/Makefile
@@ -58,8 +58,7 @@ VCS_NONCC_OPTS = \
 	+v2k \
 	+vcs+lic+wait \
 	+vc+list \
-	-f $(sim_top_blackboxes) \
-	-f $(sim_harness_blackboxes) \
+	-f $(sim_vcs_blackboxes) \
 	-f $(sim_dotf) \
 	-sverilog \
 	+incdir+$(build_dir) \
@@ -75,14 +74,22 @@ VCS_NONCC_OPTS = \
 
 VCS_OPTS = -notice -line $(VCS_CC_OPTS) $(VCS_NONCC_OPTS)
 
+########################################################################################
+# remove duplicate blackboxes
+########################################################################################
+sim_vcs_blackboxes ?= $(build_dir)/firrtl_black_box_resource_files.vcs.f
+
+$(sim_vcs_blackboxes): $(sim_top_blackboxes) $(sim_harness_blackboxes)
+	join -a 1 -a 2 <(sort $(sim_top_blackboxes)) <(sort $(sim_harness_blackboxes)) > $@
+
 #########################################################################################
 # vcs simulator rules
 #########################################################################################
-$(sim): $(sim_vsrcs) $(sim_dotf)
+$(sim): $(sim_vsrcs) $(sim_dotf) $(sim_vcs_blackboxes)
 	rm -rf csrc && $(VCS) $(VCS_OPTS) -o $@ \
 	-debug_pp
 
-$(sim_debug) : $(sim_vsrcs) $(sim_dotf)
+$(sim_debug) : $(sim_vsrcs) $(sim_dotf) $(sim_vcs_blackboxes)
 	rm -rf csrc && $(VCS) $(VCS_OPTS) -o $@ \
 	+define+DEBUG -debug_pp
 

--- a/sims/vsim/Makefile
+++ b/sims/vsim/Makefile
@@ -80,7 +80,7 @@ VCS_OPTS = -notice -line $(VCS_CC_OPTS) $(VCS_NONCC_OPTS)
 sim_vcs_blackboxes ?= $(build_dir)/firrtl_black_box_resource_files.vcs.f
 
 $(sim_vcs_blackboxes): $(sim_top_blackboxes) $(sim_harness_blackboxes)
-	join -a 1 -a 2 <(sort $(sim_top_blackboxes)) <(sort $(sim_harness_blackboxes)) > $@
+	awk '{print $1;}' $^ | sort -u > $@
 
 #########################################################################################
 # vcs simulator rules


### PR DESCRIPTION
Fixes error in VCS when there are duplicate blackbox files in the simulation.