### PR TITLE
CI Run Button

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,20 +356,35 @@ workflows:
 
     build-and-test-chipyard-integration:
         jobs:
+            - ci-approval:
+                type: approval
+
             # Make the toolchains
-            - install-riscv-toolchain
+            - install-riscv-toolchain:
+                requires:
+                    - ci-approval
 
-            - install-esp-toolchain
+            - install-esp-toolchain:
+                requires:
+                    - ci-approval
 
-            - install-verilator
+            - install-verilator:
+                requires:
+                    - ci-approval
 
-            - commit-on-master-check
+            - commit-on-master-check:
+                requires:
+                    - ci-approval
 
             # Attempt to apply the tutorial patches
-            - tutorial-setup-check
+            - tutorial-setup-check:
+                requires:
+                    - ci-approval
 
             # Check that documentation builds
-            - documentation-check
+            - documentation-check:
+                requires:
+                    - ci-approval
 
             # Build extra tests
             - build-extra-tests:


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
CI now doesn't automatically run. Instead, a person with access to the CI (i.e. Chipyard developers) can click the approve button to run CI.