### PR TITLE
Fix firesim test suite generation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,10 +106,11 @@ lazy val testchipip = (project in file("generators/testchipip"))
   .settings(commonSettings)
 
 lazy val example = conditionalDependsOn(project in file("generators/example"))
-  .dependsOn(boom, hwacha, sifive_blocks, sifive_cache)
+  .dependsOn(boom, hwacha, sifive_blocks, sifive_cache, utilities)
   .settings(commonSettings)
 
 lazy val utilities = conditionalDependsOn(project in file("generators/utilities"))
+  .dependsOn(rocketchip, boom)
   .settings(commonSettings)
 
 lazy val icenet = (project in file("generators/icenet"))
@@ -165,7 +166,7 @@ lazy val midas      = ProjectRef(firesimDir, "midas")
 lazy val firesimLib = ProjectRef(firesimDir, "firesimLib")
 
 lazy val firechip = (project in file("generators/firechip"))
-  .dependsOn(boom, icenet, testchipip, sifive_blocks, sifive_cache, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
+  .dependsOn(boom, icenet, testchipip, sifive_blocks, sifive_cache, utilities, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
   .settings(
     commonSettings,
     testGrouping in Test := isolateAllTests( (definedTests in Test).value )

--- a/generators/example/src/main/scala/Generator.scala
+++ b/generators/example/src/main/scala/Generator.scala
@@ -4,6 +4,7 @@ import chisel3._
 
 import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.util.{GeneratorApp}
+import utilities.TestSuiteHelper
 
 object Generator extends GeneratorApp {
   // add unique test suites

--- a/generators/firechip/src/main/scala/Generator.scala
+++ b/generators/firechip/src/main/scala/Generator.scala
@@ -16,9 +16,9 @@ import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.subsystem.RocketTilesKey
 import freechips.rocketchip.tile.XLen
 
-import boom.system.{BoomTilesKey, BoomTestSuites}
-
 import firesim.util.{GeneratorArgs, HasTargetAgnosticUtilites, HasFireSimGeneratorUtilities}
+
+import utilities.TestSuiteHelper
 
 trait HasTestSuites {
   val rv64RegrTestNames = collection.mutable.LinkedHashSet(
@@ -58,38 +58,8 @@ trait HasTestSuites {
       "rv32ui-p-sll")
 
   def addTestSuites(targetName: String, params: Parameters) {
-    val coreParams =
-      if (params(RocketTilesKey).nonEmpty) {
-        params(RocketTilesKey).head.core
-      } else {
-        params(BoomTilesKey).head.core
-      }
-    val xlen = params(XLen)
-    val vm = coreParams.useVM
-    val env = if (vm) List("p","v") else List("p")
-    coreParams.fpu foreach { case cfg =>
-      if (xlen == 32) {
-        TestGeneration.addSuites(env.map(rv32uf))
-        if (cfg.fLen >= 64)
-          TestGeneration.addSuites(env.map(rv32ud))
-      } else {
-        TestGeneration.addSuite(rv32udBenchmarks)
-        TestGeneration.addSuites(env.map(rv64uf))
-        if (cfg.fLen >= 64)
-          TestGeneration.addSuites(env.map(rv64ud))
-      }
-    }
-    if (coreParams.useAtomics)    TestGeneration.addSuites(env.map(if (xlen == 64) rv64ua else rv32ua))
-    if (coreParams.useCompressed) TestGeneration.addSuites(env.map(if (xlen == 64) rv64uc else rv32uc))
-    val (rvi, rvu) =
-      if (params(BoomTilesKey).nonEmpty) ((if (vm) BoomTestSuites.rv64i else BoomTestSuites.rv64pi), rv64u)
-      else if (xlen == 64) ((if (vm) rv64i else rv64pi), rv64u)
-      else            ((if (vm) rv32i else rv32pi), rv32u)
-
-    TestGeneration.addSuites(rvi.map(_("p")))
-    TestGeneration.addSuites((if (vm) List("v") else List()).flatMap(env => rvu.map(_(env))))
-    TestGeneration.addSuite(benchmarks)
-    TestGeneration.addSuite(new RegressionTestSuite(if (xlen == 64) rv64RegrTestNames else rv32RegrTestNames))
+    TestSuiteHelper.addRocketTestSuites(params)
+    TestSuiteHelper.addBoomTestSuites(params)
     TestGeneration.addSuite(FastBlockdevTests)
     TestGeneration.addSuite(SlowBlockdevTests)
     if (!targetName.contains("NoNIC"))

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -137,7 +137,7 @@ class FireSimBoomConfig extends Config(
   new WithBoomL2TLBs(1024) ++
   new WithoutClockGating ++
   // Using a small config because it has 64-bit system bus, and compiles quickly
-  new boom.system.SmallBoomConfig)
+  new boom.common.SmallBoomConfig)
 
 // A safer implementation than the one in BOOM in that it
 // duplicates whatever BOOMTileKey.head is present N times. This prevents

--- a/generators/utilities/src/main/scala/TestSuites.scala
+++ b/generators/utilities/src/main/scala/TestSuites.scala
@@ -1,4 +1,4 @@
-package example
+package utilities
 
 import scala.collection.mutable.{LinkedHashSet}
 


### PR DESCRIPTION
These commits are needed in order to fix firesim-as-library compilation. Now example and firechip share the assembly test and benchmark generation.