### PR TITLE
Only check commit-on-master on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,10 +439,20 @@ jobs:
 # Order and dependencies of jobs to run
 workflows:
     version: 2
+    submodules-on-master:
+        jobs:
+            # Check to make sure submodule commits are on master branches
+            - commit-on-master-check
+        triggers:
+            - schedule:
+                cron: "0 0 * * *"
+                filters:
+                    branches:
+                        only:
+                            - master
+
     build-and-test-chipyard-integration:
         jobs:
-            # check to make sure commits are on master
-            - commit-on-master-check
 
             # Make the toolchains
             - install-riscv-toolchain


### PR DESCRIPTION
We decided this was a bad idea, and that submodules should just avoid rebase-commits.