### PR TITLE
Deduplicate across Chipyard configs into a ChipyardBaseConfig

### DIFF
--- a/docs/Customization/Heterogeneous-SoCs.rst
+++ b/docs/Customization/Heterogeneous-SoCs.rst
@@ -8,7 +8,7 @@ Creating a Rocket and BOOM System
 -------------------------------------------
 
 Instantiating an SoC with Rocket and BOOM cores is all done with the configuration system and two specific config fragments.
-Both BOOM and Rocket have config fragments labelled ``WithNBoomCores(X)`` and ``WithNBigCores(X)`` that automatically create ``X`` copies of the core/tile [1]_.
+Both BOOM and Rocket have config fragments labelled ``WithN{Small|Medium|Large|etc.}BoomCores(X)`` and ``WithNBigCores(X)`` that automatically create ``X`` copies of the core/tile [1]_.
 When used together you can create a heterogeneous system.
 
 The following example shows a dual core BOOM with a single core Rocket.
@@ -18,52 +18,6 @@ The following example shows a dual core BOOM with a single core Rocket.
     :start-after: DOC include start: DualBoomAndRocket
     :end-before: DOC include end: DualBoomAndRocket
 
-In this example, the ``WithNBoomCores`` and ``WithNBigCores`` config fragments set up the default parameters for the multiple BOOM and Rocket cores, respectively.
-However, for BOOM, an extra config fragment called ``WithLargeBooms`` is added to override the default parameters with a different set of more common default parameters.
-This config fragment applies to all BOOM cores in the system and changes the parameters for each.
-
-Great! Now you have a heterogeneous setup with BOOMs and Rockets.
-The final thing you need to make this system work is to renumber the ``hartId``'s of the cores so that each core has a unique ``hartId`` (a ``hartId`` is the hardware thread id of the core).
-The ``WithRenumberHarts`` config fragment solves this by assigning a unique ``hartId`` to all cores in the system (it can label the Rocket cores first or the BOOM cores first).
-The reason this is needed is because by default the ``WithN...Cores(X)`` config fragment assumes that there are only BOOM or only Rocket cores in the system.
-Thus, without the ``WithRenumberHarts`` config fragment, each set of cores is labeled starting from zero causing multiple cores to be assigned the same ``hartId``.
-
-Another alternative option to create a multi heterogeneous core system is to override the parameters yourself so you can specify the core parameters per core.
-The config fragment to add to your system would look something like the following.
-
-.. code-block:: scala
-
-    // create 6 cores (4 boom and 2 rocket)
-    class WithHeterCoresSetup extends Config((site, here, up) => {
-      case BoomTilesKey => {
-        val boomTile0 = BoomTileParams(...) // params for boom core 0
-        val boomTile1 = BoomTileParams(...) // params for boom core 1
-        val boomTile2 = BoomTileParams(...) // params for boom core 2
-        val boomTile3 = BoomTileParams(...) // params for boom core 3
-        Seq(boomTile0, boomTile1, boomTile2, boomTile3)
-      }
-
-      case RocketTilesKey => {
-        val rocketTile0 = RocketTileParams(...) // params for rocket core 0
-        val rocketTile1 = RocketTileParams(...) // params for rocket core 1
-        Seq(rocketTile0, rocketTile1)
-      }
-    })
-
-Then you could use this new config fragment like the following.
-
-.. code-block:: scala
-
-    class SixCoreConfig extends Config(
-      new WithTSI ++
-      new WithBootROM ++
-      new WithUART ++
-      new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-      new freechips.rocketchip.subsystem.WithNoSlavePort ++
-      new WithHeterCoresSetup ++
-      new freechips.rocketchip.system.BaseConfig)
-
-Note, in this setup you need to specify the ``hartId`` of each core in the "TileParams", where each ``hartId`` is unique.
 
 Adding Hwachas
 -------------------------------------------
@@ -92,8 +46,7 @@ An example is shown below with two BOOM cores, and one Rocket tile with a RoCC a
     :start-after: DOC include start: DualBoomAndRocketOneHwacha
     :end-before: DOC include end: DualBoomAndRocketOneHwacha
 
