### PR TITLE
Warn if RISCV unset

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -3,6 +3,14 @@
 #########################################################################################
 SHELL=/bin/bash
 
+
+ifndef RISCV
+$(error RISCV is unset. You must set RISCV yourself, or through the Chipyard auto-generated env file)
+else
+$(info Running with RISCV=$(RISCV))
+endif
+
+
 #########################################################################################
 # extra make variables/rules from subprojects
 #


### PR DESCRIPTION
Does anyone foresee problems with this? Technically it was possible to run Hammer with $RISCV unset, but user who want to do that can just set RISCV to a dummy variable.

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: software change
