### PR TITLE
Override default baud rate for FireChip

### DIFF
--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -51,9 +51,9 @@ class WithGPIO extends Config((site, here, up) => {
 })
 // DOC include end: gpio config fragment
 
-class WithUART extends Config((site, here, up) => {
+class WithUART(baudrate: BigInt = 115200) extends Config((site, here, up) => {
   case PeripheryUARTKey => Seq(
-    UARTParams(address = 0x54000000L, nTxEntries = 256, nRxEntries = 256))
+    UARTParams(address = 0x54000000L, nTxEntries = 256, nRxEntries = 256, initBaudRate = baudrate))
 })
 
 class WithSPIFlash(size: BigInt = 0x10000000) extends Config((site, here, up) => {

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -69,7 +69,8 @@ class WithNVDLASmall extends nvidia.blocks.dla.WithNVDLA("small")
 class WithFireSimConfigTweaks extends Config(
   // Required*: When using FireSim-as-top to provide a correct path to the target bootrom source
   new WithBootROM ++
-  // Optional*: Removing this will require target-software changes to properly capture UART output
+  // Optional*: Removing this will require adjusting the UART baud rate and
+  // potential target-software changes to properly capture UART output
   new WithPeripheryBusFrequency(BigInt(3200000000L)) ++
   // Required: Existing FAME-1 transform cannot handle black-box clock gates
   new WithoutClockGating ++
@@ -85,8 +86,8 @@ class WithFireSimConfigTweaks extends Config(
   new testchipip.WithTSI ++
   // Optional: Removing this will require using an initramfs under linux
   new testchipip.WithBlockDevice ++
-  // Required*:
-  new chipyard.config.WithUART
+  // Required*: Scale default baud rate with periphery bus frequency
+  new chipyard.config.WithUART(BigInt(3686400L))
 )
 
 /*******************************************************************************


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

This avoids target software needing to explicitly set the divisor to match the [UART bridge](https://github.com/firesim/firesim/blob/f5374ffcdfdac657245274670ba18577fb8561c9/sim/firesim-lib/src/main/scala/bridges/UARTBridge.scala#L48).
