### PR TITLE
Assemble the firrtl-test.jar and put it in its own directory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Tests._
 
 // This gives us a nicer handle  to the root project instead of using the
 // implicit one
-lazy val chipyardRoot = RootProject(file("."))
+lazy val chipyardRoot = Project("chipyardRoot", file("."))
 
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",

--- a/common.mk
+++ b/common.mk
@@ -36,11 +36,18 @@ TESTCHIPIP_CLASSES ?= "$(TESTCHIP_DIR)/target/scala-$(SCALA_VERSION_MAJOR)/class
 # jar creation variables and rules
 #########################################################################################
 FIRRTL_JAR := $(base_dir)/lib/firrtl.jar
+FIRRTL_TEST_JAR := $(base_dir)/test_lib/firrtl-test.jar
 
 $(FIRRTL_JAR): $(call lookup_srcs,$(CHIPYARD_FIRRTL_DIR),scala)
 	$(MAKE) -C $(CHIPYARD_FIRRTL_DIR) SBT="$(SBT)" root_dir=$(CHIPYARD_FIRRTL_DIR) build-scala
 	mkdir -p $(@D)
 	cp -p $(CHIPYARD_FIRRTL_DIR)/utils/bin/firrtl.jar $@
+	touch $@
+
+$(FIRRTL_TEST_JAR): $(call lookup_srcs,$(CHIPYARD_FIRRTL_DIR),scala)
+	cd $(CHIPYARD_FIRRTL_DIR) && $(SBT) "test:assembly"
+	mkdir -p $(@D)
+	cp -p $(CHIPYARD_FIRRTL_DIR)/utils/bin/firrtl-test.jar $@
 	touch $@
 
 #########################################################################################


### PR DESCRIPTION
1.3 has landed -- yay! Time to use the new features.

FIRRTL now provides an assembly task for `test`, which packages up a bunch of test classes that are useful for testing firrtl passes _outside_ of firrtl. This PR calls out to `test:assembly` and drops teh resulting jar in `test_lib`. Subprojects that want to use these classes (under the `firrtl.testutils` package) may either use this new directory as their unmanagedBase, or add the resulting jar to their classpath.

I picked `test_lib` to mirror what was done in RC.

 <!-- choose one -->
**Type of change**: new feature 

<!-- choose one -->
**Impact**:  other

**Release Notes**
Assemble the firrtl-test.jar; put in separate unmanaged directory "test_lib"