### PR TITLE
Make firrtl-interpreter a submodule instead of depending on external snapshot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "generators/rocc-template"]
 	path = generators/sha3
 	url = https://github.com/ucb-bar/rocc-template.git
+[submodule "tools/firrtl-interpreter"]
+	path = tools/firrtl-interpreter
+	url = https://github.com/freechipsproject/firrtl-interpreter.git

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val sha3 = (project in file("generators/sha3"))
   .settings(commonSettings)
 
 lazy val tapeout = conditionalDependsOn(project in file("./tools/barstools/tapeout/"))
-  .dependsOn(firrtl_interpreter)
+  .dependsOn(firrtl_interpreter, `chisel-testers`)
   .settings(commonSettings)
 
 lazy val mdf = (project in file("./tools/barstools/mdf/scalalib/"))

--- a/build.sbt
+++ b/build.sbt
@@ -68,15 +68,16 @@ def isolateAllTests(tests: Seq[TestDefinition]) = tests map { test =>
 
 // Subproject definitions begin
 //
+// NB: FIRRTL should not be a managed dependency of chisel or rocketchip.
+// Instead, they will get firrtl from the JAR file placed in /lib
+lazy val chisel  = (project in rocketChipDir / "chisel3")
+
 lazy val firrtl = (project in file("tools/firrtl"))
   .settings(commonSettings)
 
 lazy val firrtl_interpreter = (project in file("tools/firrtl-interpreter"))
   .dependsOn(firrtl)
   .settings(commonSettings)
-
-// NB: FIRRTL dependency is unmanaged (and dropped in sim/lib)
-lazy val chisel  = (project in rocketChipDir / "chisel3")
 
 lazy val treadle = freshProject("treadle", file("tools/treadle"))
   .dependsOn(firrtl)
@@ -142,19 +143,19 @@ lazy val sha3 = (project in file("generators/sha3"))
   .settings(commonSettings)
 
 lazy val tapeout = conditionalDependsOn(project in file("./tools/barstools/tapeout/"))
-  .dependsOn(firrtl_interpreter, `chisel-testers`)
+  .dependsOn(`chisel-testers`)
   .settings(commonSettings)
 
 lazy val mdf = (project in file("./tools/barstools/mdf/scalalib/"))
   .settings(commonSettings)
 
 lazy val barstoolsMacros = (project in file("./tools/barstools/macros/"))
-  .dependsOn(mdf, rocketchip)
+  .dependsOn(firrtl_interpreter, mdf, rocketchip)
   .enablePlugins(sbtassembly.AssemblyPlugin)
   .settings(commonSettings)
 
 lazy val dsptools = freshProject("dsptools", file("./tools/dsptools"))
-  .dependsOn(chisel, `chisel-testers`, firrtl_interpreter)
+  .dependsOn(chisel, `chisel-testers`)
   .settings(
       commonSettings,
       libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,5 +13,6 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.4")
 
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"


### PR DESCRIPTION
Recently, the sonatype URL we were using to pull in firrtl-interpreter stopped working. This commit adds firrtl-interpreter as a submodule and switches to including it as a project in the build.sbt instead.