-In this example, the ``WithRenumberHarts`` relabels the ``hartId``'s of all the BOOM/Rocket cores.
-Then after that is applied to the parameters, the ``WithMultiRoCCHwacha`` config fragment assigns a Hwacha accelerator to a particular ``hartId`` (in this case, the ``hartId`` of ``2`` corresponds to the Rocket core).
+The ``WithMultiRoCCHwacha`` config fragment assigns a Hwacha accelerator to a particular ``hartId`` (in this case, the ``hartId`` of ``2`` corresponds to the Rocket core).
 Finally, the ``WithMultiRoCC`` config fragment is called.
 This config fragment sets the ``BuildRoCC`` key to use the ``MultiRoCCKey`` instead of the default.
 This must be used after all the RoCC parameters are set because it needs to override the ``BuildRoCC`` parameter.

--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -130,3 +130,16 @@ class WithNPerfCounters(n: Int = 29) extends Config((site, here, up) => {
     case other => other
   }
 })
+
+class WithRocketICacheScratchpad extends Config((site, here, up) => {
+  case RocketTilesKey => up(RocketTilesKey, site) map { r =>
+    r.copy(icache = r.icache.map(_.copy(itimAddr = Some(0x100000 + r.hartId * 0x10000))))
+  }
+})
+
+class WithRocketDCacheScratchpad extends Config((site, here, up) => {
+  case RocketTilesKey => up(RocketTilesKey, site) map { r =>
+    r.copy(dcache = r.dcache.map(_.copy(nSets = 32, nWays = 1, scratch = Some(0x200000 + r.hartId * 0x10000))))
+  }
+})
+

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -1,0 +1,26 @@
+package chipyard.config
+
+import freechips.rocketchip.config.{Config}
+
+// --------------
+// Chipyard abstract ("base") configuration
+// NOTE: This configuration is NOT INSTANTIABLE, as it defines a empty system with no tiles
+// --------------
+
+class AbstractConfig extends Config(
+  new chipyard.iobinders.WithUARTAdapter ++                      // display UART with a SimUARTAdapter
+  new chipyard.iobinders.WithTieOffInterrupts ++                 // tie off top-level interrupts
+  new chipyard.iobinders.WithBlackBoxSimMem ++                   // drive the master AXI4 memory with a blackbox DRAMSim model
+  new chipyard.iobinders.WithTiedOffDebug ++                     // tie off debug (since we are using SimSerial for testing)
+  new chipyard.iobinders.WithSimSerial ++                        // drive TSI with SimSerial for testing
+  new testchipip.WithTSI ++                                      // use testchipip serial offchip link
+  new chipyard.config.WithBootROM ++                             // use default bootrom
+  new chipyard.config.WithUART ++                                // add a UART
+  new chipyard.config.WithL2TLBs(1024) ++                        // use L2 TLBs
+  new freechips.rocketchip.subsystem.WithNoMMIOPort ++           // no top-level MMIO master port (overrides default set in rocketchip)
+  new freechips.rocketchip.subsystem.WithNoSlavePort ++          // no top-level MMIO slave port (overrides default set in rocketchip)
+  new freechips.rocketchip.subsystem.WithInclusiveCache ++       // use Sifive L2 cache
+  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++ // no external interrupts
+  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++  // hierarchical buses including mbus+l2
+  new freechips.rocketchip.system.BaseConfig)                    // "base" rocketchip system
+

--- a/generators/chipyard/src/main/scala/config/ArianeConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ArianeConfigs.scala
@@ -9,34 +9,11 @@ import freechips.rocketchip.config.{Config}
 // ---------------------
 
 class ArianeConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++                      // display UART with a SimUARTAdapter
