### PR TITLE
Allow user to override MAKE command used by toolchain and openocd build

### DIFF
--- a/scripts/build-util.sh
+++ b/scripts/build-util.sh
@@ -14,7 +14,8 @@ case ${ncpu} in
 *) export MAKEFLAGS="-j ${ncpu} ${MAKEFLAGS}" ;;
 esac
 
-MAKE=$(command -v gnumake || command -v gmake || command -v make)
+# Allow user to override MAKE
+[ -n "${MAKE}" ] || MAKE=$(command -v gnumake || command -v gmake || command -v make)
 readonly MAKE
 
 


### PR DESCRIPTION
On macOS, "gnumake" and "make" are both supplied by the OS, but are too old to build glibc (both are version 3.81 as of this writing). Homebrew provides the "gmake" executable, which is recent enough for glibc. However, the existing logic in "scripts/build-util.sh" will always prefer "gnumake" over "gmake".

The configure logic in the riscv-glibc library allows a user to override the preference for "gnumake" by setting the MAKE environment variable. This change makes "scripts/build-openocd.sh" and "scripts/build-toolchains.sh" mimic that behavior. A user can now use "gmake" instead of "gnumake" during the toolchain build like so:

    MAKE=gmake ./scripts/build-toolchains.sh

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
