### PR TITLE
Dedup simulation flags + Small VCS Cleanup

### DIFF
--- a/docs/Simulation/Software-RTL-Simulation.rst
+++ b/docs/Simulation/Software-RTL-Simulation.rst
@@ -195,5 +195,5 @@ When building the verilator simulator there are some additional options:
 
 The ``VERILATOR_THREADS=<num>`` option enables the compiled Verilator simulator to use ``<num>`` parallel threads.
 On a multi-socket machine, you will want to make sure all threads are on the same socket by using ``NUMACTL=1`` to enable ``numactl``.
-By enabling this, you will use CHipyard's ``numa_prefix`` wrapper, which is a simple wrapper around ``numactl`` that runs your verilated simulator like this: ``$(numa_prefix) ./simulator-<name> <simulator-args>``.
+By enabling this, you will use Chipyard's ``numa_prefix`` wrapper, which is a simple wrapper around ``numactl`` that runs your verilated simulator like this: ``$(numa_prefix) ./simulator-<name> <simulator-args>``.
 Note that both these flags are mutually exclusive, you can use either independently (though it makes sense to use ``NUMACTL`` just with ``VERILATOR_THREADS=8`` during a Verilator simulation).

--- a/sims/common-sim-flags.mk
+++ b/sims/common-sim-flags.mk
@@ -1,0 +1,24 @@
+#----------------------------------------------------------------------------------------
+# common gcc configuration/optimization
+#----------------------------------------------------------------------------------------
+SIM_OPT_CXXFLAGS := -O3
+
+SIM_CXXFLAGS = \
+	$(CXXFLAGS) \
+	$(SIM_OPT_CXXFLAGS) \
+	-std=c++11 \
+	-I$(RISCV)/include \
+	-I$(dramsim_dir) \
+	-I$(build_dir) \
+	$(EXTRA_SIM_CXXFLAGS)
+
+SIM_LDFLAGS = \
+	$(LDFLAGS) \
+	-L$(RISCV)/lib \
+	-Wl,-rpath,$(RISCV)/lib \
+	-L$(sim_dir) \
+	-L$(dramsim_dir) \
+	-lfesvr \
+	-lpthread \
+	-ldramsim \
+	$(EXTRA_SIM_LDFLAGS)

--- a/sims/common-sim-flags.mk
+++ b/sims/common-sim-flags.mk
@@ -19,6 +19,5 @@ SIM_LDFLAGS = \
 	-L$(sim_dir) \
 	-L$(dramsim_dir) \
 	-lfesvr \
-	-lpthread \
 	-ldramsim \
 	$(EXTRA_SIM_LDFLAGS)

--- a/sims/vcs/Makefile
+++ b/sims/vcs/Makefile
@@ -44,13 +44,21 @@ VCS = vcs -full64
 VCS_OPTS = $(VCS_CC_OPTS) $(VCS_NONCC_OPTS) $(PREPROC_DEFINES)
 
 #########################################################################################
+# vcs build paths
+#########################################################################################
+model_dir = $(build_dir)/$(long_name)
+model_dir_debug = $(build_dir)/$(long_name).debug
+
+#########################################################################################
 # vcs simulator rules
 #########################################################################################
 $(sim): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS)
-	rm -rf csrc && $(VCS) $(VCS_OPTS) $(EXTRA_SIM_SOURCES) -o $@
+	rm -rf $(model_dir)
+	$(VCS) $(VCS_OPTS) $(EXTRA_SIM_SOURCES) -o $@ -Mdir=$(model_dir)
 
 $(sim_debug): $(sim_vsrcs) $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS)
-	rm -rf csrc && $(VCS) $(VCS_OPTS) $(EXTRA_SIM_SOURCES) -o $@ \
+	rm -rf $(model_dir_debug)
+	$(VCS) $(VCS_OPTS) $(EXTRA_SIM_SOURCES) -o $@ -Mdir=$(model_dir_debug)  \
 	+define+DEBUG
 
 #########################################################################################
@@ -65,10 +73,10 @@ $(output_dir)/%.vpd: $(output_dir)/% $(sim_debug)
 #########################################################################################
 .PHONY: clean clean-sim clean-sim-debug
 clean:
