### PR TITLE
Don't replace memories in TestHarness RTL

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -47,24 +47,19 @@ $(FIRRTL_FILE) $(ANNO_FILE): $(SCALA_SOURCES) $(sim_dotf)
 # create verilog files rules and variables
 #########################################################################################
 REPL_SEQ_MEM = --infer-rw --repl-seq-mem -c:$(MODEL):-o:$(SMEMS_CONF)
-HARNESS_REPL_SEQ_MEM = --infer-rw --repl-seq-mem -c:$(MODEL):-o:$(HARNESS_SMEMS_CONF)
 
 $(VERILOG_FILE) $(SMEMS_CONF) $(TOP_ANNO) $(TOP_FIR) $(sim_top_blackboxes): $(FIRRTL_FILE) $(ANNO_FILE)
 	cd $(base_dir) && $(SBT) "project tapeout" "runMain barstools.tapeout.transforms.GenerateTop -o $(VERILOG_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(MODEL) -faf $(ANNO_FILE) -tsaof $(TOP_ANNO) -tsf $(TOP_FIR) $(REPL_SEQ_MEM) -td $(build_dir)"
 	cp $(build_dir)/firrtl_black_box_resource_files.f $(sim_top_blackboxes)
 
 $(HARNESS_FILE) $(HARNESS_ANNO) $(HARNESS_FIR) $(sim_harness_blackboxes): $(FIRRTL_FILE) $(ANNO_FILE) $(sim_top_blackboxes)
-	cd $(base_dir) && $(SBT) "project tapeout" "runMain barstools.tapeout.transforms.GenerateHarness -o $(HARNESS_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(VLOG_MODEL) -faf $(ANNO_FILE) -thaof $(HARNESS_ANNO) -thf $(HARNESS_FIR) $(HARNESS_REPL_SEQ_MEM) -td $(build_dir)"
+	cd $(base_dir) && $(SBT) "project tapeout" "runMain barstools.tapeout.transforms.GenerateHarness -o $(HARNESS_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(VLOG_MODEL) -faf $(ANNO_FILE) -thaof $(HARNESS_ANNO) -thf $(HARNESS_FIR) -td $(build_dir)"
 	grep -v ".*\.cc" $(build_dir)/firrtl_black_box_resource_files.f > $(sim_harness_blackboxes)
 
 # This file is for simulation only. VLSI flows should replace this file with one containing hard SRAMs
 MACROCOMPILER_MODE ?= --mode synflops
 $(SMEMS_FILE) $(SMEMS_FIR): $(SMEMS_CONF)
 	cd $(base_dir) && $(SBT) "project barstoolsMacros" "runMain barstools.macros.MacroCompiler -n $(SMEMS_CONF) -v $(SMEMS_FILE) -f $(SMEMS_FIR) $(MACROCOMPILER_MODE)"
-
-HARNESS_MACROCOMPILER_MODE = --mode synflops
-$(HARNESS_SMEMS_FILE) $(HARNESS_SMEMS_FIR): $(HARNESS_SMEMS_CONF)
-	cd $(base_dir) && $(SBT) "project barstoolsMacros" "runMain barstools.macros.MacroCompiler -n $(HARNESS_SMEMS_CONF) -v $(HARNESS_SMEMS_FILE) -f $(HARNESS_SMEMS_FIR) $(HARNESS_MACROCOMPILER_MODE)"
 
 #########################################################################################
 # helper rule to just make verilog files

--- a/variables.mk
+++ b/variables.mk
@@ -116,9 +116,6 @@ TOP_ANNO           ?= $(build_dir)/$(long_name).top.anno.json
 HARNESS_FILE       ?= $(build_dir)/$(long_name).harness.v
 HARNESS_FIR        ?= $(build_dir)/$(long_name).harness.fir
 HARNESS_ANNO       ?= $(build_dir)/$(long_name).harness.anno.json
-HARNESS_SMEMS_FILE ?= $(build_dir)/$(long_name).harness.mems.v
-HARNESS_SMEMS_CONF ?= $(build_dir)/$(long_name).harness.mems.conf
-HARNESS_SMEMS_FIR  ?= $(build_dir)/$(long_name).harness.mems.fir
 SMEMS_FILE         ?= $(build_dir)/$(long_name).mems.v
 SMEMS_CONF         ?= $(build_dir)/$(long_name).mems.conf
 SMEMS_FIR          ?= $(build_dir)/$(long_name).mems.fir
@@ -168,8 +165,7 @@ rocketchip_vsrc_dir = $(ROCKETCHIP_DIR)/src/main/resources/vsrc
 sim_vsrcs = \
 	$(VERILOG_FILE) \
 	$(HARNESS_FILE) \
-	$(SMEMS_FILE) \
-	$(HARNESS_SMEMS_FILE)
+	$(SMEMS_FILE)
 
 #########################################################################################
 # assembly/benchmark variables


### PR DESCRIPTION
Having an additional `*.harness.mems.v` file creates naming conflicts, and there's no reason to separate mems in the TestHarness verilog anyway, as it's not meant to be synthesized. 