### PR TITLE
Enforce that macrocompiler passes are done serially

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -82,7 +82,7 @@ HARNESS_MACROCOMPILER_MODE = --mode synflops
 $(HARNESS_SMEMS_FILE) $(HARNESS_SMEMS_FIR): harness_macro_temp
 	@echo "" > /dev/null
 
-harness_macro_temp: $(HARNESS_SMEMS_CONF)
+harness_macro_temp: $(HARNESS_SMEMS_CONF) | top_macro_temp
 	cd $(base_dir) && $(SBT) "project barstoolsMacros" "runMain barstools.macros.MacroCompiler -n $(HARNESS_SMEMS_CONF) -v $(HARNESS_SMEMS_FILE) -f $(HARNESS_SMEMS_FIR) $(HARNESS_MACROCOMPILER_MODE)"
 
 ########################################################################################


### PR DESCRIPTION
If you look at the CI, there are multiple points where the `HwachaRocketConfig` fails during a MacroCompiler step with the following:

- `java.lang.NoClassDefFoundError: mdf/macrolib/PortPolarity`: https://circleci.com/gh/ucb-bar/chipyard/12736
- `java.lang.ClassFormatError: Truncated class file`: https://circleci.com/gh/ucb-bar/chipyard/13029

I haven't been able to replicate the error (yay non-determinism), but I theorize that this is a problem with 2 `sbt` runs on the same binary (e.g. MacroCompiler) running at the same time (since all our CI uses parallel `make`). `sbt` seems to only lock at the beginning when looking up things in ivy, so if MacroCompiler is getting compiled twice, it might clobber files?

This is a proposed solution by making the MacroCompiler serialized by having an order only dependency (https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html) on the harness MacroCompiler pass.

Any thoughts on this?