### PR TITLE
Don't try to init nonexistent midas submodule

### DIFF
--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -59,11 +59,6 @@ git submodule update --init generators/sha3
 git config --unset submodule.sims/firesim.update
 # Minimal non-recursive clone to initialize sbt dependencies
 git submodule update --init sims/firesim
-(
-    cd sims/firesim
-    # Initialize dependencies for MIDAS-level RTL simulation
-    git submodule update --init sim/midas
-)
 git config submodule.sims/firesim.update none
 
 # Only shallow clone needed for basic SW tests


### PR DESCRIPTION
**Type of change**: bug fix
**Impact**: other
**Release Notes**
The submodule initialization script has been updated to no longer check out the now-inlined MIDAS project as a submodule of FireSim (see firesim/firesim#400).