### PR TITLE
Add Verilog blackbox FireSim simulation example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val midas      = ProjectRef(firesimDir, "midas")
 lazy val firesimLib = ProjectRef(firesimDir, "firesimLib")
 
 lazy val firechip = (project in file("generators/firechip"))
-  .dependsOn(boom, icenet, testchipip, sifive_blocks, sifive_cache, sha3, utilities, tracegen, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
+  .dependsOn(boom, icenet, testchipip, example, sifive_blocks, sifive_cache, sha3, utilities, tracegen, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
   .settings(
     commonSettings,
     testGrouping in Test := isolateAllTests( (definedTests in Test).value )

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val midas      = ProjectRef(firesimDir, "midas")
 lazy val firesimLib = ProjectRef(firesimDir, "firesimLib")
 
 lazy val firechip = (project in file("generators/firechip"))
-  .dependsOn(boom, icenet, testchipip, example, sifive_blocks, sifive_cache, sha3, utilities, tracegen, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
+  .dependsOn(example, icenet, testchipip, tracegen, midasTargetUtils, midas, firesimLib % "test->test;compile->compile")
   .settings(
     commonSettings,
     testGrouping in Test := isolateAllTests( (definedTests in Test).value )

--- a/generators/firechip/src/main/scala/Targets.scala
+++ b/generators/firechip/src/main/scala/Targets.scala
@@ -101,3 +101,15 @@ class FireSimTraceGenModuleImp(outer: FireSimTraceGen) extends BaseSubsystemModu
 
 // Supernoded-ness comes from setting p(NumNodes) (see DefaultFiresimHarness) to something > 1
 class FireSimSupernode(implicit p: Parameters) extends DefaultFireSimHarness(() => new FireSimDUT)
+
+// Verilog blackbox integration demo
+class FireSimVerilogGCDDUT(implicit p: Parameters) extends FireSimDUT
+    with example.HasPeripheryGCD
+{
+  override lazy val module = new FireSimVerilogGCDModuleImp(this)
+}
+
+class FireSimVerilogGCDModuleImp[+L <: FireSimVerilogGCDDUT](l: L) extends FireSimModuleImp(l)
+    with example.HasPeripheryGCDModuleImp
+
+class FireSimVerilogGCD(implicit p: Parameters) extends DefaultFireSimHarness(() => new FireSimVerilogGCDDUT)


### PR DESCRIPTION
This provides an example design with a GCD MMIO peripheral with a Verilog blackbox in FireChip. It can be pushed through FPGA simulation with firesim/firesim#388 and ucb-bar/midas#150.