### PR TITLE
[WIP][dromajo] Automate dromajo-enabled simulations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -119,3 +119,6 @@
 [submodule "tools/DRAMSim2"]
 	path = tools/DRAMSim2
 	url = https://github.com/firesim/DRAMSim2.git
+[submodule "tools/dromajo"]
+	path = tools/dromajo
+	url = https://github.com/abejgonzalez/dromajo.git

--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -13,7 +13,7 @@ import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams
 import freechips.rocketchip.util.{AsyncResetReg}
 
 import boom.common.{BoomTilesKey}
-
+import ariane.{ArianeTilesKey}
 import testchipip._
 
 import hwacha.{Hwacha}
@@ -151,7 +151,8 @@ class WithControlCore extends Config((site, here, up) => {
   case MaxHartIdBits => log2Up(up(RocketTilesKey, site).size + up(BoomTilesKey, site).size + 1)
 })
 
-class WithBoomTraceIO extends Config((site, here, up) => {
+class WithTraceIO extends Config((site, here, up) => {
   case BoomTilesKey => up(BoomTilesKey) map (tile => tile.copy(trace = true))
+  case ArianeTilesKey => up(ArianeTilesKey) map (tile => tile.copy(trace = true))
   case TracePortKey => Some(TracePortParams())
 })

--- a/generators/chipyard/src/main/scala/config/BoomConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/BoomConfigs.scala
@@ -6,27 +6,6 @@ import freechips.rocketchip.config.{Config}
 // BOOM Configs
 // ---------------------
 
-class DromajoBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++                      // display UART with a SimUARTAdapter
-  new chipyard.iobinders.WithTieOffInterrupts ++                 // tie off top-level interrupts
-  new chipyard.iobinders.WithBlackBoxSimMem ++                   // drive the master AXI4 memory with a SimAXIMem
-  new chipyard.iobinders.WithTiedOffDebug ++                     // tie off debug (since we are using SimSerial for testing)
-  new chipyard.iobinders.WithSimSerial ++                        // drive TSI with SimSerial for testing
-  new chipyard.iobinders.WithSimDromajoBridge ++
-  new chipyard.config.WithBoomTraceIO ++
-  new testchipip.WithTSI ++                                      // use testchipip serial offchip link
-  new chipyard.config.WithNoGPIO ++                              // no top-level GPIO pins (overrides default set in sifive-blocks)
-  new chipyard.config.WithBootROM ++                             // use default bootrom
-  new chipyard.config.WithUART ++                                // add a UART
-  new chipyard.config.WithL2TLBs(1024) ++                        // use L2 TLBs
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++           // no top-level MMIO master port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++          // no top-level MMIO slave port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++       // use Sifive L2 cache
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++ // no external interrupts
-  new boom.common.WithMediumBooms ++
-  new boom.common.WithNBoomCores(1) ++                           // single-core boom
-  new freechips.rocketchip.system.BaseConfig)                    // "base" rocketchip system
-
 class SmallBoomConfig extends Config(
   new chipyard.iobinders.WithUARTAdapter ++                      // display UART with a SimUARTAdapter
   new chipyard.iobinders.WithTieOffInterrupts ++                 // tie off top-level interrupts
@@ -181,6 +160,27 @@ class LoopbackNICLargeBoomConfig extends Config(
   new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new boom.common.WithLargeBooms ++
+  new boom.common.WithNBoomCores(1) ++
+  new freechips.rocketchip.system.BaseConfig)
+
+class DromajoBoomConfig extends Config(
+  new chipyard.iobinders.WithUARTAdapter ++
+  new chipyard.iobinders.WithTieOffInterrupts ++
+  new chipyard.iobinders.WithBlackBoxSimMem ++
+  new chipyard.iobinders.WithTiedOffDebug ++
+  new chipyard.iobinders.WithSimSerial ++
+  new chipyard.iobinders.WithSimDromajoBridge ++                 // attach Dromajo
+  new testchipip.WithTSI ++
+  new chipyard.config.WithTraceIO ++                             // enable the traceio
+  new chipyard.config.WithNoGPIO ++
+  new chipyard.config.WithBootROM ++
+  new chipyard.config.WithUART ++
+  new chipyard.config.WithL2TLBs(1024) ++
+  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
+  new freechips.rocketchip.subsystem.WithNoSlavePort ++
+  new freechips.rocketchip.subsystem.WithInclusiveCache ++
+  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
+  new boom.common.WithMediumBooms ++
   new boom.common.WithNBoomCores(1) ++
   new freechips.rocketchip.system.BaseConfig)
 

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -75,23 +75,16 @@ class WithNIC extends icenet.WithIceNIC(inBufFlits = 8192, ctrlQueueDepth = 64)
 
 
 
-// Enables tracing on all cores
-class WithTraceIO extends Config((site, here, up) => {
-  case BoomTilesKey => up(BoomTilesKey) map (tile => tile.copy(trace = true))
-  case ArianeTilesKey => up(ArianeTilesKey) map (tile => tile.copy(trace = true))
-  case TracePortKey => Some(TracePortParams())
-})
-
 
 // Tweaks that are generally applied to all firesim configs
 class WithFireSimConfigTweaks extends Config(
   new WithBootROM ++ // needed to support FireSim-as-top
   new WithPeripheryBusFrequency(BigInt(3200000000L)) ++ // 3.2 GHz
   new WithoutClockGating ++
-  new WithTraceIO ++
   new freechips.rocketchip.subsystem.WithExtMemSize((1 << 30) * 16L) ++ // 16 GB
   new testchipip.WithTSI ++
   new testchipip.WithBlockDevice ++
+  new chipyard.config.WithTraceIO ++
   new chipyard.config.WithUART
 )
 

--- a/sims/vcs/Makefile
+++ b/sims/vcs/Makefile
@@ -48,8 +48,10 @@ VCS_CC_OPTS = \
 	-CC "-I$(VCS_HOME)/include" \
 	-CC "-I$(RISCV)/include" \
 	-CC "-I$(dramsim_dir)" \
+	-CC "-I$(dromajo_dir)" \
 	-CC "-std=c++11" \
 	$(dramsim_lib) \
+	$(dromajo_lib) \
 	$(RISCV)/lib/libfesvr.a
 
 VCS_NONCC_OPTS = \
@@ -85,11 +87,11 @@ VCS_OPTS = -notice -line $(VCS_CC_OPTS) $(VCS_NONCC_OPTS) $(VCS_DEFINES)
 #########################################################################################
 # vcs simulator rules
 #########################################################################################
-$(sim): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib)
+$(sim): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib) $(dromajo_lib)
 	rm -rf csrc && $(VCS) $(VCS_OPTS) -o $@ \
 	-debug_pp
 
