### PR TITLE
Delete env scripts before generating

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -132,6 +132,9 @@ SRCDIR="$(pwd)/toolchains" module_all qemu --prefix="${RISCV}" --target-list=ris
 
 cd "$RDIR"
 
+rm -f env-$TOOLCHAIN.sh
+rm -f env.sh
+
 # create specific env.sh
 {
     echo "export CHIPYARD_TOOLCHAIN_SOURCED=1"


### PR DESCRIPTION
**Related issue**: <!-- if applicable --> #530 

<!-- choose one --> 
**Type of change**: bug fix

<!-- choose one -->
**Impact**: software change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
Deleting the two `env` scripts before generating them makes manual upgrades from 1.1.0 to 1.2.0 smoother, as they were linked together in 1.1.0 but are separate in 1.2.0. When I did the manual upgrade myself, this was the main bug that I ran into that was non-obvious (as opposed to obvious things like the `example` generator being renamed to `chipyard`).