### PR TITLE
Selective HW printfs

### DIFF
--- a/docs/Simulation/Software-RTL-Simulation.rst
+++ b/docs/Simulation/Software-RTL-Simulation.rst
@@ -181,3 +181,18 @@ An open-source vcd-capable waveform viewer is `GTKWave <http://gtkwave.sourcefor
 
 For a VCS simulation, this will generate a vpd file (this is a proprietary waveform representation format used by Synopsys) that can be loaded to vpd-supported waveform viewers.
 If you have Synopsys licenses, we recommend using the DVE waveform viewer.
+
+.. _sw-sim-verilator-opts:
+
+Additional Verilator Options
+-------------------------------
+
+When building the verilator simulator there are some additional options:
+
+.. code-block:: shell
+
+   make ENABLE_PRINTF_PATTERN='<python-regex>'
+
+The ``ENABLE_PRINTF_PATTERN`` option selectively enables hardware printf's based on a text match of the format string.
+For example, if you wanted to enable the rocket-core's instruction log, and nothing else, you could run ``make ENABLE_PRINTF_PATTERN='.*DASM\(%x\)'``.
+Don't forget to start the line with a ``.*``, since the pattern matches start at the beginning of the line.

--- a/scripts/enable_printfs
+++ b/scripts/enable_printfs
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#=============================================================================
+# this enables the PRINTF_COND around points of interest
+#=============================================================================
+
+import sys
+import re
+from textwrap import dedent as dd
+
+#=============================================================================
+# subroutines
+#=============================================================================
+def print_usage():
+  print(dd("""
+    enable_printfs <in_file> <out_file> [pattern1] [pattern2] ...
+    -------------------------------------------------------------
+    Selectively enables verbose printf() in your verilog. Right
+    now, you either get no verbose logging, or 100% verbose logging, but many
+    times, you might want to just enable logging in a specific module. THIS
+    SCRIPT IS A TEMPORARY HACK: post-processes the verilog file to remove the
+    `ifdef PRINTF_COND wrappers around the specific printf()s you care about.
+    You must manually specify python-compatible regex patterns on the cmdline
+    to match() the strings in the printf you care about. Multiple patterns are
+    treated as logical OR, not AND.
+  """))
+  exit(1)
+
+#=============================================================================
+if __name__ == "__main__":
+  if len(sys.argv) < 3:
+    print_usage()
+
+  # parse inputs
+  in_file = sys.argv[1]
+  out_file = sys.argv[2]
+  trigger = re.compile(".*`ifdef PRINTF_COND.*")
+  targets = []
+  for idx in range(3, len(sys.argv)):
+    if len(sys.argv[idx]) > 0:
+      targets.append(re.compile(sys.argv[idx]))
+
+  # read input lines
+  in_lines = []
+  with open(in_file, "r") as f:
+    in_lines = f.readlines()
+
+  # enable PRINTF_COND lines around points of interest
+  enables = 0
+  out_lines = []
+  idx = 0
+  idx_end = len(in_lines)
+  while(idx < idx_end):
+    if trigger.match(in_lines[idx]):
+      matches_target = False
+      for target in targets:
+        if target.match(in_lines[idx+4]):
+          matches_target = True
+          break
+      if matches_target:
+        enables += 1
+        out_lines += in_lines[idx+3:idx+6]
+      else:
+        out_lines += in_lines[idx:idx+9]
+      idx += 9
+    else:
+      out_lines.append(in_lines[idx])
+      idx += 1
+
+  # write to output file
+  with open(out_file, "w") as f:
+    f.writelines(out_lines)
+
+  print("INFO: enabled {} printfs in {}".format(enables, out_file))

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -53,7 +53,15 @@ HELP_COMPILATION_VARIABLES += \
 "   VERILATOR_PROFILE      = 'none' if no verilator profiling (default)" \
 "                            'all' if full verilator runtime profiling" \
 "                            'threads' if runtime thread profiling only" \
+"   ENABLE_PRINTF_PATTERN  = python regex. any printf() with text that matches this regex will be " \
+"                            force enabled in sim output default is no selectively enabled printf's" \
 "   VERILATOR_FST_MODE     = enable FST waveform instead of VCD. use with debug build"
+
+#########################################################################################
+# selectively enabling printfs
+#########################################################################################
+ENABLE_PRINTF_PATTERN ?=
+sim_vsrcs_printf := $(sim_vsrcs:.v=.printf.v)
 
 #########################################################################################
 # verilator/cxx binary and flags
@@ -189,18 +197,25 @@ model_mk = $(model_dir)/V$(VLOG_MODEL).mk
 model_mk_debug = $(model_dir_debug)/V$(VLOG_MODEL).mk
 
 #########################################################################################
+# selectively enable verbose logging
+#########################################################################################
+# see GNU Make static patterns
+$(sim_vsrcs_printf) : %.printf.v : %.v
+	$(base_dir)/scripts/enable_printfs $< $@ "$(ENABLE_PRINTF_PATTERN)"
+
+#########################################################################################
 # build makefile fragment that builds the verilator sim rules
 #########################################################################################
-$(model_mk): $(sim_vsrcs) $(sim_common_files) $(EXTRA_SIM_REQS)
+$(model_mk): $(sim_vsrcs_printf) $(sim_common_files) $(EXTRA_SIM_REQS)
 	rm -rf $(model_dir)
 	mkdir -p $(model_dir)
 	$(VERILATOR) $(VERILATOR_OPTS) $(EXTRA_SIM_SOURCES) -o $(sim) -Mdir $(model_dir) -CFLAGS "-include $(model_header)"
 	touch $@
 
-$(model_mk_debug): $(sim_vsrcs) $(sim_common_files) $(EXTRA_SIM_REQS)
+$(model_mk_debug): $(sim_vsrcs_printf) $(sim_common_files) $(EXTRA_SIM_REQS)
 	rm -rf $(model_dir_debug)
 	mkdir -p $(model_dir_debug)
-	$(VERILATOR) $(VERILATOR_OPTS) $(EXTRA_SIM_SOURCES) -o $(sim_debug) --trace -Mdir $(model_dir_debug) -CFLAGS "-include $(model_header_debug)"
+	$(VERILATOR) $(VERILATOR_OPTS) $(EXTRA_SIM_SOURCES) -o $(sim_debug) $(TRACING_OPTS) -Mdir $(model_dir_debug) -CFLAGS "-include $(model_header_debug)"
 	touch $@
 
 #########################################################################################
@@ -229,7 +244,8 @@ clean:
 	rm -rf $(gen_dir) $(sim_prefix)-*
 
 clean-sim:
-	rm -rf $(model_dir) $(sim)
+	rm -rf $(model_dir) $(sim) $(sim_vsrcs_printf)
 
 clean-sim-debug:
-	rm -rf $(model_dir_debug) $(sim_debug)
+	rm -rf $(model_dir_debug) $(sim_debug) $(sim_vsrcs_printf)
+


### PR DESCRIPTION
**Related issue**: Split from PR #562 

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: other

**Release Notes**
This is split from the work done in #562. This PR just adds a way to selectively enable certain printfs. The main differences between this and the original PR is that this PR moves the script to `scripts`.

Additionally, this fixes the `TRACE_OPTS` flag (makes it used instead of just `--trace`) from PR #650 

TODO:
- [ ] Support the same in VCS
