### PR TITLE
Clone firesim non-recursively

### DIFF
--- a/scripts/init-submodules-no-riscv-tools.sh
+++ b/scripts/init-submodules-no-riscv-tools.sh
@@ -6,25 +6,6 @@ set -o pipefail
 
 RDIR=$(git rev-parse --show-toplevel)
 
-_usage() {
-  echo "usage: ${0} [--no-firesim]" >&2
-  exit 1
-}
-
-NO_FIRESIM=false
-while getopts 'h-:' opt ; do
-  case ${opt} in
-  -)
-    case ${OPTARG} in
-    no-firesim) NO_FIRESIM=true ;;
-    *) echo "invalid option: --${OPTARG}" >&2 ; _usage ;;
-    esac ;;
-  h) _usage ;;
-  *) echo "invalid option: -${opt}" >&2 ; _usage ;;
-  esac
-done
-shift $((OPTIND - 1))
-
 # Ignore toolchain submodules
 cd "$RDIR"
 for name in toolchains/*-tools/*/ ; do
@@ -56,16 +37,17 @@ git config --unset submodule.vlsi/hammer-synopsys-plugins.update
 git config --unset submodule.vlsi/hammer-mentor-plugins.update
 
 git config --unset submodule.generators/sha3.update
-# Shallow clone by default (recursive clone would get linux)
+# Non-recursive clone to exclude riscv-linux
 git submodule update --init generators/sha3
 
-if [ $NO_FIRESIM = false ]; then
-  echo "initializing firesim"
-  # Renable firesim and init only the required submodules to provide
-  # all required scala deps, without doing a full build-setup
-  git config --unset submodule.sims/firesim.update
-  git submodule update --init sims/firesim
-  git -C sims/firesim submodule update --init sim/midas
-  git -C sims/firesim submodule update --init --recursive sw/firesim-software
-  git config submodule.sims/firesim.update none
-fi
+git config --unset submodule.sims/firesim.update
+# Minimal non-recursive clone to initialize sbt dependencies
+git submodule update --init sims/firesim
+(
+    cd sims/firesim
+    # Initialize dependencies for MIDAS-level RTL simulation
+    git submodule update --init sim/midas
+    # Exclude riscv-linux
+    git submodule update --init sw/firesim-software
+)
+git config submodule.sims/firesim.update none


### PR DESCRIPTION
This is a draft PR to demonstrate the top-level fix for the excessive riscv-linux cloning issue.

Once firesim is bumped with the midas flattening, we don't need to clone any firesim submodules except for FireMarshal.
Deprecate the `--no-firesim` switch (which did not work correctly anyway).