### PR TITLE
Alias RC WithoutTLMonitors into firesim.firesim

### DIFF
--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -73,6 +73,10 @@ class WithNVDLALarge extends nvidia.blocks.dla.WithNVDLA("large")
 class WithNVDLASmall extends nvidia.blocks.dla.WithNVDLA("small")
 
 
+// Alias WithoutTLMonitors into this package so that it can be used in config strings
+class WithoutTLMonitors extends freechips.rocketchip.subsystem.WithoutTLMonitors
+
+
 // Tweaks that are generally applied to all firesim configs
 class WithFireSimConfigTweaks extends Config(
   // Required*: When using FireSim-as-top to provide a correct path to the target bootrom source


### PR DESCRIPTION
Need to add it to my GoldenGate Config String (-ggcs) otherwise
I'm seeing TLMonitors added during SimulationMapping transform in GoldenGate

Additional detail at:
https://groups.google.com/forum/\#!topic/firesim/8loAr-29FbI

**Related issue**: #583 

<!-- choose one -->
**Type of change**: other enhancement

Not sure this is big enough to be considered a 'new feature' feel free to correct me if I'm wrong.

<!-- choose one -->
**Impact**: rtl change 

**Release Notes**
* alias `freechips.rocketchip.subsystem.WithoutTLMonitors` into `firesim.firesim` so that it can be used as a '_'-delimited ConfigString element.
