### PR TITLE
respect --no-firesim flag in init-submodules script

### DIFF
--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -19,6 +19,18 @@ fi
 
 RDIR=$(git rev-parse --show-toplevel)
 
+FIRESIM=true
+
+while test $# -gt 0
+do
+    case "$1" in
+        --no-firesim)
+            FIRESIM=false
+            ;;
+    esac
+    shift
+done
+
 # Ignore toolchain submodules
 cd "$RDIR"
 for name in toolchains/*-tools/*/ ; do
@@ -56,15 +68,17 @@ git config --unset submodule.software/firemarshal.update
 # Non-recursive clone to exclude riscv-linux
 git submodule update --init generators/sha3
 
-git config --unset submodule.sims/firesim.update
-# Minimal non-recursive clone to initialize sbt dependencies
-git submodule update --init sims/firesim
-(
-    cd sims/firesim
-    # Initialize dependencies for MIDAS-level RTL simulation
-    git submodule update --init sim/midas
-)
-git config submodule.sims/firesim.update none
+if [ "$FIRESIM" = "true" ]; then
+    git config --unset submodule.sims/firesim.update
+    # Minimal non-recursive clone to initialize sbt dependencies
+    git submodule update --init sims/firesim
+    (
+        cd sims/firesim
+        # Initialize dependencies for MIDAS-level RTL simulation
+        git submodule update --init sim/midas
+    )
+    git config submodule.sims/firesim.update none
+fi
 
 # Only shallow clone needed for basic SW tests
 git submodule update --init software/firemarshal


### PR DESCRIPTION
Firesim's build-setup script expects the init-submodules script in chipyard to respect a "--no-firesim" flag and not initialize the sims/firesim submodule. The current script does not do this, which means a second copy of firesim will be checked out if firesim is used as top. This change adds support for the flag back in. 

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
