### PR TITLE
Temp Fix to Harness Mem Rename Issue

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -56,6 +56,7 @@ $(VERILOG_FILE) $(SMEMS_CONF) $(TOP_ANNO) $(TOP_FIR) $(sim_top_blackboxes): $(FI
 $(HARNESS_FILE) $(HARNESS_ANNO) $(HARNESS_FIR) $(sim_harness_blackboxes): $(FIRRTL_FILE) $(ANNO_FILE) $(sim_top_blackboxes)
 	cd $(base_dir) && $(SBT) "project tapeout" "runMain barstools.tapeout.transforms.GenerateHarness -o $(HARNESS_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(VLOG_MODEL) -faf $(ANNO_FILE) -thaof $(HARNESS_ANNO) -thf $(HARNESS_FIR) $(HARNESS_REPL_SEQ_MEM) -td $(build_dir)"
 	grep -v ".*\.cc" $(build_dir)/firrtl_black_box_resource_files.f > $(sim_harness_blackboxes)
+	sed -i 's/name \(\w*\)/name \1_inTestHarness/g' $(HARNESS_SMEMS_CONF)
 
 # This file is for simulation only. VLSI flows should replace this file with one containing hard SRAMs
 MACROCOMPILER_MODE ?= --mode synflops


### PR DESCRIPTION
A temporary fix to the renaming issue in test harness memories.
A more permanent fix will likely require barstools and firrtl modifications (see issue https://github.com/ucb-bar/barstools/issues/60 of barstools)