### PR TITLE
Cleanup Ctags

### DIFF
--- a/.ctagsignore
+++ b/.ctagsignore
@@ -1,1 +1,3 @@
 */target
+sims
+toolchains

--- a/scripts/gen-tags.sh
+++ b/scripts/gen-tags.sh
@@ -14,4 +14,4 @@
 #   * tags file in the directory that this was called in
 
 # ctags wrapper
-ctags -R --exclude=@.ctagsignore --links=no
+ctags -R --exclude=@.ctagsignore --links=no --languages=scala,C,C++,python


### PR DESCRIPTION
This PR makes it so that you don't parse `sims/*` or the `toolchains` folder for ctags. This drastically reduces the runtime (prevents you for looking through riscv-linux) and the filesize of the tags file. Additionally, it also just parses Scala, C, C++, and Python files.