### PR TITLE
Fix generation of env.sh for zsh

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -141,5 +141,5 @@ cd "$RDIR"
 } > env-$TOOLCHAIN.sh
 
 # create general env.sh
-echo "source \$( realpath \$(dirname "\${BASH_SOURCE[0]}") )/env-$TOOLCHAIN.sh" >> env.sh
+echo "source \$( realpath \$(dirname "\${BASH_SOURCE[0]:-\${\(%\):-%x}}") )/env-$TOOLCHAIN.sh" >> env.sh
 echo "Toolchain Build Complete!"

--- a/scripts/firesim-setup.sh
+++ b/scripts/firesim-setup.sh
@@ -6,7 +6,7 @@ set -e
 set -o pipefail
 
 RDIR=$(pwd)
-scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]:-${(%):-%x}}" )" >/dev/null 2>&1 && pwd )"
 
 cd "${scripts_dir}/.."
 

--- a/scripts/init-submodules-no-riscv-tools.sh
+++ b/scripts/init-submodules-no-riscv-tools.sh
@@ -60,4 +60,4 @@ git submodule update --init software/firemarshal
 if [ ! -f $RDIR/software/firemarshal/marshal-config.yaml ]; then
   echo "firesim-dir: '../../sims/firesim/'" > $RDIR/software/firemarshal/marshal-config.yaml
 fi
-echo "PATH=\$( realpath \$(dirname "\${BASH_SOURCE[0]}") )/software/firemarshal:\$PATH" >> $RDIR/env.sh
+echo "PATH=\$( realpath \$(dirname "\${BASH_SOURCE[0]:-\${\(%\):-%x}}") )/software/firemarshal:\$PATH" >> $RDIR/env.sh


### PR DESCRIPTION
This fixes the env.sh generation for weirdos like me.

**Type of change**: A matter of perspective

**Impact**: software change 

**Release Notes**
Make references to `BASH_SOURCE` also provide a `zsh` compatible default.