### PR TITLE
Remove Berkeley-Managed Library Dependencies from Subprojects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ def isolateAllTests(tests: Seq[TestDefinition]) = tests map { test =>
 // before launching sbt if any of the firrtl source files has been updated
 // The jar is dropped in chipyard's lib/ directory, which is used as the unmanagedBase
 // for all subprojects
-lazy val chisel  = (project in rocketChipDir / "chisel3")
+lazy val chisel  = (project in file("tools/chisel3"))
 
 lazy val firrtl_interpreter = (project in file("tools/firrtl-interpreter"))
   .settings(commonSettings)


### PR DESCRIPTION
This PR does three things:
1) cleans up the interpreter change 
2) prevents sub-projects from fetching libraries from maven
3) uses the chisel3 in tools/ instead of the submodule in RC