-  new chipyard.iobinders.WithTieOffInterrupts ++                 // tie off top-level interrupts
-  new chipyard.iobinders.WithSimAXIMem ++                        // drive the master AXI4 memory with a SimAXIMem
-  new chipyard.iobinders.WithTiedOffDebug ++                     // tie off debug (since we are using SimSerial for testing)
-  new chipyard.iobinders.WithSimSerial ++                        // drive TSI with SimSerial for testing
-  new testchipip.WithTSI ++                                      // use testchipip serial offchip link
-  new chipyard.config.WithBootROM ++                             // use default bootrom
-  new chipyard.config.WithUART ++                                // add a UART
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++           // no top-level MMIO master port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++          // no top-level MMIO slave port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++       // use Sifive L2 cache
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++ // no external interrupts
-  new ariane.WithNArianeCores(1) ++                              // single Ariane core
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++  // hierarchical buses including mbus+l2
-  new freechips.rocketchip.system.BaseConfig)                    // "base" rocketchip system
+  new ariane.WithNArianeCores(1) ++                    // single Ariane core
+  new chipyard.config.AbstractConfig)
 
 class dmiArianeConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithSimAXIMem ++
-  new chipyard.iobinders.WithTiedOffSerial ++
-  new chipyard.iobinders.WithSimDebug ++               // add SimDebug and use it to drive simulation
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new ariane.WithNArianeCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.iobinders.WithTiedOffSerial ++          // Tie off the serial port, override default instantiation of SimSerial
+  new chipyard.iobinders.WithSimDebug ++               // add SimDebug and use it to drive simulation, override default tie-off debug
+  new ariane.WithNArianeCores(1) ++                    // single Ariane core
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/BoomConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/BoomConfigs.scala
@@ -7,151 +7,40 @@ import freechips.rocketchip.config.{Config}
 // ---------------------
 
 class SmallBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++                      // display UART with a SimUARTAdapter
