### PR TITLE
Fix `master` CI

### DIFF
--- a/.circleci/check-commit.sh
+++ b/.circleci/check-commit.sh
@@ -21,29 +21,66 @@ git config submodule.vlsi/hammer-synopsys-plugins.update none
 git submodule update --init
 status=$(git submodule status)
 
+all_names=()
+
 search () {
     for submodule in "${submodules[@]}"
     do
         echo "Running check on submodule $submodule in $dir"
-        hash=$(echo "$status" | grep $submodule | awk '{print$1}' | grep -o "[[:alnum:]]*")
-        echo "Searching for $hash in origin/master of $submodule"
-        git -C $dir/$submodule branch -r --contains "$hash" | grep "origin/master" # needs init'ed submodules
+        hash=$(echo "$status" | grep "$dir.*$submodule " | awk '{print$1}' | grep -o "[[:alnum:]]*")
+        echo "Searching for $hash in origin/$branch of $submodule"
+        (git -C $dir/$submodule branch -r --contains "$hash" | grep "origin/$branch") && true # needs init'ed submodules
+        all_names+=("$dir/$submodule $hash $?")
     done
 }
 
 submodules=("boom" "hwacha" "icenet" "rocket-chip" "sifive-blocks" "sifive-cache" "testchipip")
 dir="generators"
+branch="master"
 
 search
 
-submodules=("esp-tools" "riscv-tools")
-dir="toolchains"
+submodules=("riscv-gnu-toolchain" "riscv-isa-sim" "riscv-pk" "riscv-tests")
+dir="toolchains/esp-tools"
+branch="master"
+
+search
+
+
+submodules=("riscv-gnu-toolchain" "riscv-isa-sim" "riscv-pk" "riscv-tests" "riscv-gnu-toolchain-prebuilt")
+dir="toolchains/riscv-tools"
+branch="master"
+
+search
+
+# riscv-openocd doesn't use its master branch
+submodules=("riscv-openocd")
+dir="toolchains/riscv-tools"
+branch="riscv"
 
 search
 
 submodules=("barstools" "chisel3" "firrtl" "torture")
 dir="tools"
+branch="master"
 
 search
+
+# turn off verbose printing to make this easier to read
+set +x
+
+# print all result strings
+for str in "${all_names[@]}";
+do
+    echo "$str"
+done
+
+# check if there was a non-zero return code
+for str in "${all_names[@]}";
+do
+    if [ ! 0 = $(echo "$str" | awk '{print$3}') ]; then
+        exit 1
+    fi
+done
 
 echo "Done checking all submodules"

--- a/.circleci/check-commit.sh
+++ b/.circleci/check-commit.sh
@@ -66,6 +66,12 @@ branch="master"
 
 search
 
+submodules=("firesim")
+dir="sims"
+branch="master"
+
+search
+
 # turn off verbose printing to make this easier to read
 set +x
 

--- a/scripts/init-submodules-no-riscv-tools.sh
+++ b/scripts/init-submodules-no-riscv-tools.sh
@@ -50,7 +50,7 @@ git config --unset submodule.vlsi/hammer-synopsys-plugins.update
 git config --unset submodule.vlsi/hammer-mentor-plugins.update
 
 if [ $NO_FIRESIM = false ]; then
-echo "initializing firesim"
+  echo "initializing firesim"
   # Renable firesim and init only the required submodules to provide
   # all required scala deps, without doing a full build-setup
   git config --unset submodule.sims/firesim.update


### PR DESCRIPTION
This does @sagark's recommendation to print out all the failures and exit only at the end of the script. Additionally, it deals with the flattened toolchain folders.