### PR TITLE
Fix VLSI Makefile

### DIFF
--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -71,7 +71,7 @@ srams: sram_generator
 sram_generator: $(SRAM_CONF)
 
 # This should be built alongside $(SMEMS_FILE)
-$(SMEMS_HAMMER): $(SMEMS_FILE)
+$(SMEMS_HAMMER): $(TOP_SMEMS_FILE)
 
 $(SRAM_GENERATOR_CONF): $(SMEMS_HAMMER)
 	mkdir -p $(dir $@)

--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -70,7 +70,7 @@ SRAM_CONF=$(build_dir)/sram_generator-output.json
 srams: sram_generator
 sram_generator: $(SRAM_CONF)
 
-# This should be built alongside $(SMEMS_FILE)
+# This should be built alongside $(TOP_SMEMS_FILE)
 $(SMEMS_HAMMER): $(TOP_SMEMS_FILE)
 
 $(SRAM_GENERATOR_CONF): $(SMEMS_HAMMER)


### PR DESCRIPTION
The `SMEMS_FILE` was supposed to be `TOP_SMEMS_FILE`