### PR TITLE
Fix "WithHeterCoresSetup" in hetero. docs

### DIFF
--- a/docs/Customization/Heterogeneous-SoCs.rst
+++ b/docs/Customization/Heterogeneous-SoCs.rst
@@ -40,13 +40,13 @@ The config fragment to add to your system would look something like the followin
         val boomTile1 = BoomTileParams(...) // params for boom core 1
         val boomTile2 = BoomTileParams(...) // params for boom core 2
         val boomTile3 = BoomTileParams(...) // params for boom core 3
-        boomTile0 ++ boomTile1 ++ boomTile2 ++ boomTile3
+        Seq(boomTile0, boomTile1, boomTile2, boomTile3)
       }
 
       case RocketTilesKey => {
         val rocketTile0 = RocketTileParams(...) // params for rocket core 0
         val rocketTile1 = RocketTileParams(...) // params for rocket core 1
-        rocketTile0 ++ rocketTile1
+        Seq(rocketTile0, rocketTile1)
       }
     })
 


### PR DESCRIPTION
**Related issue**:#535

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**:other

**Release Notes**
This fixes the `WithHeterCoresSetup` config. fragment to correctly use a list to combine all Tile parameters instead of `++`.