-$(sim_debug): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib)
+$(sim_debug): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib) $(dromajo_lib)
 	rm -rf csrc && $(VCS) $(VCS_OPTS) -o $@ \
 	+define+DEBUG \
 	-debug_pp
@@ -99,7 +101,7 @@ $(sim_debug): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib)
 #########################################################################################
 .PRECIOUS: $(output_dir)/%.vpd %.vpd
 $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
-	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) +vcdplusfile=$@ $(PERMISSIVE_OFF) $< </dev/null 2> >(spike-dasm > $<.out) | tee $<.log)
+	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) +dramsim +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) +vcdplusfile=$@ $(DROMAJO_FLAGS) +drj_bin=$< $(PERMISSIVE_OFF) $< </dev/null 2> >(spike-dasm > $<.out) | tee $<.log)
 
 #########################################################################################
 # general cleanup rule

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -47,8 +47,19 @@ include $(base_dir)/common.mk
 #########################################################################################
 VERILATOR := verilator --cc --exe
 
-CXXFLAGS := $(CXXFLAGS) -O1 -std=c++11 -I$(RISCV)/include -I$(dramsim_dir) -D__STDC_FORMAT_MACROS
-LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(dramsim_dir) -Wl,-rpath,$(dramsim_dir) -L$(sim_dir) -lfesvr -lpthread -ldramsim
+CXXFLAGS := \
+	$(CXXFLAGS) -O1 -std=c++11 \
+	-I$(RISCV)/include \
+	-I$(dramsim_dir) \
+	-I$(dromajo_dir) \
+	-D__STDC_FORMAT_MACROS
+
+LDFLAGS := \
+	$(LDFLAGS) \
+	-L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib \
+	-L$(dramsim_dir) -Wl,-rpath,$(dramsim_dir) \
+	-L$(dromajo_dir) -Wl,-rpath,$(dromajo_dir) \
+	-L$(sim_dir) -lfesvr -lpthread -ldramsim
 
 VERILATOR_CC_OPTS = \
 	-O3 \
