### PR TITLE
Do not clobber LD_LIBRARY_PATH in env.sh

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -138,7 +138,7 @@ cd $RDIR
 echo "export CHIPYARD_TOOLCHAIN_SOURCED=1" > env.sh
 echo "export RISCV=$RISCV" >> env.sh
 echo "export PATH=$RISCV/bin:$RDIR/$DTCversion:\$PATH" >> env.sh
-echo "export LD_LIBRARY_PATH=$RISCV/lib" >> env.sh
+echo "export LD_LIBRARY_PATH=$RISCV/lib:\$LD_LIBRARY_PATH" >> env.sh
 echo "Toolchain Build Complete!"
 
 


### PR DESCRIPTION
When you run `env.sh` now, it clobbers the `LD_LIBRARY_PATH`. Instead, it should just append to it. Is there a specific reason for not being an append?