### PR TITLE
Scratchpad Config

### DIFF
--- a/generators/example/src/main/scala/ConfigMixins.scala
+++ b/generators/example/src/main/scala/ConfigMixins.scala
@@ -35,12 +35,18 @@ import ConfigValName._
 // Common Parameter Mixins
 // -----------------------
 
+/**
+ * Mixin to add the Chipyard bootrom
+ */
 class WithBootROM extends Config((site, here, up) => {
   case BootROMParams => BootROMParams(
     contentFileName = s"./bootrom/bootrom.rv${site(XLen)}.img")
 })
 
 // DOC include start: gpio mixin
+/**
+ * Mixin to add GPIOs and tie them off outside the DUT
+ */
 class WithGPIO extends Config((site, here, up) => {
   case PeripheryGPIOKey => Seq(
     GPIOParams(address = 0x10012000, width = 4, includeIOF = false))
@@ -61,19 +67,24 @@ class WithGPIO extends Config((site, here, up) => {
 // DOC include end: gpio mixin
 
 /**
- * Class to add in UART
+ * Mixin to add in UART
  */
 class WithUART extends Config((site, here, up) => {
   case PeripheryUARTKey => Seq(
     UARTParams(address = 0x54000000L, nTxEntries = 256, nRxEntries = 256))
 })
 
-
+/**
+ * Mixin to remove any GPIOs
+ */
 class WithNoGPIO extends Config((site, here, up) => {
   case PeripheryGPIOKey => Seq()
 })
 
 // DOC include start: tsi mixin
+/**
+ * Mixin to add an offchip TSI link (used for backing memory)
+ */
 class WithTSI extends Config((site, here, up) => {
   case SerialKey => true
   case BuildTop => (clock: Clock, reset: Bool, p: Parameters, success: Bool) => {
@@ -84,6 +95,9 @@ class WithTSI extends Config((site, here, up) => {
 })
 // DOC include end: tsi mixin
 
+/**
+ * Mixin to add an DTM (used for dmi or jtag bringup)
+ */
 class WithDTM extends Config((site, here, up) => {
   case BuildTop => (clock: Clock, reset: Bool, p: Parameters, success: Bool) => {
     val top = up(BuildTop, site)(clock, reset, p, success)
@@ -94,11 +108,17 @@ class WithDTM extends Config((site, here, up) => {
 })
 
 // DOC include start: GCD mixin
+/**
+ * Mixin to add a GCD peripheral
+ */
 class WithGCD(useAXI4: Boolean, useBlackBox: Boolean) extends Config((site, here, up) => {
   case GCDKey => Some(GCDParams(useAXI4 = useAXI4, useBlackBox = useBlackBox))
 })
 // DOC include end: GCD mixin
 
+/**
+ * Mixin to add a RTL block device model
+ */
 class WithBlockDeviceModel extends Config((site, here, up) => {
   case BuildTop => (clock: Clock, reset: Bool, p: Parameters, success: Bool) => {
     val top = up(BuildTop, site)(clock, reset, p, success)
@@ -107,6 +127,9 @@ class WithBlockDeviceModel extends Config((site, here, up) => {
   }
 })
 
+/**
+ * Mixin to add a simulated block device model
+ */
 class WithSimBlockDevice extends Config((site, here, up) => {
   case BuildTop => (clock: Clock, reset: Bool, p: Parameters, success: Bool) => {
     val top = up(BuildTop, site)(clock, reset, p, success)
@@ -116,6 +139,9 @@ class WithSimBlockDevice extends Config((site, here, up) => {
 })
 
 // DOC include start: WithInitZero
+/**
+ * Mixin to add a peripheral that clears memory
+ */
 class WithInitZero(base: BigInt, size: BigInt) extends Config((site, here, up) => {
   case InitZeroKey => Some(InitZeroConfig(base, size))
 })
@@ -190,6 +216,9 @@ class WithControlCore extends Config((site, here, up) => {
   case MaxHartIdBits => log2Up(up(RocketTilesKey, site).size + up(BoomTilesKey, site).size + 1)
 })
 
+/**
+ * Mixin to add an IceNIC
+ */
 class WithIceNIC(inBufFlits: Int = 1800, usePauser: Boolean = false)
     extends Config((site, here, up) => {
   case NICKey => Some(NICConfig(
@@ -198,10 +227,20 @@ class WithIceNIC(inBufFlits: Int = 1800, usePauser: Boolean = false)
     checksumOffload = true))
 })
 
+/**
+ * Mixin to loopback the IceNIC
+ */
 class WithLoopbackNIC extends Config((site, here, up) => {
   case BuildTop => (clock: Clock, reset: Bool, p: Parameters, success: Bool) => {
     val top = up(BuildTop, site)(clock, reset, p, success)
     top.connectNicLoopback()
     top
   }
+})
+
+/**
+ * Mixin to add a backing scratchpad (default size 4MB)
+ */
+class WithBackingScratchpad(base: BigInt = 0x80000000L, mask: BigInt = ((4 << 20) - 1)) extends Config((site, here, up) => {
+  case BackingScratchpadKey => Some(BackingScratchpadParams(base, mask))
 })

--- a/generators/example/src/main/scala/RocketConfigs.scala
+++ b/generators/example/src/main/scala/RocketConfigs.scala
@@ -216,11 +216,24 @@ class InitZeroRocketConfig extends Config(
 
 class LoopbackNICRocketConfig extends Config(
   new WithTSI ++
-  new WithIceNIC ++
+  new WithIceNIC ++                                         // add an IceNIC
   new WithNoGPIO ++
-  new WithLoopbackNIC ++
+  new WithLoopbackNIC ++                                    // loopback the IceNIC
   new WithBootROM ++
   new WithUART ++
+  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
+  new freechips.rocketchip.subsystem.WithNoSlavePort ++
+  new freechips.rocketchip.subsystem.WithInclusiveCache ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new freechips.rocketchip.system.BaseConfig)
+
+class ScratchpadRocketConfig extends Config(
+  new WithTSI ++
+  new WithNoGPIO ++
+  new WithBootROM ++
+  new WithUART ++
+  new WithBackingScratchpad ++                              // add backing scratchpad
+  new freechips.rocketchip.subsystem.WithNoMemPort ++       // remove offchip mem port
   new freechips.rocketchip.subsystem.WithNoMMIOPort ++
   new freechips.rocketchip.subsystem.WithNoSlavePort ++
   new freechips.rocketchip.subsystem.WithInclusiveCache ++

--- a/generators/example/src/main/scala/Top.scala
+++ b/generators/example/src/main/scala/Top.scala
@@ -30,7 +30,8 @@ class Top(implicit p: Parameters) extends System
   with CanHavePeripheryInitZero // Enables optionally adding the initzero example widget
   with CanHavePeripheryGCD // Enables optionally adding the GCD example widget
   with CanHavePeripherySerial // Enables optionally adding the TSI serial-adapter and port
-  with CanHavePeripheryIceNIC // Enables optionally adding the IceNIC for firesim
+  with CanHavePeripheryIceNIC // Enables optionally adding the IceNIC for FireSim
+  with CanHaveBackingScratchpad // Enables optionally adding a backing scratchpad
 {
   override lazy val module = new TopModule(this)
 }

--- a/generators/example/src/main/scala/TopCakes.scala
+++ b/generators/example/src/main/scala/TopCakes.scala
@@ -1,0 +1,27 @@
+package example
+
+import chisel3._
+
+import freechips.rocketchip.subsystem.BaseSubsystem
+import freechips.rocketchip.config.{Field}
+import freechips.rocketchip.diplomacy.{LazyModule, AddressSet}
+import freechips.rocketchip.tilelink.{TLRAM}
+
+case class BackingScratchpadParams(
+  base: BigInt,
+  mask: BigInt)
+
+case object BackingScratchpadKey extends Field[Option[BackingScratchpadParams]](None)
+
+/**
+ * Trait to add a scratchpad on the mbus
+ */
+trait CanHaveBackingScratchpad { this: BaseSubsystem =>
+  private val portName = "Backing-Scratchpad"
+
+  val spadOpt = p(BackingScratchpadKey).map { param =>
+    val spad = LazyModule(new TLRAM(address=AddressSet(param.base, param.mask), beatBytes=mbus.beatBytes))
+    mbus.toVariableWidthSlave(Some(portName)) { spad.node }
+    spad
+  }
+}


### PR DESCRIPTION
Fixes #381.

Adds a configuration that removes off-chip memory interface in favor of a configurable scratchpad hanging off the `mbus`. This builds Verilog but I haven't tested any code with this. 

Based on #347 so this must go in after that. (Ill change the base branch when the other PR is done).