### PR TITLE
[firechip] Enable trace by default in BOOM-based targets

### DIFF
--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -80,6 +80,10 @@ class WithBoomL2TLBs(entries: Int) extends Config((site, here, up) => {
   ))
 })
 
+class WithBoomEnableTrace extends Config((site, here, up) => {
+  case BoomTilesKey => up(BoomTilesKey) map (tile => tile.copy(trace = true))
+})
+
 // Disables clock-gating; doesn't play nice with our FAME-1 pass
 class WithoutClockGating extends Config((site, here, up) => {
   case DebugModuleKey => up(DebugModuleKey, site).map(_.copy(clockGate = false))
@@ -176,6 +180,7 @@ class FireSimBoomConfig extends Config(
   new WithNICKey ++
   new WithSerial ++
   new WithBlockDevice ++
+  new WithBoomEnableTrace ++
   new WithBoomL2TLBs(1024) ++
   new WithoutClockGating ++
   new WithDefaultMemModel ++

--- a/generators/firechip/src/main/scala/TargetMixins.scala
+++ b/generators/firechip/src/main/scala/TargetMixins.scala
@@ -45,7 +45,7 @@ trait HasTraceIOImp extends LazyModuleImp {
   // Enabled to test TracerV trace capture
   if (p(PrintTracePort)) {
     val traceprint = Wire(UInt(512.W))
-    traceprint := Cat(traceIO.traces.map(_.asUInt))
+    traceprint := Cat(traceIO.traces.map(_.reverse.asUInt))
     printf("TRACEPORT: %x\n", traceprint)
   }
 }


### PR DESCRIPTION
Since BOOM does not drive the trace port by default, TracerV was capturing an empty trace. 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
Enables trace capture by default in BOOM-based FireChip targets.