### PR TITLE
Make .vpd rules generate the .out as well

### DIFF
--- a/sims/vcs/Makefile
+++ b/sims/vcs/Makefile
@@ -92,7 +92,7 @@ $(sim_debug) : $(sim_vsrcs) $(sim_common_files)
 #########################################################################################
 .PRECIOUS: $(output_dir)/%.vpd %.vpd
 $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
-	$(sim_debug) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) +vcdplusfile=$@ $(PERMISSIVE_OFF) $<
+	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) +vcdplusfile=$@ $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $<.out)
 
 #########################################################################################
 # general cleanup rule

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -110,7 +110,7 @@ $(sim_debug): $(model_mk_debug)
 $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 	rm -f $@.vcd && mkfifo $@.vcd
 	vcd2vpd $@.vcd $@ > /dev/null &
-	$(sim_debug) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) -v$@.vcd $(PERMISSIVE_OFF) $<
+	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) -v$@.vcd $(PERMISSIVE_OFF) $< 3>&1 1>&2 2>&3 | spike-dasm > $<.out)
 
 #########################################################################################
 # general cleanup rule


### PR DESCRIPTION
This fixes `run-asm-tests-debug`.
We can't have a test case to test the `run-XXX-debug` targets because the Makefiles need to generate vpds with the vcd2vpd utility.