### PR TITLE
Allow dramsim_ini folder to be set at the command line

### DIFF
--- a/generators/utilities/src/main/resources/csrc/emulator.cc
+++ b/generators/utilities/src/main/resources/csrc/emulator.cc
@@ -35,7 +35,6 @@
 extern tsi_t* tsi;
 extern dtm_t* dtm;
 extern remote_bitbang_t * jtag;
-extern int dramsim;
 
 static uint64_t trace_count = 0;
 bool verbose = false;
@@ -49,11 +48,6 @@ void handle_sigterm(int sig)
 double sc_time_stamp()
 {
   return trace_count;
-}
-
-extern "C" int vpi_get_vlog_info(void* arg)
-{
-  return 0;
 }
 
 static void usage(const char * program_name)
@@ -125,7 +119,6 @@ int main(int argc, char** argv)
   char ** htif_argv = NULL;
   int verilog_plusargs_legal = 1;
 
-  dramsim = 0;
   opterr = 1;
 
   while (1) {
@@ -136,7 +129,6 @@ int main(int argc, char** argv)
       {"seed",            required_argument, 0, 's' },
       {"rbb-port",        required_argument, 0, 'r' },
       {"verbose",         no_argument,       0, 'V' },
-      {"dramsim",         no_argument,       0, 'D' },
       {"permissive",      no_argument,       0, 'p' },
       {"permissive-off",  no_argument,       0, 'o' },
 #if VM_TRACE
@@ -147,9 +139,9 @@ int main(int argc, char** argv)
     };
     int option_index = 0;
 #if VM_TRACE
-    int c = getopt_long(argc, argv, "-chm:s:r:v:Vx:Dpo", long_options, &option_index);
+    int c = getopt_long(argc, argv, "-chm:s:r:v:Vx:po", long_options, &option_index);
 #else
-    int c = getopt_long(argc, argv, "-chm:s:r:VDpo", long_options, &option_index);
+    int c = getopt_long(argc, argv, "-chm:s:r:Vpo", long_options, &option_index);
 #endif
     if (c == -1) break;
  retry:
@@ -162,7 +154,6 @@ int main(int argc, char** argv)
       case 's': random_seed = atoi(optarg); break;
       case 'r': rbb_port = atoi(optarg);    break;
       case 'V': verbose = true;             break;
-      case 'D': dramsim = 1;                break;
       case 'p': opterr = 0;                 break;
       case 'o': opterr = 1;                 break;
 #if VM_TRACE
@@ -198,8 +189,6 @@ int main(int argc, char** argv)
 #endif
         else if (arg.substr(0, 12) == "+cycle-count")
           c = 'c';
-        else if (arg == "+dramsim")
-          c = 'D';
         else if (arg == "+permissive")
           c = 'p';
         else if (arg == "+permissive-off")

--- a/sims/vcs/dramsim2_ini
+++ b/sims/vcs/dramsim2_ini
@@ -1,1 +1,0 @@
-../../generators/testchipip/src/main/resources/dramsim2_ini

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -87,6 +87,7 @@ TIMESCALE_OPTS := $(shell verilator --version | perl -lne 'if (/(\d.\d+)/ && $$1
 VERILATOR_NONCC_OPTS = \
 	$(TIMESCALE_OPTS) \
 	--top-module $(VLOG_MODEL) \
+	--vpi \
 	-Wno-fatal \
 	$(shell if ! grep -iq "module.*ariane" $(build_dir)/*.*v; then echo "$(CHIPYARD_VERILATOR_FLAGS)"; else echo "$(ARIANE_VERILATOR_FLAGS)"; fi) \
 	--output-split 10000 \

--- a/sims/verilator/dramsim2_ini
+++ b/sims/verilator/dramsim2_ini
@@ -1,1 +1,0 @@
-../../generators/testchipip/src/main/resources/dramsim2_ini

--- a/variables.mk
+++ b/variables.mk
@@ -139,7 +139,7 @@ output_dir=$(sim_dir)/output/$(long_name)
 PERMISSIVE_ON=+permissive
 PERMISSIVE_OFF=+permissive-off
 BINARY ?=
-override SIM_FLAGS += +dramsim +max-cycles=$(timeout_cycles)
+override SIM_FLAGS += +dramsim +dramsim_ini_dir=$(TESTCHIP_DIR)/src/main/resources/dramsim2_ini +max-cycles=$(timeout_cycles)
 VERBOSE_FLAGS ?= +verbose
 sim_out_name = $(subst $() $(),_,$(notdir $(basename $(BINARY))).$(long_name))
 

--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -99,8 +99,6 @@ SIM_TIMING_CONF = $(OBJ_DIR)/sim-timing-inputs.yml
 include $(vlsi_dir)/sim.mk
 $(SIM_CONF): $(VLSI_RTL) $(HARNESS_FILE) $(HARNESS_SMEMS_FILE) $(sim_common_files) $(dramsim_lib)
 	mkdir -p $(dir $@)
-	mkdir -p $(OBJ_DIR)/$(HAMMER_SIM_RUN_DIR)/$(notdir $(BINARY))
-	ln -sf $(base_dir)/generators/testchipip/src/main/resources/dramsim2_ini $(OBJ_DIR)/$(HAMMER_SIM_RUN_DIR)/$(notdir $(BINARY))/dramsim2_ini
 	echo "sim.inputs:" > $@
 	echo "  top_module: $(VLSI_TOP)" >> $@
 	echo "  input_files:" >> $@


### PR DESCRIPTION
verilator supports the amount of `vpi` we need to do our own argument parsing without messing with emulator.cc every time.