### PR TITLE
Control Core Example

### DIFF
--- a/generators/example/src/main/scala/ConfigMixins.scala
+++ b/generators/example/src/main/scala/ConfigMixins.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.config.{Field, Parameters, Config}
 import freechips.rocketchip.subsystem.{SystemBusKey, RocketTilesKey, WithRoccExample, WithNMemoryChannels, WithNBigCores, WithRV32, CacheBlockBytes}
 import freechips.rocketchip.diplomacy.{LazyModule, ValName}
 import freechips.rocketchip.devices.tilelink.BootROMParams
-import freechips.rocketchip.tile.{RocketTileParams, XLen, BuildRoCC, TileKey, LazyRoCC}
+import freechips.rocketchip.tile.{RocketTileParams, MaxHartIdBits, XLen, BuildRoCC, TileKey, LazyRoCC}
 import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams, ICacheParams}
 
 import boom.common.{BoomTilesKey}
@@ -209,6 +209,7 @@ class WithControlCore extends Config((site, here, up) => {
         nWays = 1,
         nTLBEntries = 4,
         blockBytes = site(CacheBlockBytes))),
-      hartId = up(RocketTilesKey, site).length + up(BoomTilesKey, site).length
+      hartId = up(RocketTilesKey, site).size + up(BoomTilesKey, site).size
     )
+  case MaxHartIdBits => log2Up(up(RocketTilesKey, site).size + up(BoomTilesKey, site).size + 1)
 })

--- a/generators/example/src/main/scala/ConfigMixins.scala
+++ b/generators/example/src/main/scala/ConfigMixins.scala
@@ -4,10 +4,11 @@ import chisel3._
 import chisel3.util.{log2Up}
 
 import freechips.rocketchip.config.{Field, Parameters, Config}
-import freechips.rocketchip.subsystem.{RocketTilesKey, WithRoccExample, WithNMemoryChannels, WithNBigCores, WithRV32}
+import freechips.rocketchip.subsystem.{SystemBusKey, RocketTilesKey, WithRoccExample, WithNMemoryChannels, WithNBigCores, WithRV32, CacheBlockBytes}
 import freechips.rocketchip.diplomacy.{LazyModule, ValName}
 import freechips.rocketchip.devices.tilelink.BootROMParams
-import freechips.rocketchip.tile.{XLen, BuildRoCC, TileKey, LazyRoCC}
+import freechips.rocketchip.tile.{RocketTileParams, XLen, BuildRoCC, TileKey, LazyRoCC}
+import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams, ICacheParams}
 
 import boom.common.{BoomTilesKey}
 
@@ -182,3 +183,32 @@ class WithInitZeroTop extends Config((site, here, up) => {
     Module(LazyModule(new TopWithInitZero()(p)).module)
 })
 // DOC include end: WithInitZero
+
+/**
+ * Mixin to add a small Rocket core to the system as a "control" core.
+ * Used as an example of a PMU core.
+ */
+class WithControlCore extends Config((site, here, up) => {
+  case RocketTilesKey => up(RocketTilesKey, site) :+
+    RocketTileParams(
+      core = RocketCoreParams(
+        useVM = false,
+        fpu = None,
+        mulDiv = Some(MulDivParams(mulUnroll = 8))),
+      btb = None,
+      dcache = Some(DCacheParams(
+        rowBits = site(SystemBusKey).beatBits,
+        nSets = 64,
+        nWays = 1,
+        nTLBEntries = 4,
+        nMSHRs = 0,
+        blockBytes = site(CacheBlockBytes))),
+      icache = Some(ICacheParams(
+        rowBits = site(SystemBusKey).beatBits,
+        nSets = 64,
+        nWays = 1,
+        nTLBEntries = 4,
+        blockBytes = site(CacheBlockBytes))),
+      hartId = up(RocketTilesKey, site).length + up(BoomTilesKey, site).length
+    )
+})

--- a/generators/example/src/main/scala/HeteroConfigs.scala
+++ b/generators/example/src/main/scala/HeteroConfigs.scala
@@ -103,9 +103,9 @@ class MultiCoreWithControlCoreConfig extends Config(
   new WithTop ++
   new WithBootROM ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
+  new WithControlCore ++                                 // add small control core (last hartid)
   new boom.common.WithRenumberHarts ++
   new boom.common.WithLargeBooms ++
   new boom.common.WithNBoomCores(2) ++                   // 2 normal boom cores
   new freechips.rocketchip.subsystem.WithNBigCores(2) ++ // 2 normal rocket cores
-  new WithControlCore ++                                 // add small control core
   new freechips.rocketchip.system.BaseConfig)

--- a/generators/example/src/main/scala/HeteroConfigs.scala
+++ b/generators/example/src/main/scala/HeteroConfigs.scala
@@ -98,3 +98,14 @@ class DualLargeBoomAndDualRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(2) ++ // 2 rocket cores
   new freechips.rocketchip.system.BaseConfig)
 // DOC include end: DualBoomAndRocket
+
+class MultiCoreWithControlCoreConfig extends Config(
+  new WithTop ++
+  new WithBootROM ++
+  new freechips.rocketchip.subsystem.WithInclusiveCache ++
+  new boom.common.WithRenumberHarts ++
+  new boom.common.WithLargeBooms ++
+  new boom.common.WithNBoomCores(2) ++                   // 2 normal boom cores
+  new freechips.rocketchip.subsystem.WithNBigCores(2) ++ // 2 normal rocket cores
+  new WithControlCore ++                                 // add small control core
+  new freechips.rocketchip.system.BaseConfig)


### PR DESCRIPTION
Example MultiCore configuration with a small "control" core attached on the side (i.e. a PMU). This was requested by @jwright6323 and @alonamid.