### PR TITLE
Esp tsi loadmem

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -161,9 +161,7 @@ run-fast: run-asm-tests-fast run-bmark-tests-fast
 # helper rules to run simulator with fast loadmem via hex files
 #########################################################################################
 $(binary_hex): $(output_dir) $(BINARY)
-	hex_bytes=$(shell readelf --segments --wide $(BINARY) | grep LOAD | tail -n 1 | tr -s [:space:] | cut -f4,6 -d' ' | tr -d x | tr [:lower:] [:upper:] | tr ' ' + | sed 's/0000000008/ibase=16;/' | bc);\
-	power_2_bytes=`python -c "import math; print int(pow(2,math.ceil(math.log($$hex_bytes)/math.log(2))))"`;\
-	elf2hex 64 $$power_2_bytes $(BINARY) $(shell echo "ibase=16;$(LOADMEM_ADDR)" | bc) > $(binary_hex)
+	$(base_dir)/scripts/smartelf2hex.sh $(BINARY) > $(binary_hex)
 
 run-binary-hex: $(output_dir) $(sim) $(binary_hex)
 run-binary-hex: run-binary

--- a/docs/Simulation/Software-RTL-Simulation.rst
+++ b/docs/Simulation/Software-RTL-Simulation.rst
@@ -150,6 +150,12 @@ The ``.hex`` file should be a text file with a hexadecimal number on each line.
 
 Each line uses little-endian order, so this file would produce the bytes "ef be ad de 01 23". ``LOADMEM_ADDR`` specifies which address in memory (in hexadecimal) to write the first byte to. The default is 0x81000000.
 
+A special target that facilitates automatically generating a hex file for an entire elf RISC-V exectuable and then running the simulator with the appropriate flags is also available.
+
+.. code-block:: shell
+
+    make run-binary-hex BINARY=test.riscv
+
 Generating Waveforms
 -----------------------
 

--- a/generators/utilities/src/main/resources/csrc/emulator.cc
+++ b/generators/utilities/src/main/resources/csrc/emulator.cc
@@ -116,7 +116,6 @@ int main(int argc, char** argv)
   FILE * vcdfile = NULL;
   uint64_t start = 0;
 #endif
-  char ** htif_argv = NULL;
   int verilog_plusargs_legal = 1;
 
   opterr = 1;
@@ -252,10 +251,6 @@ done_processing:
     usage(argv[0]);
     return 1;
   }
-  int htif_argc = 1 + argc - optind;
-  htif_argv = (char **) malloc((htif_argc) * sizeof (char *));
-  htif_argv[0] = argv[0];
-  for (int i = 1; optind < argc;) htif_argv[i++] = argv[optind++];
 
   if (verbose)
     fprintf(stderr, "using random seed %u\n", random_seed);
@@ -278,8 +273,8 @@ done_processing:
 #endif
 
   jtag = new remote_bitbang_t(rbb_port);
-  dtm = new dtm_t(htif_argc, htif_argv);
-  tsi = new tsi_t(htif_argc, htif_argv);
+  dtm = new dtm_t(argc, argv);
+  tsi = new tsi_t(argc, argv);
 
   signal(SIGTERM, handle_sigterm);
 
@@ -364,6 +359,5 @@ done_processing:
   if (tsi) delete tsi;
   if (jtag) delete jtag;
   if (tile) delete tile;
-  if (htif_argv) free(htif_argv);
   return ret;
 }

--- a/scripts/smartelf2hex.sh
+++ b/scripts/smartelf2hex.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script find the appropriate arguments to pass to elf2hex by inspecting the given RISC-V elf binary
+# First and only argument is the binary to be converted.
+# The output of this script should be redirected to a file (as with normal elf2hex).
+
+binary=$1
+segments=`readelf --segments --wide $binary`
+entry_hex=`echo -e "$segments" | grep "Entry point" | cut -f3 -d' ' | sed 's/0x//' | tr [:lower:] [:upper:]`
+entry_dec=`bc <<< "ibase=16;$entry_hex"`
+length_hex=`echo "$segments" | grep LOAD | tail -n 1 | tr -s [:space:] | cut -f4,6 -d' '`
+length_dec=`echo $length_hex | tr -d x | tr [:lower:] [:upper:] | tr ' ' + | sed 's/^/ibase=16;/' | sed "s/$/-$entry_hex/" | bc`
+power_2_length=`echo "x=l($length_dec)/l(2); scale=0; 2^((x+1)/1)" | bc -l`
+elf2hex 64 $power_2_length $binary $entry_dec

--- a/variables.mk
+++ b/variables.mk
@@ -173,6 +173,7 @@ override SIM_FLAGS += +loadmem=$(LOADMEM) +loadmem_addr=$(LOADMEM_ADDR)
 endif
 VERBOSE_FLAGS ?= +verbose
 sim_out_name = $(output_dir)/$(subst $() $(),_,$(notdir $(basename $(BINARY))))
+binary_hex= $(sim_out_name).loadmem_hex
 
 #########################################################################################
 # build output directory for compilation


### PR DESCRIPTION
This build on #635 to add a `run-binary*-hex` target that creates a hex file from the executable and loads it for simulation.

This speeds up simulations for large executables considerably. 
Requires https://github.com/ucb-bar/esp-isa-sim/pull/16