### PR TITLE
Bypass approval button on dev/master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,6 +358,11 @@ workflows:
     build-and-test-chipyard-integration:
         jobs:
             - ci-approval:
+                filters:
+                  branches:
+                    ignore:
+                      - master
+                      - dev
                 type: approval
 
             # Make the toolchains


### PR DESCRIPTION
**Related issue**: 

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
Bypasses the `ci-approval` job in CI so that developers don't have to approve CI to run on `dev` and `master` branches.
