### PR TITLE
Improve robustness/portability of toolchain shell scripts

### DIFF
--- a/scripts/build-static-libfesvr.sh
+++ b/scripts/build-static-libfesvr.sh
@@ -11,7 +11,11 @@ fi
 
 set -e
 
-objs=$(head -n 1 <(make -f <( echo -e 'include Makefile\n$(info $(value fesvr_objs))') -n))
+objs=$(make -n -f <(
+    echo 'include Makefile'
+    echo '$(info $(value fesvr_objs))'
+    ) | head -n 1)
+
 ar rcs -o libfesvr.a $objs
 cp -f libfesvr.a "${RISCV}/lib"
 

--- a/scripts/build-static-libfesvr.sh
+++ b/scripts/build-static-libfesvr.sh
@@ -13,5 +13,5 @@ set -e
 
 objs=$(head -n 1 <(make -f <( echo -e 'include Makefile\n$(info $(value fesvr_objs))') -n))
 ar rcs -o libfesvr.a $objs
-cp -f libfesvr.a $RISCV/lib
+cp -f libfesvr.a "${RISCV}/lib"
 

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -135,12 +135,13 @@ fi
 
 cd "$RDIR"
 
-echo "export CHIPYARD_TOOLCHAIN_SOURCED=1" > env.sh
-echo "export RISCV=$RISCV" >> env.sh
-echo "export PATH=$RISCV/bin:$RDIR/$DTCversion:\$PATH" >> env.sh
-echo "export LD_LIBRARY_PATH=$RISCV/lib\${LD_LIBRARY_PATH:+":${LD_LIBRARY_PATH}"}" >> env.sh
+{
+    echo "export CHIPYARD_TOOLCHAIN_SOURCED=1"
+    echo "export RISCV=$(printf '%q' "$RISCV")"
+    echo "export PATH=\${RISCV}/bin:\${PATH}"
+    echo "export LD_LIBRARY_PATH=\${RISCV}/lib\${LD_LIBRARY_PATH:+":\${LD_LIBRARY_PATH}"}"
+} > env.sh
 echo "Toolchain Build Complete!"
-
 
 if [ "$FASTINSTALL" = "false" ]; then
     # commands that can't run on EC2 (specifically, OpenOCD because of autoconf version_

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -82,12 +82,12 @@ if [ "$EC2FASTINSTALL" = "true" ]; then
           FASTINSTALL=true
           echo "Using fast pre-compiled install for riscv-tools"
       else
-          echo "Error: hash of precompiled toolchain doesn't match the riscv-tools submodule hash."
-          exit
+          error 'error: hash of precompiled toolchain does not match the riscv-tools submodule hash'
+          exit -1
       fi
     else
-          echo "Error: No precompiled toolchain for esp-tools or other non-native riscv-tools."
-          exit 
+          error "error: unsupported precompiled toolchain: ${TOOLCHAIN}"
+          exit -1
     fi
 fi
 

--- a/scripts/check-tracegen.sh
+++ b/scripts/check-tracegen.sh
@@ -13,11 +13,11 @@ AXE_SHRINK=${AXE_DIR}/src/axe-shrink.py
 PATH=$PATH:${AXE_DIR}/src
 
 grep '.*:.*#.*@' $1 > /tmp/clean-trace.txt
-$TO_AXE /tmp/clean-trace.txt > /tmp/trace.axe
-result=$($AXE check wmo /tmp/trace.axe)
+"$TO_AXE" /tmp/clean-trace.txt > /tmp/trace.axe
+result=$("$AXE" check wmo /tmp/trace.axe)
 
-if [ $result != "OK" ]; then
-    $AXE_SHRINK wmo /tmp/trace.axe
+if [ "$result" != OK ]; then
+    "$AXE_SHRINK" wmo /tmp/trace.axe
 else
-    echo "OK"
+    echo OK
 fi

--- a/scripts/firesim-setup.sh
+++ b/scripts/firesim-setup.sh
@@ -8,11 +8,11 @@ set -o pipefail
 RDIR=$(pwd)
 scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-cd $scripts_dir/..
+cd "${scripts_dir}/.."
 
 # Reenable the FireSim submodule
 git config --unset submodule.sims/firesim.update || true
 git submodule update --init sims/firesim
 cd sims/firesim
-./build-setup.sh $@ --library
-cd $RDIR
+./build-setup.sh "$@" --library
+cd "$RDIR"

--- a/scripts/init-submodules-no-riscv-tools.sh
+++ b/scripts/init-submodules-no-riscv-tools.sh
@@ -28,9 +28,9 @@ git config --unset submodule.vlsi/hammer-cad-plugins.update
 # Renable firesim and init only the required submodules to provide
 # all required scala deps, without doing a full build-setup
 git config --unset submodule.sims/firesim.update
-cd $scripts_dir/../sims/
+cd "${scripts_dir}/../sims"
 git submodule update --init firesim
 cd firesim/sim
 git submodule update --init midas
-cd $RDIR
+cd "$RDIR"
 git config submodule.sims/firesim.update none

--- a/scripts/init-vlsi.sh
+++ b/scripts/init-vlsi.sh
@@ -3,11 +3,9 @@
 set -e
 set -o pipefail
 
-
-
 # Initialize HAMMER and CAD-plugins
 git submodule update --init --recursive vlsi/hammer
 git submodule update --init --recursive vlsi/hammer-cad-plugins
 
 # Initialize HAMMER tech plugin
-git submodule update --init --recursive vlsi/hammer-$1-plugin
+git submodule update --init --recursive vlsi/hammer-"$1"-plugin


### PR DESCRIPTION
Included are miscellaneous changes to address some less known edge cases with the shell scripting and improve clarity and maintainability.

* Parse command-line options with the `getopts` builtin.
* Fix quoting to tolerate paths with whitespace characters.
* Set make jobs based on hardware thread count instead of a hard-coded value (16).