-  new chipyard.iobinders.WithTieOffInterrupts ++                 // tie off top-level interrupts
-  new chipyard.iobinders.WithBlackBoxSimMem ++                   // drive the master AXI4 memory with a SimAXIMem
-  new chipyard.iobinders.WithTiedOffDebug ++                     // tie off debug (since we are using SimSerial for testing)
-  new chipyard.iobinders.WithSimSerial ++                        // drive TSI with SimSerial for testing
-  new testchipip.WithTSI ++                                      // use testchipip serial offchip link
-  new chipyard.config.WithBootROM ++                             // use default bootrom
-  new chipyard.config.WithUART ++                                // add a UART
-  new chipyard.config.WithL2TLBs(1024) ++                        // use L2 TLBs
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++           // no top-level MMIO master port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++          // no top-level MMIO slave port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++       // use Sifive L2 cache
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++ // no external interrupts
   new boom.common.WithNSmallBooms(1) ++                          // small boom config
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++  // hierarchical buses including mbus+l2
-  new freechips.rocketchip.system.BaseConfig)                    // "base" rocketchip system
+  new chipyard.config.AbstractConfig)
 
 class MediumBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new boom.common.WithNMediumBooms(1) ++                             // medium boom config
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new boom.common.WithNMediumBooms(1) ++                         // medium boom config
+  new chipyard.config.AbstractConfig)
 
 class LargeBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new boom.common.WithNLargeBooms(1) ++                          // large boom config
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class MegaBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new boom.common.WithNMegaBooms(1) ++                        // mega boom config
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new boom.common.WithBoomBranchPrintf ++
+  new boom.common.WithNMegaBooms(1) ++                           // mega boom config
+  new chipyard.config.AbstractConfig)
 
 class DualSmallBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new boom.common.WithNSmallBooms(2) ++                         // 2 boom cores
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new boom.common.WithNSmallBooms(2) ++                          // 2 boom cores
+  new chipyard.config.AbstractConfig)
 
 class HwachaLargeBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new hwacha.DefaultHwachaConfig ++                         // use Hwacha vector accelerator
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
+  new hwacha.DefaultHwachaConfig ++                              // use Hwacha vector accelerator
   new boom.common.WithNLargeBooms(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class LoopbackNICLargeBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new chipyard.iobinders.WithLoopbackNIC ++                        // drive NIC IOs with loopback
-  new testchipip.WithTSI ++
-  new icenet.WithIceNIC ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
+  new chipyard.iobinders.WithLoopbackNIC ++                      // drive NIC IOs with loopback
+  new icenet.WithIceNIC ++                                       // build a NIC
   new boom.common.WithNLargeBooms(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class DromajoBoomConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithSimDromajoBridge ++                 // attach Dromajo
-  new testchipip.WithTSI ++
   new chipyard.config.WithTraceIO ++                             // enable the traceio
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new boom.common.WithNSmallBooms(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 

--- a/generators/chipyard/src/main/scala/config/BoomConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/BoomConfigs.scala
@@ -19,7 +19,6 @@ class LargeBoomConfig extends Config(
   new chipyard.config.AbstractConfig)
 
 class MegaBoomConfig extends Config(
-  new boom.common.WithBoomBranchPrintf ++
   new boom.common.WithNMegaBooms(1) ++                           // mega boom config
   new chipyard.config.AbstractConfig)
 
@@ -43,4 +42,3 @@ class DromajoBoomConfig extends Config(
   new chipyard.config.WithTraceIO ++                             // enable the traceio
   new boom.common.WithNSmallBooms(1) ++
   new chipyard.config.AbstractConfig)
-

--- a/generators/chipyard/src/main/scala/config/HeteroConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/HeteroConfigs.scala
@@ -7,108 +7,38 @@ import freechips.rocketchip.config.{Config}
 // ---------------------
 
 class LargeBoomAndRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++                      // display UART with a SimUARTAdapter
-  new chipyard.iobinders.WithTieOffInterrupts ++                 // tie off top-level interrupts
-  new chipyard.iobinders.WithBlackBoxSimMem ++                   // drive the master AXI4 memory with a SimAXIMem
-  new chipyard.iobinders.WithTiedOffDebug ++                     // tie off debug (since we are using SimSerial for testing)
-  new chipyard.iobinders.WithSimSerial ++                        // drive TSI with SimSerial for testing
-  new testchipip.WithTSI ++                                      // use testchipip serial offchip link
-  new chipyard.config.WithBootROM ++                             // use default bootrom
-  new chipyard.config.WithUART ++                                // add a UART
-  new chipyard.config.WithL2TLBs(1024) ++                        // use L2 TLBs
   new boom.common.WithNLargeBooms(1) ++                          // single-core boom
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++           // no top-level MMIO master port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++          // no top-level MMIO slave port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++       // use Sifive L2 cache
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++ // no external interrupts
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++         // single rocket-core
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++  // hierarchical buses including mbus+l2
-  new freechips.rocketchip.system.BaseConfig)                    // "base" rocketchip system
+  new chipyard.config.AbstractConfig)
 
 // DOC include start: BoomAndRocketWithHwacha
 class HwachaLargeBoomAndHwachaRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new hwacha.DefaultHwachaConfig ++                      // add hwacha to all harts
-  new boom.common.WithNLargeBooms(1) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new hwacha.DefaultHwachaConfig ++                          // add hwacha to all harts
+  new boom.common.WithNLargeBooms(1) ++                      // add 1 boom core
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++     // add 1 rocket core
+  new chipyard.config.AbstractConfig)
 // DOC include end: BoomAndRocketWithHwacha
-// DOC include start: DualBoomAndRocketOneHwacha
 
+// DOC include start: DualBoomAndRocketOneHwacha
 class LargeBoomAndHwachaRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
   new chipyard.config.WithMultiRoCC ++                                  // support heterogeneous rocc
   new chipyard.config.WithMultiRoCCHwacha(1) ++                         // put hwacha on hart-1 (rocket)
