### PR TITLE
Use an accurate name for the ci skip list

### DIFF
--- a/.githooks/ignore-certain-dirs-commit-msg
+++ b/.githooks/ignore-certain-dirs-commit-msg
@@ -8,9 +8,9 @@ fi
 changes=( `git diff --name-only --cached` )
 
 # Load the patterns we want to skip into an array
-mapfile -t blacklist < .ciignore
+mapfile -t blocklist < .ciignore
 
-for i in "${blacklist[@]}"
+for i in "${blocklist[@]}"
 do
 	# Remove the current pattern from the list of changes
 	changes=( ${changes[@]/$i/} )


### PR DESCRIPTION
This more accurately describes what the array contains.