### PR TITLE
Add UART and UARTAdapter to all configs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val rocketchip = freshProject("rocketchip", rocketChipDir)
   .dependsOn(chisel, hardfloat, rocketMacros, rocketConfig)
 
 lazy val testchipip = (project in file("generators/testchipip"))
-  .dependsOn(rocketchip)
+  .dependsOn(rocketchip, sifive_blocks)
   .settings(commonSettings)
 
 lazy val example = conditionalDependsOn(project in file("generators/example"))

--- a/docs/Generators/TestChipIP.rst
+++ b/docs/Generators/TestChipIP.rst
@@ -3,13 +3,13 @@ Test Chip IP
 
 Chipyard includes a Test Chip IP library which provides various hardware
 widgets that may be useful when designing SoCs. This includes a :ref:`Serial Adapter`,
-:ref:`Block Device Controller`, :ref:`TileLink SERDES`, and :ref:`TileLink Switcher`.
+:ref:`Block Device Controller`, :ref:`TileLink SERDES`, :ref:`TileLink Switcher`, and :ref:`UART Adapter`.
 
 Serial Adapter
 --------------
 
 The serial adapter is used by tethered test chips to communicate with the host
-processor. An instance of RISC-V frontend server running on the host CPU 
+processor. An instance of RISC-V frontend server running on the host CPU
 can send commands to the serial adapter to read and write data from the memory
 system. The frontend server uses this functionality to load the test program
 into memory and to poll for completion of the program. More information on
@@ -61,3 +61,15 @@ the select signal once TileLink messages have begun sending.
 
 For an example of how to use the switcher, take a look at the ``SwitcherTest``
 unit test in the `Test Chip IP unit tests <https://github.com/ucb-bar/testchipip/blob/master/src/main/scala/Unittests.scala>`_.
+
+UART Adapter
+------------
+
+The UART Adapter is a device that lives in the TestHarness and connects to the
+UART port of the DUT to simulate communication over UART (ex. printing out to UART
+during Linux boot). In addition to working with ``stdin/stdout`` of the host, it is able to
+output a UART log to a particular file using ``+uartlog=<NAME_OF_FILE>`` during simulation.
+
+By default, this UART Adapter is added to all systems within Chipyard by adding the
+``CanHavePeripheryUARTWithAdapter`` and ``CanHavePeripheryUARTWithAdapterImp`` traits to the ``Top`` system.
+These traits add a SiFive UART to the system as well as add the UART Adapter to the TestHarness.

