### PR TITLE
Hwacha CI Update

### DIFF
--- a/.circleci/defaults.sh
+++ b/.circleci/defaults.sh
@@ -41,4 +41,4 @@ mapping["boomrocketexample"]="SUB_PROJECT=example CONFIG=DefaultBoomAndRocketCon
 mapping["boom"]="SUB_PROJECT=boom"
 mapping["rocketchip"]="SUB_PROJECT=rocketchip"
 mapping["blockdevrocketchip"]="SUB_PROJECT=example CONFIG=BlockDeviceModelRocketConfig TOP=BoomRocketTopWithBlockDevice"
-mapping["hwacha"]="SUB_PROJECT=hwacha"
+mapping["hwacha"]="SUB_PROJECT=example CONFIG=HwachaL2Config GENERATOR_PACKAGE=hwacha"

--- a/generators/example/src/main/scala/Configs.scala
+++ b/generators/example/src/main/scala/Configs.scala
@@ -63,7 +63,13 @@ class GB1MemoryConfig extends Config(
   new DefaultRocketConfig)
 
 class RocketL2Config extends Config(
-  new WithInclusiveCache ++ new DefaultRocketConfig)
+  new WithInclusiveCache ++
+  new DefaultRocketConfig)
+
+class HwachaL2Config extends Config(
+  new hwacha.DefaultHwachaConfig ++
+  new WithInclusiveCache ++
+  new DefaultRocketConfig)
 
 // ------------
 // BOOM Configs
@@ -146,7 +152,8 @@ class RV32UnifiedBoomConfig extends Config(
   new boom.system.SmallRV32UnifiedBoomConfig)
 
 class BoomL2Config extends Config(
-  new WithInclusiveCache ++ new SmallDefaultBoomConfig)
+  new WithInclusiveCache ++
+  new SmallDefaultBoomConfig)
 
 // ---------------------
 // BOOM and Rocket Configs
@@ -255,4 +262,5 @@ class RV32BoomAndRocketConfig extends Config(
   new freechips.rocketchip.system.BaseConfig)
 
 class DualCoreRocketL2Config extends Config(
-  new WithInclusiveCache ++ new DualCoreRocketConfig)
+  new WithInclusiveCache ++
+  new DualCoreRocketConfig)


### PR DESCRIPTION
Have Hwacha use the L2 during CI. This requires the config to live in `example` land. However, I use the `hwacha` generator to use the tests from their project.

This resolves the CI failures for Hwacha.