### PR TITLE
remove build.sbt dependencies - better solution?

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,9 @@ lazy val example = conditionalDependsOn(project in file("generators/example"))
   .dependsOn(boom, hwacha, sifive_blocks, sifive_cache)
   .settings(commonSettings)
 
-lazy val utilities = conditionalDependsOn(project in file("generators/utilities"))
+// should depend on just the *.jars of rocket-chip and testchipip
+// shouldn't have to rebuild if they change (as long as they are rebuilt before this)
+lazy val utilities = (project in file("generators/utilities"))
   .settings(commonSettings)
 
 lazy val icenet = (project in file("generators/icenet"))
@@ -99,7 +101,10 @@ lazy val boom = (project in file("generators/boom"))
   .dependsOn(rocketchip)
   .settings(commonSettings)
 
-lazy val tapeout = conditionalDependsOn(project in file("./tools/barstools/tapeout/"))
+// should depend on just the *.jar of testchipip
+// shouldn't have to rebuild if testchipip changes (as long as testchipip is rebuilt before this)
+lazy val tapeout = (project in file("./tools/barstools/tapeout/"))
+  .dependsOn(rocketchip)
   .settings(commonSettings)
 
 lazy val mdf = (project in file("./tools/barstools/mdf/scalalib/"))


### PR DESCRIPTION
This is a question for folks...

Take this scenario: 
I add a new module (`chisel-awl`) that has many blackboxes. I use `[set|add]Resource("path/to/file")` to add the file path to the FIRRTL annotations file. I then run the FIRRTL compiler to add the resource (using the annotation) to the `firrtl_blackbox.....f` file. This will only work because the project doing the FIRRTL passes (the compiler or `tapeout` in this repo), must `dependOn` on the new `chisel-awl` project so that its classpath can be added and thus its can resources accessed.

This is shown below with `testchipip` where `testchipip` adds resources and the `utilities` and `tapeout` project access these resources specified by `testchipip` (through the `conditionalDependsOn`). 

However, if you look at the projects `utilities` and `tapeout`, they do not share any code from `testchipip`. So they don't need to be rebuilt when `testchipip` changes... they only need to be given the most up to date version of the `testchipip` jar with the resources within it. 

Question:
Is there an elegant way of doing this? Whenever `testchipip` changes... can the `utilities` and `tapeout` projects not rebuilt? Instead, we can pass the `testchipip.jar` to them. Is there a way to specify a `sbt` `project.dependsOn` where it must make sure that the "dependsOn" project builds first BUT the  `project` doesn't rebuild if the `dependsOn` project changed? I don't think `sbt` supports this... but something like `project.softDependsOn(foo).dependsOn(bar)` so `foo` and `bar` are built first, but `project` recompiles only if `bar`/`project` changed (but `foo` is still added to the classpath).