### PR TITLE
Remove MasterAXI4MMIOPort and SlaveAXI4Port

### DIFF
--- a/generators/example/src/main/scala/RocketConfigs.scala
+++ b/generators/example/src/main/scala/RocketConfigs.scala
@@ -99,6 +99,13 @@ class GPIORocketConfig extends Config(
   new freechips.rocketchip.system.BaseConfig)
 // DOC include end: GPIORocketConfig
 
+class AXI4PortsRocketConfig extends Config(
+  new WithAXI4PortsTop ++                                   // use top that creates a 2 axi4 ports to be a slave/master to offchip devices
+  new WithBootROM ++
+  new freechips.rocketchip.subsystem.WithInclusiveCache ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new freechips.rocketchip.system.BaseConfig)
+
 class DualCoreRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++

--- a/generators/example/src/main/scala/TestHarness.scala
+++ b/generators/example/src/main/scala/TestHarness.scala
@@ -32,21 +32,8 @@ class TestHarness(implicit val p: Parameters) extends Module {
 
   dut.debug := DontCare
   dut.connectSimAXIMem()
-  dut.connectSimAXIMMIO()
   dut.dontTouchPorts()
   dut.tieOffInterrupts()
-  dut.l2_frontend_bus_axi4.foreach(axi => {
-    axi.tieoff()
-    experimental.DataMirror.directionOf(axi.ar.ready) match {
-      case core.ActualDirection.Input =>
-        axi.r.bits := DontCare
-        axi.b.bits := DontCare
-      case core.ActualDirection.Output =>
-        axi.aw.bits := DontCare
-        axi.ar.bits := DontCare
-        axi.w.bits := DontCare
-    }
-  })
 
   io.success := dut.connectSimSerial()
 }
@@ -67,21 +54,8 @@ class TestHarnessWithDTM(implicit p: Parameters) extends Module
 
   dut.reset := reset.asBool | dut.debug.ndreset
   dut.connectSimAXIMem()
-  dut.connectSimAXIMMIO()
   dut.dontTouchPorts()
   dut.tieOffInterrupts()
-  dut.l2_frontend_bus_axi4.foreach(axi => {
-    axi.tieoff()
-    experimental.DataMirror.directionOf(axi.ar.ready) match {
-      case core.ActualDirection.Input =>
-        axi.r.bits := DontCare
-        axi.b.bits := DontCare
-      case core.ActualDirection.Output =>
-        axi.aw.bits := DontCare
-        axi.ar.bits := DontCare
-        axi.w.bits := DontCare
-    }
-  })
 
   Debug.connectDebug(dut.debug, clock, reset.asBool, io.success)
 }

--- a/generators/example/src/main/scala/Top.scala
+++ b/generators/example/src/main/scala/Top.scala
@@ -92,6 +92,7 @@ class TopWithDTM(implicit p: Parameters) extends System
 class TopWithDTMModule[+L <: TopWithDTM](l: L) extends SystemModule(l)
 
 //---------------------------------------------------------------------------------------------------------
+
 // DOC include start: TopWithInitZero
 class TopWithInitZero(implicit p: Parameters) extends Top
     with HasPeripheryInitZero {
@@ -101,3 +102,15 @@ class TopWithInitZero(implicit p: Parameters) extends Top
 class TopWithInitZeroModuleImp(l: TopWithInitZero) extends TopModule(l)
   with HasPeripheryInitZeroModuleImp
 // DOC include end: TopWithInitZero
+
+//---------------------------------------------------------------------------------------------------------
+
+class TopWithAXI4Ports(implicit p: Parameters) extends Top
+    with CanHaveMasterAXI4MMIOPort
+    with CanHaveSlaveAXI4Port {
+  override lazy val module = new TopWithAXI4PortsModuleImp(this)
+}
+
+class TopWithAXI4PortsModuleImp(l: TopWithAXI4Ports) extends TopModule(l)
+  with CanHaveMasterAXI4MMIOPortModuleImp
+  with CanHaveSlaveAXI4PortModuleImp

--- a/generators/utilities/src/main/scala/System.scala
+++ b/generators/utilities/src/main/scala/System.scala
@@ -25,8 +25,6 @@ class System(implicit p: Parameters) extends Subsystem
   with HasHierarchicalBusTopology
   with HasAsyncExtInterrupts
   with CanHaveMasterAXI4MemPort
-  with CanHaveMasterAXI4MMIOPort
-  with CanHaveSlaveAXI4Port
   with HasPeripheryBootROM
 {
   override lazy val module = new SystemModule(this)
@@ -39,7 +37,5 @@ class SystemModule[+L <: System](_outer: L) extends SubsystemModuleImp(_outer)
   with HasRTCModuleImp
   with HasExtInterruptsModuleImp
   with CanHaveMasterAXI4MemPortModuleImp
-  with CanHaveMasterAXI4MMIOPortModuleImp
-  with CanHaveSlaveAXI4PortModuleImp
   with HasPeripheryBootROMModuleImp
   with DontTouch


### PR DESCRIPTION
This PR removes...
MasterAXI4MMIOPort - where through Rocket Chip MMIO you can control an off-chip AXI port
and
SlaveAXI4Port - where through an off-chip AXI port you can write to the fbus.

Both of these seem to be un-needed in Chipyard by default and can be added by others in their own chips if they want to have the Chipyard SoC be a slave/master in another system. This significantly reduces the number of ports on the top-level SoC and frees up some address space (no more MMIO region for the MasterAXI4MMIOPort).