### PR TITLE
Add a specific toolchain `env.sh`

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -126,10 +126,14 @@ SRCDIR="$(pwd)/toolchains" module_all qemu --prefix="${RISCV}" --target-list=ris
 
 cd "$RDIR"
 
+# create specific env.sh
 {
     echo "export CHIPYARD_TOOLCHAIN_SOURCED=1"
     echo "export RISCV=$(printf '%q' "$RISCV")"
     echo "export PATH=\${RISCV}/bin:\${PATH}"
     echo "export LD_LIBRARY_PATH=\${RISCV}/lib\${LD_LIBRARY_PATH:+":\${LD_LIBRARY_PATH}"}"
-} > env.sh
+} > env-$TOOLCHAIN.sh
+
+# create general env.sh
+ln -s env-$TOOLCHAIN.sh env.sh
 echo "Toolchain Build Complete!"

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -135,5 +135,5 @@ cd "$RDIR"
 } > env-$TOOLCHAIN.sh
 
 # create general env.sh
-ln -s env-$TOOLCHAIN.sh env.sh
+ln -sf env-$TOOLCHAIN.sh env.sh
 echo "Toolchain Build Complete!"


### PR DESCRIPTION
This adds another `env.sh` that is specific to the toolchain that is built. This makes it so that the `env.sh` does not get clobbered.