### PR TITLE
[Documentation] Fix name of Ubuntu/Debian package "libexpat1-dev".

### DIFF
--- a/scripts/ubuntu-req.sh
+++ b/scripts/ubuntu-req.sh
@@ -10,7 +10,7 @@ curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89
 sudo apt-get update
 sudo apt-get install -y sbt
 sudo apt-get install -y texinfo gengetopt
-sudo apt-get install -y libxpat1-dev libusb-dev libncurses5-dev cmake
+sudo apt-get install -y libexpat1-dev libusb-dev libncurses5-dev cmake
 # deps for poky
 sudo apt-get install -y python3.6 patch diffstat texi2html texinfo subversion chrpath git wget
 # deps for qemu


### PR DESCRIPTION
The "libxpat1-dev" package doesn't exist on Ubuntu/Debian, and results in an error when installing Ubuntu/Debian dependencies.

The desired package: https://packages.ubuntu.com/bionic/libexpat1-dev

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->