-  new chipyard.config.WithL2TLBs(1024) ++
-  new boom.common.WithNLargeBooms(1) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new hwacha.DefaultHwachaConfig ++                                     // set default hwacha config keys
+  new boom.common.WithNLargeBooms(1) ++                                 // add 1 boom core
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++                // add 1 rocket core
+  new chipyard.config.AbstractConfig)
 // DOC include end: DualBoomAndRocketOneHwacha
 
 
 // DOC include start: DualBoomAndRocket
 class DualLargeBoomAndDualRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new boom.common.WithNLargeBooms(2) ++                   // 2 boom cores
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new freechips.rocketchip.subsystem.WithNBigCores(2) ++   // 2 rocket cores
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new boom.common.WithNLargeBooms(2) ++                   // add 2 boom cores
+  new freechips.rocketchip.subsystem.WithNBigCores(2) ++  // add 2 rocket cores
+  new chipyard.config.AbstractConfig)
 // DOC include end: DualBoomAndRocket
 
 class LargeBoomAndRocketWithControlCoreConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNSmallCores(1) ++ // Add a small control core
-  new boom.common.WithNLargeBooms(1) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
-
+  new freechips.rocketchip.subsystem.WithNSmallCores(1) ++ // Add a small "control" core
+  new boom.common.WithNLargeBooms(1) ++                    // Add 1 boom core
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++   // add 1 rocket core
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -7,556 +7,179 @@ import freechips.rocketchip.config.{Config}
 // --------------
 
 class RocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++                      // display UART with a SimUARTAdapter
-  new chipyard.iobinders.WithTieOffInterrupts ++                 // tie off top-level interrupts
-  new chipyard.iobinders.WithBlackBoxSimMem ++                   // drive the master AXI4 memory with a blackbox DRAMSim model
-  new chipyard.iobinders.WithTiedOffDebug ++                     // tie off debug (since we are using SimSerial for testing)
-  new chipyard.iobinders.WithSimSerial ++                        // drive TSI with SimSerial for testing
-  new testchipip.WithTSI ++                                      // use testchipip serial offchip link
-  new chipyard.config.WithBootROM ++                             // use default bootrom
-  new chipyard.config.WithUART ++                                // add a UART
-  new chipyard.config.WithL2TLBs(1024) ++                        // use L2 TLBs
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++           // no top-level MMIO master port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++          // no top-level MMIO slave port (overrides default set in rocketchip)
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++       // use Sifive L2 cache
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++ // no external interrupts
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++         // single rocket-core
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++  // hierarchical buses including mbus+l2
-  new freechips.rocketchip.system.BaseConfig)                    // "base" rocketchip system
+  new chipyard.config.AbstractConfig)
 
 class HwachaRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new hwacha.DefaultHwachaConfig ++                        // use Hwacha vector accelerator
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 // DOC include start: GemminiRocketConfig
 class GemminiRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new gemmini.DefaultGemminiConfig ++                        // use Gemmini systolic array GEMM accelerator
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: GemminiRocketConfig
-
-class RoccRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithRoccExample ++    // use example RoCC-based accelerator
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
 
 // DOC include start: JtagRocket
 class jtagRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithSimDebug ++    // add SimJtag and SimSerial, use both to drive sim
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
+  new chipyard.iobinders.WithSimDebug ++                   // add SimDebug, in addition to default SimSerial
   new freechips.rocketchip.subsystem.WithJtagDTM ++        // sets DTM communication interface to JTAG
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: JtagRocket
 
 // DOC include start: DmiRocket
 class dmiRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffSerial ++
