### PR TITLE
Don't run find in base_dir to avoid slow filesystem search

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -62,7 +62,8 @@ SOURCE_DIRS = $(addprefix $(base_dir)/,generators sims/firesim/sim tools/barstoo
 SCALA_SOURCES = $(call lookup_srcs,$(SOURCE_DIRS),scala)
 VLOG_SOURCES = $(call lookup_srcs,$(SOURCE_DIRS),sv) $(call lookup_srcs,$(SOURCE_DIRS),v)
 # This assumes no SBT meta-build sources
-SBT_SOURCES = $(call lookup_srcs,$(base_dir),sbt)
+SBT_SOURCE_DIRS = $(addprefix $(base_dir)/,generators sims/firesim/sim tools)
+SBT_SOURCES = $(call lookup_srcs,$(SBT_SOURCE_DIRS),sbt) $(base_dir)/build.sbt $(base_dir)/project/plugins.sbt
 
 #########################################################################################
 # jar creation variables and rules


### PR DESCRIPTION
This should drastically improve performance for users who store lots of stuff in `$(base_dir)`.
In my workspace, running out of `/nscratch`, this change improved runtime of `make` with no source changes from 60 seconds to 3 seconds.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: software change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
