### PR TITLE
More fixes for post-syn/par hammer simulations

### DIFF
--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -99,6 +99,8 @@ SIM_TIMING_CONF = $(OBJ_DIR)/sim-timing-inputs.yml
 include $(vlsi_dir)/sim.mk
 $(SIM_CONF): $(VLSI_RTL) $(HARNESS_FILE) $(HARNESS_SMEMS_FILE) $(sim_common_files) $(dramsim_lib)
 	mkdir -p $(dir $@)
+	mkdir -p $(OBJ_DIR)/$(HAMMER_SIM_RUN_DIR)/$(notdir $(BINARY))
+	ln -sf $(base_dir)/generators/testchipip/src/main/resources/dramsim2_ini $(OBJ_DIR)/$(HAMMER_SIM_RUN_DIR)/$(notdir $(BINARY))/dramsim2_ini
 	echo "sim.inputs:" > $@
 	echo "  top_module: $(VLSI_TOP)" >> $@
 	echo "  input_files:" >> $@

--- a/vlsi/power.mk
+++ b/vlsi/power.mk
@@ -3,4 +3,4 @@ power-par: $(POWER_CONF) sim-par
 power-par: override HAMMER_POWER_EXTRA_ARGS += -p $(POWER_CONF)
 redo-power-par: $(POWER_CONF)
 redo-power-par: override HAMMER_EXTRA_ARGS += -p $(POWER_CONF)
-$(OBJ_DIR)/power-rundir/power-output-full.json: private override HAMMER_EXTRA_ARGS += $(HAMMER_POWER_EXTRA_ARGS)
+$(OBJ_DIR)/power-par-rundir/power-output-full.json: private override HAMMER_EXTRA_ARGS += $(HAMMER_POWER_EXTRA_ARGS)

--- a/vlsi/sim.mk
+++ b/vlsi/sim.mk
@@ -2,16 +2,19 @@
 # Update hammer top-level sim targets to include our generated sim configs
 redo-sim-rtl: $(SIM_CONF)
 redo-sim-rtl: override HAMMER_EXTRA_ARGS += -p $(SIM_CONF)
+redo-sim-rtl: override HAMMER_SIM_RUN_DIR = sim-rtl-rundir
 redo-sim-rtl-debug: $(SIM_DEBUG_CONF) redo-sim-rtl
 redo-sim-rtl-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
 
 redo-sim-syn: $(SIM_CONF)
 redo-sim-syn: override HAMMER_EXTRA_ARGS += -p $(SIM_CONF)
+redo-sim-syn: override HAMMER_SIM_RUN_DIR = sim-syn-rundir
 redo-sim-syn-debug: $(SIM_DEBUG_CONF) redo-sim-syn
 redo-sim-syn-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
 
 redo-sim-par: $(SIM_CONF)
 redo-sim-par: override HAMMER_EXTRA_ARGS += -p $(SIM_CONF)
+redo-sim-par: override HAMMER_SIM_RUN_DIR = sim-par-rundir
 redo-sim-par-debug: $(SIM_DEBUG_CONF) redo-sim-par
 redo-sim-par-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
 redo-sim-par-timing-debug: $(SIM_TIMING_CONF) redo-sim-par-debug
@@ -19,18 +22,21 @@ redo-sim-par-timing-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_TIMING_CONF)
 
 sim-rtl: $(SIM_CONF)
 sim-rtl: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_CONF)
+sim-rtl: override HAMMER_SIM_RUN_DIR = sim-rtl-rundir
 sim-rtl-debug: $(SIM_DEBUG_CONF) sim-rtl
 sim-rtl-debug: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
-$(OBJ_DIR)/sim-rundir/sim-output-full.json: private override HAMMER_EXTRA_ARGS += $(HAMMER_SIM_EXTRA_ARGS)
+$(OBJ_DIR)/sim-rtl-rundir/sim-output-full.json: private override HAMMER_EXTRA_ARGS += $(HAMMER_SIM_EXTRA_ARGS)
 
 sim-syn: $(SIM_CONF)
 sim-syn: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_CONF)
+sim-syn: override HAMMER_SIM_RUN_DIR = sim-syn-rundir
 sim-syn-debug: $(SIM_DEBUG_CONF) sim-syn
 sim-syn-debug: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
 $(OBJ_DIR)/sim-syn-rundir/sim-output-full.json: private override HAMMER_EXTRA_ARGS += $(HAMMER_SIM_EXTRA_ARGS)
 
 sim-par: $(SIM_CONF)
 sim-par: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_CONF)
+sim-par: override HAMMER_SIM_RUN_DIR = sim-par-rundir
 sim-par-debug: $(SIM_DEBUG_CONF) sim-par
 sim-par-debug: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
 sim-par-timing-debug: $(SIM_TIMING_CONF) sim-par-debug


### PR DESCRIPTION
Symlink dramsim2 into hammer-sims rundirs
update some hammer generated makefile targets that were missed before
bump barstools to get an iocell fix


I'm currently running a design through the flow again to verify that the new iocell change works as intended. I've verified that dramsim now correctly find the ini files, and we have all the up-to-date hammer auto-generated makefile targets.