-  new chipyard.iobinders.WithSimDebug ++               // add SimDebug and use it to drive simulation
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
+  new chipyard.iobinders.WithTiedOffSerial ++          // tie-off serial, override default add SimSerial
+  new chipyard.iobinders.WithSimDebug ++               // add SimDebug, override default tie-off debug
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: DmiRocket
 
 // DOC include start: GCDTLRocketConfig
 class GCDTLRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new chipyard.example.WithGCD(useAXI4=false, useBlackBox=false) ++          // Use GCD Chisel, connect Tilelink
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: GCDTLRocketConfig
 
 // DOC include start: GCDAXI4BlackBoxRocketConfig
 class GCDAXI4BlackBoxRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new chipyard.example.WithGCD(useAXI4=true, useBlackBox=true) ++          // Use GCD blackboxed verilog, connect by AXI4->Tilelink
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: GCDAXI4BlackBoxRocketConfig
 
 class LargeSPIFlashROMRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithSimSPIFlashModel(true) ++      // add the SPI flash model in the harness (read-only)
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
   new chipyard.config.WithSPIFlash ++                       // add the SPI flash controller
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class SmallSPIFlashRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithSimSPIFlashModel(false) ++     // add the SPI flash model in the harness (writeable)
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
   new chipyard.config.WithSPIFlash(0x100000) ++             // add the SPI flash controller (1 MiB)
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class SimAXIRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithSimAXIMem ++                       // drive the master AXI4 memory with a SimAXIMem, a 1-cycle magic memory
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
+  new chipyard.iobinders.WithSimAXIMem ++                   // drive the master AXI4 memory with a SimAXIMem, a 1-cycle magic memory, instead of default SimDRAM
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class SimBlockDeviceRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithSimBlockDevice ++             // drive block-device IOs with SimBlockDevice
-  new testchipip.WithTSI ++
   new testchipip.WithBlockDevice ++                        // add block-device module to peripherybus
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class BlockDeviceModelRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithBlockDeviceModel ++           // drive block-device IOs with a BlockDeviceModel
-  new testchipip.WithTSI ++
   new testchipip.WithBlockDevice ++                        // add block-device module to periphery bus
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 // DOC include start: GPIORocketConfig
 class GPIORocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithGPIOTiedOff ++                // tie off GPIO inputs into the top
-  new testchipip.WithTSI ++
   new chipyard.config.WithGPIO ++                          // add GPIOs to the peripherybus
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: GPIORocketConfig
 
 class QuadRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(4) ++   // quad-core (4 RocketTiles)
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class RV32RocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
   new freechips.rocketchip.subsystem.WithRV32 ++           // set RocketTiles to be 32-bit
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class GB1MemoryRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new freechips.rocketchip.subsystem.WithExtMemSize((1<<30) * 1L) ++ // use 1GB simulated external memory
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 // DOC include start: Sha3Rocket
 class Sha3RocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new sha3.WithSha3Accel ++                                // add SHA3 rocc accelerator
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: Sha3Rocket
 
 // DOC include start: InitZeroRocketConfig
 class InitZeroRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new chipyard.example.WithInitZero(0x88000000L, 0x1000L) ++                // add InitZero
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: InitZeroRocketConfig
 
 class LoopbackNICRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithLoopbackNIC ++                        // drive NIC IOs with loopback
-  new testchipip.WithTSI ++
   new icenet.WithIceNIC ++                                         // add an IceNIC
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 // DOC include start: l1scratchpadrocket
-class L1ScratchpadSmallRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
+class ScratchpadOnlyRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNMemoryChannels(0) ++ // remove offchip mem port
   new freechips.rocketchip.subsystem.WithNBanks(0) ++
   new freechips.rocketchip.subsystem.WithNoMemPort ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use rocket l1 scratchpad
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
-  new freechips.rocketchip.subsystem.WithNSmallCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use rocket l1 DCache scratchpad as base phys mem
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
 // DOC include end: l1scratchpadrocket
