### PR TITLE
Fix multi-rocc boom+rocket+hwacha config

### DIFF
--- a/generators/example/src/main/scala/HeteroConfigs.scala
+++ b/generators/example/src/main/scala/HeteroConfigs.scala
@@ -92,7 +92,8 @@ class DualLargeBoomAndHwachaRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNoMMIOPort ++
   new freechips.rocketchip.subsystem.WithNoSlavePort ++
   new WithMultiRoCC ++                                  // support heterogeneous rocc
-  new WithMultiRoCCHwacha(2) ++                         // put hwacha on hart-2 (rocket)
+  new WithMultiRoCCHwacha(2) ++                         // override: put hwacha on hart-2 (rocket)
+  new hwacha.DefaultHwachaConfig ++                     // setup hwacha on all harts
   new boom.common.WithRenumberHarts ++
   new boom.common.WithLargeBooms ++
   new boom.common.WithNBoomCores(2) ++


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
FIxes the `DualLargeBoomAndHwachaRocketConfig` elaboration error where it can't find the "HwachaLanes" parameter since the `DefaultHwachaConfig` was not added.