@@ -119,10 +130,10 @@ $(model_mk_debug): $(sim_vsrcs) $(sim_common_files)
 #########################################################################################
 # invoke make to make verilator sim rules
 #########################################################################################
-$(sim): $(model_mk) $(dramsim_lib)
+$(sim): $(model_mk) $(dramsim_lib) $(dromajo_lib)
 	$(MAKE) VM_PARALLEL_BUILDS=1 -C $(model_dir) -f V$(VLOG_MODEL).mk
 
-$(sim_debug): $(model_mk_debug) $(dramsim_lib)
+$(sim_debug): $(model_mk_debug) $(dramsim_lib) $(dromajo_lib)
 	$(MAKE) VM_PARALLEL_BUILDS=1 -C $(model_dir_debug) -f V$(VLOG_MODEL).mk
 
 #########################################################################################
@@ -132,7 +143,7 @@ $(sim_debug): $(model_mk_debug) $(dramsim_lib)
 $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 	rm -f $@.vcd && mkfifo $@.vcd
 	vcd2vpd $@.vcd $@ > /dev/null &
-	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) -v$@.vcd $(PERMISSIVE_OFF) $< </dev/null 2> >(spike-dasm > $<.out) | tee $<.log)
+	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) +dramsim +max-cycles=$(timeout_cycles) $(SIM_FLAGS) $(VERBOSE_FLAGS) -v$@.vcd $(DROMAJO_FLAGS) +drj_bin=$< $(PERMISSIVE_OFF) $< </dev/null 2> >(spike-dasm > $<.out) | tee $<.log)
 
 #########################################################################################
 # general cleanup rule

--- a/variables.mk
+++ b/variables.mk
@@ -98,6 +98,10 @@ endif
 
 FIRRTL_FILE ?= $(build_dir)/$(long_name).fir
 ANNO_FILE   ?= $(build_dir)/$(long_name).anno.json
+DTS_FILE    ?= $(build_dir)/$(long_name).dts
+DTB_FILE    ?= $(build_dir)/$(long_name).dtb
+DROMAJO_PARAMS_FILE    ?= $(build_dir)/$(long_name).dromajo_params.h
+DROMAJO_PARAMS_SYMLINK ?= $(build_dir)/dromajo_params.h
 
 TOP_FILE       ?= $(build_dir)/$(long_name).top.v
 TOP_FIR        ?= $(build_dir)/$(long_name).top.fir


### PR DESCRIPTION
This PR integrates Dromajo like dramsim, based off Abe's work, and seamlessly enables dromajo-enabled simulations. The changes are mildly invasive, but the additional flags should have no effect on non-dromajo simulations.

@zhemao can you take a look at the dramsim flag change here? I think the flag wasn't being used everywhere before. 

The plan is to merge dromajo/boom work into the sboom-release branch, and we will merge that branch into `dev` closer to a potential 1.3.0 release.