+
+class L1ScratchpadRocketConfig extends Config(
+  new chipyard.config.WithRocketICacheScratchpad ++   // use rocket ICache scratchpad
+  new chipyard.config.WithRocketDCacheScratchpad ++   // use rocket DCache scratchpad
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
 
 // DOC include start: mbusscratchpadrocket
 class MbusScratchpadRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
   new testchipip.WithBackingScratchpad ++                   // add mbus backing scratchpad
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new freechips.rocketchip.subsystem.WithNoMemPort ++       // remove offchip mem port
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: mbusscratchpadrocket
 
 // DOC include start: RingSystemBusRocket
 class RingSystemBusRocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new testchipip.WithRingSystemBus ++ // Ring-topology system bus
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: RingSystemBusRocket
 
 class StreamingPassthroughRocketConfig extends Config(
   new chipyard.example.WithStreamingPassthrough ++ // use top with tilelink-controlled streaming passthrough
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 // DOC include start: StreamingFIRRocketConfig
 class StreamingFIRRocketConfig extends Config (
   new chipyard.example.WithStreamingFIR ++ // use top with tilelink-controlled streaming FIR
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 // DOC include end: StreamingFIRRocketConfig
 
 class SmallNVDLARocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new nvidia.blocks.dla.WithNVDLA("small") ++ // add a small NVDLA
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class LargeNVDLARocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
   new nvidia.blocks.dla.WithNVDLA("large", true) ++ // add a large NVDLA with synth. rams
-  new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-  new freechips.rocketchip.subsystem.WithNoSlavePort ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)
 
 class MMIORocketConfig extends Config(
-  new chipyard.iobinders.WithUARTAdapter ++
-  new chipyard.iobinders.WithTieOffInterrupts ++
-  new chipyard.iobinders.WithBlackBoxSimMem ++
-  new chipyard.iobinders.WithTiedOffDebug ++
-  new chipyard.iobinders.WithSimSerial ++
   new chipyard.iobinders.WithTieOffL2FBusAXI ++ // Tie-off the incoming MMIO port
   new chipyard.iobinders.WithSimAXIMMIO ++ // Attach a simulated memory to the outwards MMIO port
-  new testchipip.WithTSI ++
-  new chipyard.config.WithBootROM ++
-  new chipyard.config.WithUART ++
-  new chipyard.config.WithL2TLBs(1024) ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache ++
-  new freechips.rocketchip.subsystem.WithNExtTopInterrupts(0) ++
+  new freechips.rocketchip.subsystem.WithDefaultMMIOPort ++ // add default external master port
+  new freechips.rocketchip.subsystem.WithDefaultSlavePort ++ // add default external slave port
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
-  new freechips.rocketchip.system.BaseConfig)
+  new chipyard.config.AbstractConfig)

--- a/scripts/tutorial-patches/RocketConfigs.scala.patch
+++ b/scripts/tutorial-patches/RocketConfigs.scala.patch
@@ -1,13 +1,13 @@
 diff --git a/generators/chipyard/src/main/scala/config/RocketConfigs.scala b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
-index f29c580..0bd36ca 100644
+index 8e6e486..fc3a811 100644
 --- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
 +++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
-@@ -333,7 +333,7 @@ class Sha3RocketConfig extends Config(
-   new chipyard.config.WithBootROM ++
-   new chipyard.config.WithUART ++
-   new chipyard.config.WithL2TLBs(1024) ++
+@@ -105,7 +105,7 @@ class GB1MemoryRocketConfig extends Config(
+ 
+ // DOC include start: Sha3Rocket
+ class Sha3RocketConfig extends Config(
 -  new sha3.WithSha3Accel ++                                // add SHA3 rocc accelerator
 +//  new sha3.WithSha3Accel ++                                // add SHA3 rocc accelerator
-   new freechips.rocketchip.subsystem.WithNoMMIOPort ++
-   new freechips.rocketchip.subsystem.WithNoSlavePort ++
-   new freechips.rocketchip.subsystem.WithInclusiveCache ++
+   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+   new chipyard.config.AbstractConfig)
+ // DOC include end: Sha3Rocket


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: software change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

I originally argued for the value of fully flattened Configs, for better visibility of configuration options. However, with the addition of IOBinders, further divergence from Rocketchip's BaseConfig, and more supported configurations, its clear this approach is unsustainable. What took 5 lines to express in v1.0, now takes 16. This PR deduplicates a `ChipyardBaseConfig` across all existing standard Chipyard configs.

`TutorialConfigs` is left fully flattened, as that structure may be useful for education.

We should discuss the changes in the next Chipyard meeting.
