### PR TITLE
Include scripts for dependencies in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,20 @@ Start by fetching Chipyard's sources. Run:
 
 This will initialize and checkout all of the necessary git submodules.
 
+Installing Dependencies
+-------------------------------------------
+Installing the recommended dependencies on Ubuntu/Debian-based platforms:
+
+.. code-block:: shell
+
+    ./scripts/ubuntu-req.sh
+    
+Installing the recommended dependencies on CentOS-based platforms:
+
+.. code-block:: shell
+
+   ./scripts/centos-req.sh
+
 Installing the RISC-V Tools
 -------------------------------------------
 


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->
Related to #455, #436 and #514: Users forget to install dependencies because there is no reference in the quick start documentation
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: documentation


