### PR TITLE
Disable all make suffix rules for improved EC2 performance

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -189,3 +189,10 @@ dramsim_lib = $(dramsim_dir)/libdramsim.a
 
 $(dramsim_lib):
 	$(MAKE) -C $(dramsim_dir) $(notdir $@)
+
+#########################################################################################
+# Implicit rule handling
+#########################################################################################
+# Disable all suffix rules to improve Make performance on systems running older
+# versions of Make
+.SUFFIXES:


### PR DESCRIPTION
On a typical manager instance, editing a scala file and typing make leads to a long  during which Make resolves all possible implicit rules on all prerequisites which includes 1000+ scala files. Disabling the builtin suffix rules produces a nice speedup:

On my manager instance: 
/usr/bin/time make -n: 52s -> 0.25s

On millennium:
/usr/bin/time make -n: 1.52s -> 0.17s


<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**:  other

**Release Notes**
* Improve make performance on systems running Make 3.*
