### PR TITLE
Upgrade verilator to support permissive args in the same way as vcs

### DIFF
--- a/generators/utilities/src/main/resources/csrc/emulator.cc
+++ b/generators/utilities/src/main/resources/csrc/emulator.cc
@@ -126,27 +126,30 @@ int main(int argc, char** argv)
   int verilog_plusargs_legal = 1;
 
   dramsim = 0;
+  opterr = 1;
 
   while (1) {
     static struct option long_options[] = {
-      {"cycle-count", no_argument,       0, 'c' },
-      {"help",        no_argument,       0, 'h' },
-      {"max-cycles",  required_argument, 0, 'm' },
-      {"seed",        required_argument, 0, 's' },
-      {"rbb-port",    required_argument, 0, 'r' },
-      {"verbose",     no_argument,       0, 'V' },
-      {"dramsim",     no_argument,       0, 'D' },
+      {"cycle-count",     no_argument,       0, 'c' },
+      {"help",            no_argument,       0, 'h' },
+      {"max-cycles",      required_argument, 0, 'm' },
+      {"seed",            required_argument, 0, 's' },
+      {"rbb-port",        required_argument, 0, 'r' },
+      {"verbose",         no_argument,       0, 'V' },
+      {"dramsim",         no_argument,       0, 'D' },
+      {"permissive",      no_argument,       0, 'p' },
+      {"permissive-off",  no_argument,       0, 'o' },
 #if VM_TRACE
-      {"vcd",         required_argument, 0, 'v' },
-      {"dump-start",  required_argument, 0, 'x' },
+      {"vcd",             required_argument, 0, 'v' },
+      {"dump-start",      required_argument, 0, 'x' },
 #endif
       HTIF_LONG_OPTIONS
     };
     int option_index = 0;
 #if VM_TRACE
-    int c = getopt_long(argc, argv, "-chm:s:r:v:Vx:D", long_options, &option_index);
+    int c = getopt_long(argc, argv, "-chm:s:r:v:Vx:Dpo", long_options, &option_index);
 #else
-    int c = getopt_long(argc, argv, "-chm:s:r:VD", long_options, &option_index);
+    int c = getopt_long(argc, argv, "-chm:s:r:VDpo", long_options, &option_index);
 #endif
     if (c == -1) break;
  retry:
@@ -160,6 +163,8 @@ int main(int argc, char** argv)
       case 'r': rbb_port = atoi(optarg);    break;
       case 'V': verbose = true;             break;
       case 'D': dramsim = 1;                break;
+      case 'p': opterr = 0;                 break;
+      case 'o': opterr = 1;                 break;
 #if VM_TRACE
       case 'v': {
         vcdfile = strcmp(optarg, "-") == 0 ? stdout : fopen(optarg, "w");
@@ -195,6 +200,10 @@ int main(int argc, char** argv)
           c = 'c';
         else if (arg == "+dramsim")
           c = 'D';
+        else if (arg == "+permissive")
+          c = 'p';
+        else if (arg == "+permissive-off")
+          c = 'o';
         // If we don't find a legacy '+' EMULATOR argument, it still could be
         // a VERILOG_PLUSARG and not an error.
         else if (verilog_plusargs_legal) {
@@ -226,9 +235,13 @@ int main(int argc, char** argv)
             }
             htif_option++;
           }
-          std::cerr << argv[0] << ": invalid plus-arg (Verilog or HTIF) \""
-                    << arg << "\"\n";
-          c = '?';
+          if(opterr) {
+            std::cerr << argv[0] << ": invalid plus-arg (Verilog or HTIF) \""
+                      << arg << "\"\n";
+            c = '?';
+          } else {
+            c = 'p';
+          }
         }
         goto retry;
       }

--- a/sims/vcs/Makefile
+++ b/sims/vcs/Makefile
@@ -25,9 +25,6 @@ sim_prefix = simv
 sim = $(sim_dir)/$(sim_prefix)-$(MODEL_PACKAGE)-$(CONFIG)
 sim_debug = $(sim_dir)/$(sim_prefix)-$(MODEL_PACKAGE)-$(CONFIG)-debug
 
-PERMISSIVE_ON=+permissive
-PERMISSIVE_OFF=+permissive-off
-
 WAVEFORM_FLAG=+vcdplusfile=$(sim_out_name).vpd
 
 .PHONY: default debug

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -28,9 +28,6 @@ sim_prefix = simulator
 sim = $(sim_dir)/$(sim_prefix)-$(MODEL_PACKAGE)-$(CONFIG)
 sim_debug = $(sim_dir)/$(sim_prefix)-$(MODEL_PACKAGE)-$(CONFIG)-debug
 
-PERMISSIVE_ON=+permissive
-PERMISSIVE_OFF=+permissive-off
-
 WAVEFORM_FLAG=-v$(sim_out_name).vcd
 
 .PHONY: default debug

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -28,8 +28,8 @@ sim_prefix = simulator
 sim = $(sim_dir)/$(sim_prefix)-$(MODEL_PACKAGE)-$(CONFIG)
 sim_debug = $(sim_dir)/$(sim_prefix)-$(MODEL_PACKAGE)-$(CONFIG)-debug
 
-PERMISSIVE_ON=
-PERMISSIVE_OFF=
+PERMISSIVE_ON=+permissive
+PERMISSIVE_OFF=+permissive-off
 
 WAVEFORM_FLAG=-v$(sim_out_name).vcd
 

--- a/variables.mk
+++ b/variables.mk
@@ -136,6 +136,8 @@ output_dir=$(sim_dir)/output/$(long_name)
 #########################################################################################
 # helper variables to run binaries
 #########################################################################################
+PERMISSIVE_ON=+permissive
+PERMISSIVE_OFF=+permissive-off
 BINARY ?=
 override SIM_FLAGS += +dramsim +max-cycles=$(timeout_cycles)
 VERBOSE_FLAGS ?= +verbose


### PR DESCRIPTION
Fixes #563 

**Release Notes**
Verilator now supports `+permissive` and now can be passed its runtime arguments such as `+verilator+rand+reset+0`
