### PR TITLE
make sure grep filter only omits .h files

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -80,7 +80,7 @@ harness_macro_temp: $(HARNESS_SMEMS_CONF)
 # remove duplicate files and headers in list of simulation file inputs
 ########################################################################################
 $(sim_common_files): $(sim_files) $(sim_top_blackboxes) $(sim_harness_blackboxes)
-	awk '{print $1;}' $^ | sort -u | grep -v '.*\.h' > $@
+	awk '{print $1;}' $^ | sort -u | grep -v '.*\.h$$' > $@
 
 #########################################################################################
 # helper rule to just make verilog files


### PR DESCRIPTION
Without the end-of-line marker, the grep rule would match file paths with a ".h" anywhere in the path. For instance, if you have a configuration that begins in h (either upper or lower case), it would match on 

    generated-src/example.TestHarness.HwachaConfig/TestDriver.v

Causing the file to inappropriately omitted from sim_files.common.f