--- a/generators/example/src/main/scala/BoomConfigs.scala
+++ b/generators/example/src/main/scala/BoomConfigs.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.config.{Config}
 class SmallBoomConfig extends Config(
   new WithTop ++                                            // use normal top
   new WithBootROM ++                                        // use testchipip bootrom
+  new WithUART ++                                           // add a UART
   new freechips.rocketchip.subsystem.WithInclusiveCache ++  // use SiFive L2 cache
   new boom.common.WithSmallBooms ++                         // 1-wide BOOM
   new boom.common.WithNBoomCores(1) ++                      // single-core
@@ -19,6 +20,7 @@ class SmallBoomConfig extends Config(
 class MediumBoomConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithMediumBooms ++                        // 2-wide BOOM
   new boom.common.WithNBoomCores(1) ++
@@ -27,6 +29,7 @@ class MediumBoomConfig extends Config(
 class LargeBoomConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithLargeBooms ++                         // 3-wide BOOM
   new boom.common.WithNBoomCores(1) ++
@@ -35,6 +38,7 @@ class LargeBoomConfig extends Config(
 class MegaBoomConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithMegaBooms ++                          // 4-wide BOOM
   new boom.common.WithNBoomCores(1) ++
@@ -43,6 +47,7 @@ class MegaBoomConfig extends Config(
 class DualSmallBoomConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithSmallBooms ++
   new boom.common.WithNBoomCores(2) ++                      // dual-core
@@ -51,6 +56,7 @@ class DualSmallBoomConfig extends Config(
 class SmallRV32BoomConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithoutBoomFPU ++                        // no fp
   new boom.common.WithBoomRV32 ++                          // rv32 (32bit)
@@ -61,6 +67,7 @@ class SmallRV32BoomConfig extends Config(
 class HwachaLargeBoomConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new hwacha.DefaultHwachaConfig ++                         // use Hwacha vector accelerator
   new boom.common.WithLargeBooms ++                         // 3-wide BOOM
@@ -71,6 +78,7 @@ class LoopbackNICBoomConfig extends Config(
   new WithIceNIC ++
   new WithLoopbackNICTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithLargeBooms ++                         // 3-wide BOOM
   new boom.common.WithNBoomCores(1) ++

--- a/generators/example/src/main/scala/ConfigMixins.scala
+++ b/generators/example/src/main/scala/ConfigMixins.scala
@@ -17,6 +17,7 @@ import testchipip._
 import hwacha.{Hwacha}
 
 import sifive.blocks.devices.gpio._
+import sifive.blocks.devices.uart._
 
 import icenet.{NICKey, NICConfig}
 
@@ -45,10 +46,18 @@ class WithBootROM extends Config((site, here, up) => {
  * Class to add in GPIO
  */
 class WithGPIO extends Config((site, here, up) => {
-  case PeripheryGPIOKey => List(
+  case PeripheryGPIOKey => Seq(
     GPIOParams(address = 0x10012000, width = 4, includeIOF = false))
 })
 // DOC include end: WithGPIO
+
+/**
+ * Class to add in UART
+ */
+class WithUART extends Config((site, here, up) => {
+  case PeripheryUARTKey => Seq(
+    UARTParams(address = 0x54000000L, nTxEntries = 256, nRxEntries = 256))
+})
 
 // -----------------------------------------------
 // BOOM and/or Rocket Top Level System Parameter Mixins

--- a/generators/example/src/main/scala/HeteroConfigs.scala
+++ b/generators/example/src/main/scala/HeteroConfigs.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.config.{Config}
 class LargeBoomAndRocketConfig extends Config(
   new WithTop ++                                           // default top
   new WithBootROM ++                                       // default bootrom
+  new WithUART ++                                          // add a UART
   new freechips.rocketchip.subsystem.WithInclusiveCache ++ // use SiFive l2
   new boom.common.WithRenumberHarts ++                     // avoid hartid overlap
   new boom.common.WithLargeBooms ++                        // 3-wide boom
@@ -21,6 +22,7 @@ class LargeBoomAndRocketConfig extends Config(
 class SmallBoomAndRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithRenumberHarts ++
   new boom.common.WithSmallBooms ++                        // 1-wide boom
@@ -32,6 +34,7 @@ class SmallBoomAndRocketConfig extends Config(
 class HwachaLargeBoomAndHwachaRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new hwacha.DefaultHwachaConfig ++                      // add hwacha to all harts
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithRenumberHarts ++
@@ -44,6 +47,7 @@ class HwachaLargeBoomAndHwachaRocketConfig extends Config(
 class RoccLargeBoomAndRoccRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithRoccExample ++  // add example rocc accelerator to all harts
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithRenumberHarts ++
@@ -55,6 +59,7 @@ class RoccLargeBoomAndRoccRocketConfig extends Config(
 class DualLargeBoomAndRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithRenumberHarts ++
   new boom.common.WithLargeBooms ++
@@ -66,6 +71,7 @@ class DualLargeBoomAndRocketConfig extends Config(
 class DualLargeBoomAndHwachaRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new WithMultiRoCC ++                                  // support heterogeneous rocc
   new WithMultiRoCCHwacha(2) ++                         // put hwacha on hart-2 (rocket)
@@ -79,6 +85,7 @@ class DualLargeBoomAndHwachaRocketConfig extends Config(
 class LargeBoomAndRV32RocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithRenumberHarts ++
   new boom.common.WithLargeBooms ++
@@ -91,6 +98,7 @@ class LargeBoomAndRV32RocketConfig extends Config(
 class DualLargeBoomAndDualRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new boom.common.WithRenumberHarts ++
   new boom.common.WithLargeBooms ++
@@ -102,6 +110,7 @@ class DualLargeBoomAndDualRocketConfig extends Config(
 class MultiCoreWithControlCoreConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new WithControlCore ++                                 // add small control core (last hartid)
   new boom.common.WithRenumberHarts ++

--- a/generators/example/src/main/scala/RocketConfigs.scala
+++ b/generators/example/src/main/scala/RocketConfigs.scala
@@ -11,6 +11,7 @@ import freechips.rocketchip.config.{Config}
 class RocketConfig extends Config(
   new WithTop ++                                           // use default top
   new WithBootROM ++                                       // use default bootrom
+  new WithUART ++                                          // add a UART
   new freechips.rocketchip.subsystem.WithInclusiveCache ++ // use Sifive L2 cache
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++   // single rocket-core
   new freechips.rocketchip.system.BaseConfig)              // "base" rocketchip system
@@ -18,6 +19,7 @@ class RocketConfig extends Config(
 class HwachaRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new hwacha.DefaultHwachaConfig ++                        // use Hwacha vector accelerator
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
@@ -27,6 +29,7 @@ class HwachaRocketConfig extends Config(
 class GemminiRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new gemmini.DefaultGemminiConfig ++                        // use Gemmini systolic array GEMM accelerator
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
@@ -36,6 +39,7 @@ class GemminiRocketConfig extends Config(
 class RoccRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithRoccExample ++    // use example RoCC-based accelerator
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
@@ -46,6 +50,7 @@ class jtagRocketConfig extends Config(
   new WithDTMTop ++                                        // use top with dtm
   new freechips.rocketchip.subsystem.WithJtagDTM ++        // add jtag+DTM module to coreplex
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -55,6 +60,7 @@ class jtagRocketConfig extends Config(
 class dmiRocketConfig extends Config(
   new WithDTMTop ++                                        // use top with dtm
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -64,6 +70,7 @@ class dmiRocketConfig extends Config(
 class PWMRocketConfig extends Config(
   new WithPWMTop ++                                        // use top with tilelink-controlled PWM
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -72,6 +79,7 @@ class PWMRocketConfig extends Config(
 class PWMAXI4RocketConfig extends Config(
   new WithPWMAXI4Top ++                                    // use top with axi4-controlled PWM
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -79,6 +87,7 @@ class PWMAXI4RocketConfig extends Config(
 class GCDRocketConfig extends Config(                      // add MMIO GCD module
   new WithGCDTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -87,6 +96,7 @@ class SimBlockDeviceRocketConfig extends Config(
   new testchipip.WithBlockDevice ++                        // add block-device module to peripherybus
   new WithSimBlockDeviceTop ++                             // use top with block-device IOs and connect to simblockdevice
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -95,6 +105,7 @@ class BlockDeviceModelRocketConfig extends Config(
   new testchipip.WithBlockDevice ++                        // add block-device module to periphery bus
   new WithBlockDeviceModelTop ++                           // use top with block-device IOs and connect to a blockdevicemodel
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -104,6 +115,7 @@ class GPIORocketConfig extends Config(
   new WithGPIO ++                                          // add GPIOs to the peripherybus
   new WithGPIOTop ++                                       // use top with GPIOs
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -112,6 +124,7 @@ class GPIORocketConfig extends Config(
 class DualCoreRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(2) ++   // dual-core (2 RocketTiles)
   new freechips.rocketchip.system.BaseConfig)
@@ -119,6 +132,7 @@ class DualCoreRocketConfig extends Config(
 class RV32RocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithRV32 ++           // set RocketTiles to be 32-bit
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
@@ -127,6 +141,7 @@ class RV32RocketConfig extends Config(
 class GB1MemoryRocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithExtMemSize((1<<30) * 1L) ++ // use 2GB simulated external memory
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
@@ -136,6 +151,7 @@ class GB1MemoryRocketConfig extends Config(
 class Sha3RocketConfig extends Config(
   new WithTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new sha3.WithSha3Accel ++                                // add SHA3 rocc accelerator
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
@@ -147,6 +163,7 @@ class InitZeroRocketConfig extends Config(
   new WithInitZero(0x88000000L, 0x1000L) ++
   new WithInitZeroTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
@@ -156,6 +173,7 @@ class LoopbackNICRocketConfig extends Config(
   new WithIceNIC ++
   new WithLoopbackNICTop ++
   new WithBootROM ++
+  new WithUART ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new freechips.rocketchip.system.BaseConfig)

--- a/generators/example/src/main/scala/TestHarness.scala
+++ b/generators/example/src/main/scala/TestHarness.scala
@@ -47,6 +47,7 @@ class TestHarness(implicit val p: Parameters) extends Module {
         axi.w.bits := DontCare
     }
   })
+  dut.connectSimUARTs()
 
   io.success := dut.connectSimSerial()
 }

--- a/generators/example/src/main/scala/Top.scala
+++ b/generators/example/src/main/scala/Top.scala
@@ -13,6 +13,7 @@ import testchipip._
 import utilities.{System, SystemModule}
 
 import sifive.blocks.devices.gpio._
+import sifive.blocks.devices.uart._
 
 import icenet.{HasPeripheryIceNIC, HasPeripheryIceNICModuleImp}
 
@@ -22,13 +23,15 @@ import icenet.{HasPeripheryIceNIC, HasPeripheryIceNICModuleImp}
 
 class Top(implicit p: Parameters) extends System
   with HasNoDebug
-  with HasPeripherySerial {
+  with HasPeripherySerial
+  with CanHavePeripheryUARTWithAdapter {
   override lazy val module = new TopModule(this)
 }
 
 class TopModule[+L <: Top](l: L) extends SystemModule(l)
   with HasNoDebugModuleImp
   with HasPeripherySerialModuleImp
+  with CanHavePeripheryUARTWithAdapterImp
   with DontTouch
 
 //---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a UART to all systems and adds a UARTAdapter in the TestHarness to talk to the UART.

Things to do:
- [x] Add UART to all configurations