-	rm -rf $(gen_dir) csrc $(sim_prefix)-* ucli.key vc_hdrs.h
+	rm -rf $(gen_dir) $(sim_prefix)-* ucli.key
 
 clean-sim:
-	rm -rf csrc/ $(sim) ucli.key vc_hdrs.h
+	rm -rf $(model_dir) $(build_dir)/vc_hdrs.h $(sim) $(sim).daidir ucli.key
 
 clean-sim-debug:
-	rm -rf csrc/ $(sim_debug) ucli.key vc_hdrs.h
+	rm -rf $(model_dir_debug) $(build_dir)/vc_hdrs.h $(sim_debug) $(sim_debug).daidir ucli.key

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -141,35 +141,19 @@ VERILATOR_NONCC_OPTS = \
 #----------------------------------------------------------------------------------------
 # gcc configuration/optimization
 #----------------------------------------------------------------------------------------
-# -flto slows down compilation on small-memory and breaks on firesim-manager
-CXX_OPT_FLAGS := -O3
+include $(base_dir)/sims/common-sim-flags.mk
 
 VERILATOR_CXXFLAGS = \
-	$(CXXFLAGS) \
+	$(SIM_CXXFLAGS) \
 	$(RUNTIME_PROFILING_CFLAGS) \
 	$(TRACING_CFLAGS) \
-	$(CXX_OPT_FLAGS) \
-	-std=c++11 \
 	-D__STDC_FORMAT_MACROS \
 	-DTEST_HARNESS=V$(VLOG_MODEL) \
 	-DVERILATOR \
-	-I$(RISCV)/include \
-	-I$(dramsim_dir) \
-	-I$(build_dir) \
 	-include $(build_dir)/$(long_name).plusArgs \
-	-include $(build_dir)/verilator.h \
-	$(EXTRA_SIM_CXXFLAGS)
+	-include $(build_dir)/verilator.h
 
-VERILATOR_LDFLAGS =	\
-	$(LDFLAGS) \
-	-L$(RISCV)/lib \
-	-Wl,-rpath,$(RISCV)/lib \
-	-L$(sim_dir) \
-	-L$(dramsim_dir) \
-	-lfesvr \
-	-lpthread \
-	-ldramsim \
-	$(EXTRA_SIM_LDFLAGS)
+VERILATOR_LDFLAGS = $(SIM_LDFLAGS)
 
 VERILATOR_CC_OPTS = \
 	-CFLAGS "$(VERILATOR_CXXFLAGS)" \

--- a/vcs.mk
+++ b/vcs.mk
@@ -14,25 +14,10 @@ RESET_DELAY ?= 777.7
 #----------------------------------------------------------------------------------------
 # gcc configuration/optimization
 #----------------------------------------------------------------------------------------
-CXX_OPT_FLAGS := -O3
+include $(base_dir)/sims/common-sim-flags.mk
 
-VCS_CXXFLAGS = \
-	$(CXXFLAGS) \
-	$(CXX_OPT_FLAGS) \
-	-I$(RISCV)/include \
-	-I$(dramsim_dir) \
-	-std=c++11 \
-	$(EXTRA_SIM_CXXFLAGS)
-
-VCS_LDFLAGS =	\
-	$(LDFLAGS) \
-	-L$(RISCV)/lib \
-	-Wl,-rpath,$(RISCV)/lib \
-	-L$(sim_dir) \
-	-L$(dramsim_dir) \
-	-lfesvr \
-	-ldramsim \
-	$(EXTRA_SIM_LDFLAGS)
+VCS_CXXFLAGS = $(SIM_CXXFLAGS)
+VCS_LDFLAGS = $(SIM_LDFLAGS)
 
 # vcs requires LDFLAGS to not include library names (i.e. -l needs to be separate)
 VCS_CC_OPTS = \


### PR DESCRIPTION
**Related issue**: Fixes #653 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
Requires PR #654 to go be merged 1st. This PR deduplicates the simulator flags in Chipyard, does some minor VCS cleanup to put its `csrc` directory in a similar place to Verilator, and removes the need for the `libpthread` library.

This is tested on multi-threaded Verilator, normal Verilator, as well as VCS.
