### PR TITLE
Sw docs

### DIFF
--- a/docs/Software/FireMarshal.rst
+++ b/docs/Software/FireMarshal.rst
@@ -7,7 +7,7 @@ currently only supports the FireSim FPGA-accelerated simulation platform.
 **Workloads** in FireMarshal consist of a series of **Jobs** that are assigned
 to logical nodes in the target system. If no jobs are specified, then the
 workload is considered ``uniform`` and only a single image will be produced for
-all nodes in the system. Workloads are described by a json file and a
+all nodes in the system. Workloads are described by a ``json`` file and a
 corresponding workload directory and can inherit their definitions from
 existing workloads. Typically, workload configurations are kept in
 ``workloads/`` although you can use any directory you like. We provide a few

--- a/docs/Software/FireMarshal.rst
+++ b/docs/Software/FireMarshal.rst
@@ -1,0 +1,23 @@
+FireMarshal
+=================
+
+FireMarshal is a workload generation tool for RISC-V based systems. It
+currently only supports the FireSim FPGA-accelerated simulation platform.
+
+**Workloads** in FireMarshal consist of a series of **Jobs** that are assigned
+to logical nodes in the target system. If no jobs are specified, then the
+workload is considered ``uniform`` and only a single image will be produced for
+all nodes in the system. Workloads are described by a json file and a
+corresponding workload directory and can inherit their definitions from
+existing workloads. Typically, workload configurations are kept in
+``workloads/`` although you can use any directory you like. We provide a few
+basic workloads to start with including buildroot or Fedora-based linux
+distributions and bare-metal.
+
+Once you define a workload, the ``marshal`` command will produce a
+corresponding boot-binary and rootfs for each job in the workload. This binary
+and rootfs can then be launched on qemu or spike (for functional simulation), or
+installed to a platform for running on real RTL (currently only FireSim is
+automated).
+
+To get started, checkout the full `FireMarshal documentation <https://firemarshal.readthedocs.io/en/latest/index.html>`_.

--- a/docs/Software/Spike.rst
+++ b/docs/Software/Spike.rst
@@ -1,0 +1,4 @@
+The RISC-V ISA Simulator (Spike)
+=================================
+
+.. attention:: This article is a stub. Fill it out!

--- a/docs/Software/index.rst
+++ b/docs/Software/index.rst
@@ -1,0 +1,21 @@
+Target Software
+==================================
+
+Chipyard includes tools for developing target software workloads. The primary
+tool is FireMarshal, which manages workload descriptions and generates binaries
+and disk images to run on your target designs. Workloads can be bare-metal, or
+be based on standard Linux distributions. Users can customize every part of the
+build process, including providing custom kernels (if needed by the hardware).
+
+FireMarshal can also run your workloads on high-performance functional
+simulators like Spike and Qemu. Spike is easily customized and serves as the
+official RISC-V ISA reference implementation. Qemu is a high-performance
+functional simulator that can run nearly as fast as native code, but can be
+challenging to modify.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   FireMarshal
+   Spike

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,8 @@ Table of Contents
 
    Customization/index
 
+   Software/index
+
    Advanced-Usage/index
 
    TileLink-Diplomacy-Reference/index


### PR DESCRIPTION
This PR creates the Software section of chipyard docs and fills in a simple FireMarshal section which links to the official Marshal docs. A spike page was added just to fill out the structure, but I haven't put anything in there yet.