### PR TITLE
Bloop Support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tags
 *~
 env-riscv-tools.sh
 env-esp-tools.sh
+.bloop/

--- a/common.mk
+++ b/common.mk
@@ -34,6 +34,8 @@ lookup_srcs = $(shell find -L $(1)/ -name target -prune -o -iname "*.$(2)" -prin
 SOURCE_DIRS = $(addprefix $(base_dir)/,generators sims/firesim/sim tools/barstools/iocell)
 SCALA_SOURCES = $(call lookup_srcs,$(SOURCE_DIRS),scala)
 VLOG_SOURCES = $(call lookup_srcs,$(SOURCE_DIRS),sv) $(call lookup_srcs,$(SOURCE_DIRS),v)
+# This assumes no SBT meta-build sources
+SBT_SOURCES = $(call lookup_srcs,$(base_dir),sbt)
 
 #########################################################################################
 # rocket and testchipip classes

--- a/common.mk
+++ b/common.mk
@@ -38,13 +38,6 @@ VLOG_SOURCES = $(call lookup_srcs,$(SOURCE_DIRS),sv) $(call lookup_srcs,$(SOURCE
 SBT_SOURCES = $(call lookup_srcs,$(base_dir),sbt)
 
 #########################################################################################
-# rocket and testchipip classes
-#########################################################################################
-# NB: target/ lives under source ----V , due to how we're handling midas dependency injection
-ROCKET_CLASSES ?= "$(ROCKETCHIP_DIR)/src/target/scala-$(SCALA_VERSION_MAJOR)/classes:$(ROCKETCHIP_DIR)/chisel3/target/scala-$(SCALA_VERSION_MAJOR)/*"
-TESTCHIPIP_CLASSES ?= "$(TESTCHIP_DIR)/target/scala-$(SCALA_VERSION_MAJOR)/classes"
-
-#########################################################################################
 # jar creation variables and rules
 #########################################################################################
 FIRRTL_JAR := $(base_dir)/lib/firrtl.jar
@@ -66,7 +59,7 @@ $(FIRRTL_TEST_JAR): $(call lookup_srcs,$(CHIPYARD_FIRRTL_DIR),scala)
 #########################################################################################
 # Bloop Project Definitions
 #########################################################################################
-$(BLOOP_CONFIG_DIR)/TIMESTAMP: $(base_dir)/build.sbt
+$(BLOOP_CONFIG_DIR)/TIMESTAMP: $(SBT_SOURCES)
 	cd $(base_dir) && $(SBT) "project chipyardRoot" "bloopInstall"
 	touch $@
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,5 +15,6 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.1")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.1")
 
 libraryDependencies += "com.github.os72" % "protoc-jar" % "3.5.1.1"

--- a/scripts/firesim-setup.sh
+++ b/scripts/firesim-setup.sh
@@ -12,7 +12,6 @@ cd "${scripts_dir}/.."
 
 # Reenable the FireSim submodule
 git config --unset submodule.sims/firesim.update || true
-git submodule update --init sims/firesim
 cd sims/firesim
 ./build-setup.sh "$@" --library
 cd "$RDIR"

--- a/variables.mk
+++ b/variables.mk
@@ -130,7 +130,7 @@ SBT ?= java $(JAVA_ARGS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar
 BLOOP ?= bloop
 BLOOP_CONFIG_DIR ?= $(base_dir)/.bloop
 
-SCALA_BUILDTOOL_DEPS ?= $(base_dir)/build.sbt
+SCALA_BUILDTOOL_DEPS = $(SBT_SOURCES)
 
 ifdef ENABLE_BLOOP
 override SCALA_BUILDTOOL_DEPS += $(BLOOP_CONFIG_DIR)/TIMESTAMP

--- a/variables.mk
+++ b/variables.mk
@@ -125,8 +125,23 @@ JAVA_ARGS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -XX:MaxPermSize=256M
 #########################################################################################
 SCALA_VERSION=2.12.10
 SCALA_VERSION_MAJOR=$(basename $(SCALA_VERSION))
-
 SBT ?= java $(JAVA_ARGS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar
+
+BLOOP ?= bloop
+BLOOP_CONFIG_DIR ?= $(base_dir)/.bloop
+
+SCALA_BUILDTOOL_DEPS ?= $(base_dir)/build.sbt
+
+ifdef ENABLE_BLOOP
+override SCALA_BUILDTOOL_DEPS += $(BLOOP_CONFIG_DIR)/TIMESTAMP
+define run_scala_main
+	cd $(base_dir) && bloop run $(shell echo $(1) | sed 's/{.*}//') --main $(2) -- $(3)
+endef
+else
+define run_scala_main
+	cd $(base_dir) && $(SBT) "project $(1)" "runMain $(2) $(3)"
+endef
+endif
 
 #########################################################################################
 # output directory for tests

--- a/variables.mk
+++ b/variables.mk
@@ -129,13 +129,22 @@ SBT ?= java $(JAVA_ARGS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar
 
 BLOOP ?= bloop
 BLOOP_CONFIG_DIR ?= $(base_dir)/.bloop
+# This mirrors the bloop default. Set to a system-unique port in a multi-user environment
+BLOOP_NAILGUN_PORT ?= 8212
 
 SCALA_BUILDTOOL_DEPS = $(SBT_SOURCES)
 
 ifdef ENABLE_BLOOP
 override SCALA_BUILDTOOL_DEPS += $(BLOOP_CONFIG_DIR)/TIMESTAMP
+# Two notes about the bloop invocation:
+# 1) the sed removes a leading {file:<path>} that sometimes needs to be
+#    provided to SBT when a project but not for bloop.
+# 2) Generally, one could could pass '--' to indicate all remaining arguments are
+# 	 destined for the scala Main, however a bug in Bloop's argument parsing causes the
+#    --nailgun-port argument to be lost in this case. Workaround this by prefixing
+#    every main-destined argument with "--args"
 define run_scala_main
-	cd $(base_dir) && bloop run $(shell echo $(1) | sed 's/{.*}//') --main $(2) -- $(3)
+	cd $(base_dir) && bloop --nailgun-port $(BLOOP_NAILGUN_PORT) run $(shell echo $(1) | sed 's/{.*}//') --main $(2)  $(addprefix --args ,$3)
 endef
 else
 define run_scala_main


### PR DESCRIPTION
This PR brings up support for [bloop](https://scalacenter.github.io/bloop/) to do scala source compiles and for invoking scala executables. Builds/runs with bloop are enabled by setting ENABLE_BLOOP=1. I'll add documentation explaining installation.
 
The Bloop flow is faster across the board, but for a common iteration loop, where i touch a scala source (IOBinder.scala) and regenerate verilog (`make verilog` in sims/verilator) i've measured:

F1 c4.4xlarge: 5m21s SBT, 3m04s Bloop  (2 previous elaborations)
My 2019 mbpro:  3m4s SBT, 1m47s Bloop  (1 previous elaboration)

Neither build tool recompiles sources since i've only touched the files, but bloop seems to be ~30% faster compiling chipyard's sources.  For the figures above, much of the win comes from not having to relaunch SBT repeatedly, but having a long-lived JVM means the JIT can warm up and stay warm. For smaller designs the speed up becomes more profound as the SBT launches don't scale in design size. 

Unrelated fixes:
- Stop re-initializing firesim in firesim-setup.sh
- Delete dead `CLASSES` variables in Makefile

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**:  other

**Release Notes**
- Support optionally using bloop as the scala build tool 
