### PR TITLE
Use new website links

### DIFF
--- a/docs/Chipyard-Basics/Development-Ecosystem.rst
+++ b/docs/Chipyard-Basics/Development-Ecosystem.rst
@@ -11,7 +11,7 @@ Chipyard aims to be the "one-stop shop" for creating and testing your own unique
 Chisel/FIRRTL
 -------------------------------------------
 
-One of the tools to help create new RTL designs quickly is the `Chisel Hardware Construction Language <https://chisel.eecs.berkeley.edu/>`__ and the `FIRRTL Compiler <https://freechipsproject.github.io/firrtl/>`__.
+One of the tools to help create new RTL designs quickly is the `Chisel Hardware Construction Language <https://chisel-lang.org/>`__ and the `FIRRTL Compiler <https://chisel-lang.org/firrtl/>`__.
 Chisel is an embedded language within Scala that provides a set of libraries to help hardware designers create highly parameterizable RTL.
 FIRRTL on the other hand is a compiler for hardware which allows the user to run FIRRTL passes that can do dead code elimination, circuit analysis, connectivity checks, and much more!
 These two tools in combination allow quick design space exploration and development of new RTL.

--- a/docs/Tools/Chisel.rst
+++ b/docs/Tools/Chisel.rst
@@ -1,7 +1,7 @@
 Chisel
 ===========================
 
-`Chisel <https://chisel.eecs.berkeley.edu/>`__ is an open-source hardware description language embedded in Scala.
+`Chisel <https://chisel-lang.org/>`__ is an open-source hardware description language embedded in Scala.
 It supports advanced hardware design using highly parameterized generators and supports things such as Rocket Chip and BOOM.
 
 After writing Chisel, there are multiple steps before the Chisel source code "turns into" Verilog.
@@ -16,4 +16,4 @@ However, if that passes, the output of the generator gives you an FIRRTL file an
 See :ref:`FIRRTL` for more information on how to get a FIRRTL file to Verilog.
 
 For an interactive tutorial on how to use Chisel and get started please visit the `Chisel Bootcamp <https://github.com/freechipsproject/chisel-bootcamp>`__.
-Otherwise, for all things Chisel related including API documentation, news, etc, visit their `website <https://chisel.eecs.berkeley.edu/>`__.
+Otherwise, for all things Chisel related including API documentation, news, etc, visit their `website <https://chisel-lang.org/>`__.

--- a/docs/Tools/FIRRTL.rst
+++ b/docs/Tools/FIRRTL.rst
@@ -7,6 +7,4 @@ Without going into too much detail, FIRRTL is consumed by a FIRRTL compiler (ano
 An example of a FIRRTL pass (transformation) is one that optimizes out unused signals.
 Once the transformations are done, a Verilog file is emitted and the build process is done.
 
-For more information on please visit their `website <https://freechipsproject.github.io/firrtl/>`__.
-
-
+For more information on please visit their `website <https://chisel-lang.org/firrtl/>`__.


### PR DESCRIPTION
Use the new website links. `chisel.eecs.berkeley.edu` will properly redirect. However, `freechipsproject.github.io/firrtl` is legacy at this point.