### PR TITLE
Add Hwacha generator in example subproject

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ $(sim_files): $(call lookup_scala_srcs,$(base_dir)/generators/utilities/src/main
 #########################################################################################
 $(FIRRTL_FILE) $(ANNO_FILE): $(SCALA_SOURCES) $(sim_files)
 	mkdir -p $(build_dir)
-	cd $(base_dir) && $(SBT) "project $(SBT_PROJECT)" "runMain $(GENERATOR_PACKAGE).Generator $(build_dir) $(MODEL_PACKAGE) $(MODEL) $(CONFIG_PACKAGE) $(CONFIG)"
+	cd $(base_dir) && $(SBT) "project $(SBT_PROJECT)" "runMain $(GENERATOR_PACKAGE).$(GENERATOR) $(build_dir) $(MODEL_PACKAGE) $(MODEL) $(CONFIG_PACKAGE) $(CONFIG)"
 
 #########################################################################################
 # create verilog files rules and variables

--- a/generators/example/src/main/scala/Generator.scala
+++ b/generators/example/src/main/scala/Generator.scala
@@ -4,6 +4,7 @@ import chisel3._
 
 import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.util.{GeneratorApp}
+import freechips.rocketchip.system.{TestGeneration}
 
 import boom.system.{BoomTilesKey, TestSuiteHelper}
 
@@ -13,6 +14,37 @@ object Generator extends GeneratorApp {
     implicit val p: Parameters = params
     TestSuiteHelper.addRocketTestSuites
     TestSuiteHelper.addBoomTestSuites
+  }
+
+  // specify the name that the generator outputs files as
+  val longName = names.topModuleProject + "." + names.topModuleClass + "." + names.configs
+
+  // generate files
+  generateFirrtl
+  generateAnno
+  generateTestSuiteMakefrags
+  generateArtefacts
+}
+
+object GeneratorWithHwacha extends GeneratorApp {
+  // add unique test suites
+  override def addTestSuites {
+    implicit val p: Parameters = params
+    TestSuiteHelper.addRocketTestSuites
+    TestSuiteHelper.addBoomTestSuites
+
+    // add hwacha bmarks + asm tests
+    import hwacha.HwachaTestSuites._
+    TestGeneration.addSuites(rv64uv.map(_("p")))
+    TestGeneration.addSuites(rv64uv.map(_("vp")))
+    TestGeneration.addSuite(rv64sv("p"))
+    TestGeneration.addSuite(hwachaBmarks)
+  }
+
+  override def generateTestSuiteMakefrags {
+    addTestSuites
+    var frag = TestGeneration.generateMakefrag + "\nSRC_EXTENSION = $(base_dir)/hwacha/$(src_path)/*.scala" + "\nDISASM_EXTENSION = --extension=hwacha"
+    writeOutputFile(td, s"$longName.d", frag)
   }
 
   // specify the name that the generator outputs files as

--- a/variables.mk
+++ b/variables.mk
@@ -34,6 +34,7 @@ ifeq ($(SUB_PROJECT),example)
 	MODEL_PACKAGE     ?= $(SBT_PROJECT)
 	CONFIG            ?= DefaultRocketConfig
 	CONFIG_PACKAGE    ?= $(SBT_PROJECT)
+	GENERATOR         ?= Generator
 	GENERATOR_PACKAGE ?= $(SBT_PROJECT)
 	TB                ?= TestDriver
 	TOP               ?= BoomRocketTop
@@ -46,6 +47,7 @@ ifeq ($(SUB_PROJECT),boom)
 	MODEL_PACKAGE     ?= boom.system
 	CONFIG            ?= LargeBoomConfig
 	CONFIG_PACKAGE    ?= boom.system
+	GENERATOR         ?= Generator
 	GENERATOR_PACKAGE ?= boom.system
 	TB                ?= TestDriver
 	TOP               ?= BoomRocketSystem
@@ -58,6 +60,7 @@ ifeq ($(SUB_PROJECT),rocketchip)
 	MODEL_PACKAGE     ?= freechips.rocketchip.system
 	CONFIG            ?= DefaultConfig
 	CONFIG_PACKAGE    ?= freechips.rocketchip.system
+	GENERATOR         ?= Generator
 	GENERATOR_PACKAGE ?= freechips.rocketchip.system
 	TB                ?= TestDriver
 	TOP               ?= ExampleRocketSystem
@@ -70,6 +73,7 @@ ifeq ($(SUB_PROJECT),hwacha)
 	MODEL_PACKAGE     ?= freechips.rocketchip.system
 	CONFIG            ?= HwachaConfig
 	CONFIG_PACKAGE    ?= hwacha
+	GENERATOR         ?= Generator
 	GENERATOR_PACKAGE ?= hwacha
 	TB                ?= TestDriver
 	TOP               ?= ExampleRocketSystem
@@ -83,6 +87,7 @@ endif
 #	MODEL_PACKAGE     ?= freechips.rocketchip.system
 #	CONFIG            ?= FireSimRocketChipConfig
 #	CONFIG_PACKAGE    ?= firesim.firesim
+#	GENERATOR         ?= Generator
 #	GENERATOR_PACKAGE ?= firesim.firesim
 #	TB                ?= TestDriver
 #	TOP               ?= FireSimNoNIC


### PR DESCRIPTION
This is my quick solution to generating Hwacha tests for a particular config. Just create a new `Generator` that needs to be called with the `make` variables to instantiate Hwacha tests in the new setup.

For ex: `make CONFIG=HwachaBoomConfig GENERATOR=GeneratorWithHwacha`.

If anyone has recommendations on how to do this better that would be great! I basically want to create a generator that is able to detect what RoCC accelerator is on `hartId == 0` and bring in the tests for that accelerator (if any). The problem with doing this right now is that you have to code around whether you are using `MultiRoCC` or just `BuildRoCC` to instantiate the design. I can do something like... if BuildRoCC is a map (aka using `MultiRoCC`)... find out what `hart0` is assigned to and add tests, otherwise, normally check what `BuildRoCC` is. However, this seems like it can get very gnarly...

Maybe have the RoCC accelerators add the tests if they are instantiated? For that matter why not have the cores do this?

Was there a reason why the target design didn't add these tests? I feel like this is a decision that was made in the past.