### PR TITLE
Bump SHA-3 accelerator for tutorial enhancements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -77,9 +77,9 @@
 [submodule "tools/treadle"]
 	path = tools/treadle
 	url = https://github.com/freechipsproject/treadle.git
-[submodule "generators/rocc-template"]
+[submodule "generators/sha3"]
 	path = generators/sha3
-	url = https://github.com/ucb-bar/rocc-template.git
+	url = https://github.com/ucb-bar/sha3.git
 [submodule "tools/firrtl-interpreter"]
 	path = tools/firrtl-interpreter
 	url = https://github.com/freechipsproject/firrtl-interpreter.git

--- a/build.sbt
+++ b/build.sbt
@@ -188,7 +188,7 @@ lazy val midas      = ProjectRef(firesimDir, "midas")
 lazy val firesimLib = ProjectRef(firesimDir, "firesimLib")
 
 lazy val firechip = (project in file("generators/firechip"))
-  .dependsOn(boom, icenet, testchipip, sifive_blocks, sifive_cache, utilities, tracegen, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
+  .dependsOn(boom, icenet, testchipip, sifive_blocks, sifive_cache, sha3, utilities, tracegen, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
   .settings(
     commonSettings,
     testGrouping in Test := isolateAllTests( (definedTests in Test).value )

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -138,6 +138,13 @@ class FireSimRocketChipOctaCoreConfig extends Config(
   new WithNDuplicatedRocketCores(8) ++
   new FireSimRocketChipSingleCoreConfig)
 
+// SHA-3 accelerator config
+class FireSimRocketChipSha3L2Config extends Config(
+  new WithInclusiveCache ++
+  new sha3.WithSha3Accel ++
+  new WithNBigCores(1) ++
+  new FireSimRocketChipConfig)
+
 class FireSimBoomConfig extends Config(
   new WithBootROM ++
   new WithPeripheryBusFrequency(BigInt(3200000000L)) ++


### PR DESCRIPTION
* ucb-bar/sha3#14: Conform to the finalized FIPS 202 standard.
* ucb-bar/sha3#15: Fix virtual memory interaction with interrupts.

This was tested on FireSim.