### PR TITLE
Use output_dir for run-binary logs and waveforms

### DIFF
--- a/.circleci/run-tests.sh
+++ b/.circleci/run-tests.sh
@@ -93,10 +93,10 @@ case $1 in
         make -C $LOCAL_SIM_DIR ${mapping[$1]} BINARY=$LOCAL_CHIPYARD_DIR/tests/nvdla.riscv run-binary
         ;;
     icenet)
-        make run-none-fast -C $LOCAL_SIM_DIR ${mapping[$1]}
+        make run-binary-fast BINARY=none -C $LOCAL_SIM_DIR ${mapping[$1]}
         ;;
     testchipip)
-        make run-none-fast -C $LOCAL_SIM_DIR ${mapping[$1]}
+        make run-binary-fast BINARY=none -C $LOCAL_SIM_DIR ${mapping[$1]}
         ;;
     *)
         echo "No set of tests for $1. Did you spell it right?"

--- a/sims/vcs/Makefile
+++ b/sims/vcs/Makefile
@@ -62,10 +62,6 @@ $(sim_debug): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS)
 $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(VERBOSE_FLAGS) +vcdplusfile=$@ $(PERMISSIVE_OFF) $< </dev/null 2> >(spike-dasm > $<.out) | tee $<.log)
 
-$(output_dir)/none.vpd: $(sim_debug)
-	mkdir -p $(output_dir)
-	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(VERBOSE_FLAGS) +vcdplusfile=$@ $(PERMISSIVE_OFF) none </dev/null 2> >(spike-dasm > $(output_dir)/none.out) | tee $(output_dir)/none.log)
-
 #########################################################################################
 # general cleanup rule
 #########################################################################################

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -146,12 +146,6 @@ $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 	vcd2vpd $@.vcd $@ > /dev/null &
 	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(VERBOSE_FLAGS) -v$@.vcd $(PERMISSIVE_OFF) $< </dev/null 2> >(spike-dasm > $<.out) | tee $<.log)
 
-$(output_dir)/none.vpd: $(sim_debug)
-	mkdir -p $(output_dir)
-	rm -f $@.vcd && mkfifo $@.vcd
-	vcd2vpd $@.vcd $@ > /dev/null &
-	(set -o pipefail && $(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(VERBOSE_FLAGS) -v$@.vcd $(PERMISSIVE_OFF) none </dev/null 2> >(spike-dasm > $(output_dir)/none.out) | tee $(output_dir)/none.log)
-
 #########################################################################################
 # general cleanup rule
 #########################################################################################

--- a/variables.mk
+++ b/variables.mk
@@ -141,7 +141,7 @@ PERMISSIVE_OFF=+permissive-off
 BINARY ?=
 override SIM_FLAGS += +dramsim +max-cycles=$(timeout_cycles)
 VERBOSE_FLAGS ?= +verbose
-sim_out_name = $(subst $() $(),_,$(notdir $(basename $(BINARY))).$(long_name))
+sim_out_name = $(output_dir)/$(subst $() $(),_,$(notdir $(basename $(BINARY))))
 
 #########################################################################################
 # build output directory for compilation


### PR DESCRIPTION
 * Dump run-binary files in `output/$(long_name)` instead of current directory
 * Remove run-none rules, these were equivalent to run-binary BINARY=none

**Type of change**: new feature

<!-- choose one -->
**Impact**: software change
