### PR TITLE
View GDS w/ gdspy

### DIFF
--- a/docs/VLSI/Tutorial.rst
+++ b/docs/VLSI/Tutorial.rst
@@ -127,6 +127,14 @@ Intermediate database are written in ``build/par-rundir`` between each step of t
 
 Timing reports are found in ``build/par-rundir/timingReports``. They are gzipped text files.
 
+`gdspy` can be used to `view the final layout <https://gdspy.readthedocs.io/en/stable/reference.html?highlight=scale#layoutviewer>`__, but it is somewhat crude and slow (wait a few minutes for it to load):
+
+.. code-block:: shell
+
+    ``python3 view_gds.py build/par-rundir/Sha3AccelwBB.gds``
+
+By default, this script only shows the M2 thru M4 routing. Layers can be toggled in the layout viewer's side pane and ``view_gds.py`` has a mapping of layer numbers to layer names.
+
 DRC & LVS
 ^^^^^^^^^
 To run DRC & LVS, and view the results in Calibre:

--- a/vlsi/view_gds.py
+++ b/vlsi/view_gds.py
@@ -1,0 +1,66 @@
+import sys
+
+try:
+    import gdspy
+except ImportError:
+    print('Bad gdspy installation!')
+    sys.exit()
+
+print('Loading GDS...')
+gds_lib = gdspy.GdsLibrary().read_gds(infile=str(sys.argv[1]), units='import')
+
+# Comment to show layer
+hidden=[
+        (1, 0),     #well
+        (1, 251),   #well lbl
+        (2, 0),     #fin
+        (3, 0),     #psub
+        (3, 251),   #psub lbl
+        (7, 0),     #gate
+        (8, 0),     #dummy
+        (10, 0),    #gate cut
+        (11, 0),    #active
+        (12, 0),    #nselect
+        (13, 0),    #pselect
+        (16, 0),    #LIG
+        (17, 0),    #LISD
+        (18, 0),    #V0
+        (19, 0),    #M1
+        (19, 251),  #M1 lbl
+        (21, 0),    #V1
+        #(20, 0),    #M2
+        (20, 251),  #M2 lbl
+        #(25, 0),    #V2
+        #(30, 0),    #M3
+        (30, 251),  #M3 lbl
+        #(35, 0),    #V3
+        #(40, 0),    #M4
+        (40, 251),  #M4 lbl
+        (45, 0),    #V4
+        (50, 0),    #M5
+        (50, 251),  #M5 lbl
+        (55, 0),    #V5
+        (60, 0),    #M6
+        (60, 251),  #M6 lbl
+        (65, 0),    #V6
+        (70, 0),    #M7
+        (70, 251),  #M7 lbl
+        (75, 0),    #V7
+        (80, 0),    #M8
+        (80, 251),  #M8 lbl
+        (85, 0),    #V8
+        (88, 0),    #SDT
+        (90, 0),    #M9
+        (90, 251),  #M9 lbl
+        (95, 0),    #V9
+        (96, 0),    #Pad
+        (97, 0),    #SLVT
+        (98, 0),    #LVT
+        (99, 0),    #SRAMDRC
+        (100, 0),   #???
+        (101, 0),   #???
+        (110, 0)    #SRAMVT
+        ]
+
+print('Opening layout...')
+gdspy.LayoutViewer(gds_lib, hidden_types=hidden, depth=1)


### PR DESCRIPTION
This adds a script for the tutorial to use `gdspy`'s LayoutViewer to look at the GDS.