### PR TITLE
Fix bug in verilator Makefile for 'debug' rule

### DIFF
--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -116,14 +116,14 @@ model_mk_debug = $(model_dir_debug)/V$(VLOG_MODEL).mk
 # build makefile fragment that builds the verilator sim rules
 #########################################################################################
 $(model_mk): $(sim_vsrcs) $(sim_common_files) $(EXTRA_SIM_REQS)
-	rm -rf $(build_dir)/$(long_name)
-	mkdir -p $(build_dir)/$(long_name)
+	rm -rf $(model_dir)
+	mkdir -p $(model_dir)
 	$(VERILATOR) $(VERILATOR_OPTS) -o $(sim) -Mdir $(model_dir) -CFLAGS "-include $(model_header)"
 	touch $@
 
 $(model_mk_debug): $(sim_vsrcs) $(sim_common_files) $(EXTRA_SIM_REQS)
-	rm -rf $(build_dir)/$(long_name)
-	mkdir -p $(build_dir)/$(long_name).debug
+	rm -rf $(model_dir_debug)
+	mkdir -p $(model_dir_debug)
 	$(VERILATOR) $(VERILATOR_OPTS) -o $(sim_debug) --trace -Mdir $(model_dir_debug) -CFLAGS "-include $(model_header_debug)"
 	touch $@
 


### PR DESCRIPTION
The 'debug' rule is currently cleaning out the non-debug-model directory rather than the debug-model directory. This means a debug-mode build would cause the non-debug-mode build to get cleared out.

This PR fixes that, and changes both the debug and non-debug rules to use the variables defined for referring to these two model directories.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
