### PR TITLE
Support Placing DRAM Memory Systems In Their Own Clock Domain

### DIFF
--- a/generators/chipyard/src/main/scala/Clocks.scala
+++ b/generators/chipyard/src/main/scala/Clocks.scala
@@ -8,11 +8,11 @@ import freechips.rocketchip.prci._
 import freechips.rocketchip.subsystem.{BaseSubsystem, SubsystemDriveAsyncClockGroupsKey}
 import freechips.rocketchip.config.{Parameters, Field, Config}
 import freechips.rocketchip.diplomacy.{OutwardNodeHandle, InModuleBody, LazyModule}
-import freechips.rocketchip.util.{ResetCatchAndSync, Pow2ClockDivider}
+import freechips.rocketchip.util.{ResetCatchAndSync}
 
 import barstools.iocell.chisel._
 
-import chipyard.clocking.{DividerOnlyClockGenerator, ClockGroupNamePrefixer, ClockGroupFrequencySpecifier}
+import chipyard.clocking._
 
 /**
   * Chipyard provides three baseline, top-level reset schemes, set using the
@@ -116,6 +116,7 @@ object ClockingSchemeGenerators {
     val referenceClockSource =  ClockSourceNode(Seq(ClockSourceParameters()))
     (aggregator
       := ClockGroupFrequencySpecifier(p(ClockFrequencyAssignersKey), p(DefaultClockFrequencyKey))
+      := ClockGroupResetSynchronizer()
       := DividerOnlyClockGenerator()
       := referenceClockSource)
 

--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -5,13 +5,13 @@ import chisel3.util.{log2Up}
 
 import freechips.rocketchip.config.{Field, Parameters, Config}
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.diplomacy.{LazyModule, ValName}
+import freechips.rocketchip.diplomacy.{LazyModule, ValName, RationalCrossing}
 import freechips.rocketchip.devices.tilelink.{BootROMLocated}
 import freechips.rocketchip.devices.debug.{Debug, ExportDebug, DebugModuleKey, DMI}
 import freechips.rocketchip.groundtest.{GroundTestSubsystem}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams, ICacheParams}
-import freechips.rocketchip.util.{AsyncResetReg}
+import freechips.rocketchip.util.{AsyncResetReg, Symmetric}
 import freechips.rocketchip.prci._
 
 import testchipip._
@@ -167,8 +167,17 @@ class WithNoDebug extends Config((site, here, up) => {
 })
 
 class WithTileFrequency(fMHz: Double) extends ClockNameContainsAssignment("core", fMHz)
+class WithDRAMControllerFrequency(fMHz: Double) extends ClockNameContainsAssignment("dram_controller", fMHz)
 
 class WithPeripheryBusFrequencyAsDefault extends Config((site, here, up) => {
   case DefaultClockFrequencyKey => (site(PeripheryBusKey).dtsFrequency.get / (1000 * 1000)).toDouble
+})
+
+class WithRationalDRAMController extends Config((site, here, up) => {
+  // NB: Symmetric to avoid assumptions abotu MBUS vs DRAM frequency
+  // TODO: There's some unsettling assertion behavior when using FastToSlow
+  // consistent with the assertions not being reversed to consider SlowToFast
+  // on channels being driven by the controller.
+  case DRAMCrossingTypeKey => RationalCrossing(Symmetric)
 })
 

--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -5,7 +5,7 @@ import chisel3.util.{log2Up}
 
 import freechips.rocketchip.config.{Field, Parameters, Config}
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.diplomacy.{LazyModule, ValName, RationalCrossing}
+import freechips.rocketchip.diplomacy.{LazyModule, ValName, RationalCrossing, AsynchronousCrossing}
 import freechips.rocketchip.devices.tilelink.{BootROMLocated}
 import freechips.rocketchip.devices.debug.{Debug, ExportDebug, DebugModuleKey, DMI}
 import freechips.rocketchip.groundtest.{GroundTestSubsystem}
@@ -173,7 +173,7 @@ class WithPeripheryBusFrequencyAsDefault extends Config((site, here, up) => {
   case DefaultClockFrequencyKey => (site(PeripheryBusKey).dtsFrequency.get / (1000 * 1000)).toDouble
 })
 
-class WithRationalDRAMController extends Config((site, here, up) => {
+class WithRationalDRAMControllerXing extends Config((site, here, up) => {
   // NB: Symmetric to avoid assumptions abotu MBUS vs DRAM frequency
   // TODO: There's some unsettling assertion behavior when using FastToSlow
   // consistent with the assertions not being reversed to consider SlowToFast
@@ -181,3 +181,6 @@ class WithRationalDRAMController extends Config((site, here, up) => {
   case DRAMCrossingTypeKey => RationalCrossing(Symmetric)
 })
 
+class WithAsyncDRAMControllerXing extends Config((site, here, up) => {
+  case DRAMCrossingTypeKey => AsynchronousCrossing
+})

--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -182,5 +182,5 @@ class WithRationalDRAMControllerXing extends Config((site, here, up) => {
 })
 
 class WithAsyncDRAMControllerXing extends Config((site, here, up) => {
-  case DRAMCrossingTypeKey => AsynchronousCrossing
+  case DRAMCrossingTypeKey => AsynchronousCrossing()
 })

--- a/generators/chipyard/src/main/scala/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/HarnessBinders.scala
@@ -125,11 +125,11 @@ class WithSimNetwork extends OverrideHarnessBinder({
 })
 
 class WithSimAXIMem extends OverrideHarnessBinder({
-  (system: CanHaveMasterAXI4MemPort, th: HasHarnessSignalReferences, ports: Seq[ClockedIO[AXI4Bundle]]) => {
+  (system: chipyard.CanHaveFlexiblyClockedMasterAXI4MemPort, th: HasHarnessSignalReferences, ports: Seq[ClockedAndResetIO[AXI4Bundle]]) => {
     val p: Parameters = chipyard.iobinders.GetSystemParameters(system)
     (ports zip system.memAXI4Node.edges.in).map { case (port, edge) =>
       val mem = LazyModule(new SimAXIMem(edge, size=p(ExtMem).get.master.size)(p))
-      withClockAndReset(port.clock, th.harnessReset) {
+      withClockAndReset(port.clock, port.reset) {
         Module(mem.module).suggestName("mem")
       }
       mem.io_axi4.head <> port.bits
@@ -139,7 +139,7 @@ class WithSimAXIMem extends OverrideHarnessBinder({
 })
 
 class WithBlackBoxSimMem extends OverrideHarnessBinder({
-  (system: CanHaveMasterAXI4MemPort, th: HasHarnessSignalReferences, ports: Seq[ClockedIO[AXI4Bundle]]) => {
+  (system: chipyard.CanHaveFlexiblyClockedMasterAXI4MemPort, th: HasHarnessSignalReferences, ports: Seq[ClockedAndResetIO[AXI4Bundle]]) => {
     val p: Parameters = chipyard.iobinders.GetSystemParameters(system)
     (ports zip system.memAXI4Node.edges.in).map { case (port, edge) =>
       val memSize = p(ExtMem).get.master.size
@@ -147,7 +147,7 @@ class WithBlackBoxSimMem extends OverrideHarnessBinder({
       val mem = Module(new SimDRAM(memSize, lineSize, edge.bundle)).suggestName("simdram")
       mem.io.axi <> port.bits
       mem.io.clock := port.clock
-      mem.io.reset := th.harnessReset
+      mem.io.reset := port.reset
     }
     Nil
   }

--- a/generators/chipyard/src/main/scala/IOBinders.scala
+++ b/generators/chipyard/src/main/scala/IOBinders.scala
@@ -24,7 +24,7 @@ import barstools.iocell.chisel._
 import testchipip._
 import icenet.{CanHavePeripheryIceNIC, SimNetwork, NicLoopback, NICKey, NICIOvonly}
 
-import chipyard.GlobalResetSchemeKey
+import chipyard.{GlobalResetSchemeKey, CanHaveFlexiblyClockedMasterAXI4MemPort}
 
 import scala.reflect.{ClassTag}
 
@@ -256,11 +256,10 @@ class WithSerialTLIOCells extends OverrideIOBinder({
 
 
 class WithAXI4MemPunchthrough extends OverrideIOBinder({
-  (system: CanHaveMasterAXI4MemPort) => {
-    val ports: Seq[ClockedIO[AXI4Bundle]] = system.mem_axi4.zipWithIndex.map({ case (m, i) =>
-      val p = IO(new ClockedIO(DataMirror.internal.chiselTypeClone[AXI4Bundle](m))).suggestName(s"axi4_mem_${i}")
-      p.bits <> m
-      p.clock := BoreHelper("axi4_mem_clock", system.asInstanceOf[BaseSubsystem].mbus.module.clock)
+  (system: CanHaveFlexiblyClockedMasterAXI4MemPort) => {
+    val ports: Seq[ClockedAndResetIO[AXI4Bundle]] = system.mem_axi4.zipWithIndex.map({ case (m, i) =>
+      val p = IO(m.cloneType).suggestName(s"axi4_mem_${i}")
+      p <> m
       p
     })
     (ports, Nil)

--- a/generators/chipyard/src/main/scala/Ports.scala
+++ b/generators/chipyard/src/main/scala/Ports.scala
@@ -1,0 +1,80 @@
+package chipyard
+
+import chisel3._
+import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.amba.axi4._
+import freechips.rocketchip.util._
+import freechips.rocketchip.subsystem._
+import freechips.rocketchip.prci.{ClockGroup, ClockSinkDomain, ClockParameters}
+
+import testchipip.ClockedAndResetIO
+
+case object DRAMCrossingTypeKey extends Field[ClockCrossingType](NoCrossing)
+case object DRAMControllerFrequencyMHzKey extends Field[Option[Double]](None)
+
+/** Adds a port to the system intended to master an AXI4 DRAM controller. */
+trait CanHaveFlexiblyClockedMasterAXI4MemPort { this: BaseSubsystem =>
+  private val memPortParamsOpt = p(ExtMem)
+  private val portName = "axi4"
+  private val device = new MemoryDevice
+  private val idBits = memPortParamsOpt.map(_.master.idBits).getOrElse(1)
+
+  val dramControllerDomainWrapper = LazyModule(new ClockSinkDomain(
+    name = Some("dram_controller"),
+    take = p(DRAMControllerFrequencyMHzKey).map {f => ClockParameters(f) }))
+
+  dramControllerDomainWrapper.clockNode := (p(DRAMCrossingTypeKey) match {
+    case _: SynchronousCrossing =>
+      mbus.fixedClockNode
+    case _: RationalCrossing =>
+      mbus.clockNode
+    case _: AsynchronousCrossing =>
+      val dramClockGroup = ClockGroup()
+      dramClockGroup := asyncClockGroupsNode
+      dramClockGroup
+  })
+
+  val memAXI4Node = AXI4SlaveNode(memPortParamsOpt.map({ case MemoryPortParams(memPortParams, nMemoryChannels) =>
+    Seq.tabulate(nMemoryChannels) { channel =>
+      val base = AddressSet.misaligned(memPortParams.base, memPortParams.size)
+      val filter = AddressSet(channel * mbus.blockBytes, ~((nMemoryChannels-1) * mbus.blockBytes))
+
+      AXI4SlavePortParameters(
+        slaves = Seq(AXI4SlaveParameters(
+          address       = base.flatMap(_.intersect(filter)),
+          resources     = device.reg,
+          regionType    = RegionType.UNCACHED, // cacheable
+          executable    = true,
+          supportsWrite = TransferSizes(1, mbus.blockBytes),
+          supportsRead  = TransferSizes(1, mbus.blockBytes),
+          interleavedId = Some(0))), // slave does not interleave read responses
+        beatBytes = memPortParams.beatBytes)
+    }
+  }).toList.flatten)
+
+  val dramDomainTLNode = dramControllerDomainWrapper { (memAXI4Node
+    :*= AXI4UserYanker()
+    :*= AXI4IdIndexer(idBits)
+    :*= TLToAXI4())
+  }
+
+  mbus.coupleTo(s"memory_controller_port_named_$portName") {
+    (dramControllerDomainWrapper.crossIn(dramDomainTLNode)(ValName("dram_crossing"))(p(DRAMCrossingTypeKey))
+      :*= TLWidthWidget(mbus.beatBytes)
+      :*= _)
+  }
+
+  val mem_axi4 = InModuleBody {
+    for ((bundle, edge) <- memAXI4Node.in) yield {
+      val io = chisel3.experimental.IO(new ClockedAndResetIO(bundle.cloneType)).suggestName("axi4_mem")
+      io.bits <> bundle
+      io.clock := dramControllerDomainWrapper.module.clock
+      io.reset := dramControllerDomainWrapper.module.reset
+      io
+    }
+  }
+}
+
+

--- a/generators/chipyard/src/main/scala/Ports.scala
+++ b/generators/chipyard/src/main/scala/Ports.scala
@@ -31,9 +31,11 @@ trait CanHaveFlexiblyClockedMasterAXI4MemPort { this: BaseSubsystem =>
     case _: RationalCrossing =>
       mbus.clockNode
     case _: AsynchronousCrossing =>
-      val dramClockGroup = ClockGroup()
-      dramClockGroup := asyncClockGroupsNode
-      dramClockGroup
+      // TODO: determine how we wish to handle the asyncClockGroup
+      //val dramClockGroup = ClockGroup()
+      //dramClockGroup := asyncClockGroupsNode
+      //dramClockGroup
+      mbus.clockNode
   })
 
   val memAXI4Node = AXI4SlaveNode(memPortParamsOpt.map({ case MemoryPortParams(memPortParams, nMemoryChannels) =>

--- a/generators/chipyard/src/main/scala/System.scala
+++ b/generators/chipyard/src/main/scala/System.scala
@@ -23,8 +23,8 @@ import freechips.rocketchip.util.{DontTouch}
  */
 class ChipyardSystem(implicit p: Parameters) extends ChipyardSubsystem
   with HasAsyncExtInterrupts
-  with CanHaveMasterAXI4MemPort
   with CanHaveMasterAXI4MMIOPort
+  with CanHaveFlexiblyClockedMasterAXI4MemPort
   with CanHaveSlaveAXI4Port
 {
 

--- a/generators/chipyard/src/main/scala/clocking/DividerOnlyClockGenerator.scala
+++ b/generators/chipyard/src/main/scala/clocking/DividerOnlyClockGenerator.scala
@@ -62,6 +62,10 @@ case class DividerOnlyClockGeneratorNode(pllName: String)(implicit valName: ValN
   * fast reference clock (roughly LCM(requested frequencies)) which is passed up the
   * diplomatic graph, and then generates dividers for each unique requested
   * frequency.
+  *
+  * Output resets are not synchronized to generated clocks and should be
+  * synchronized by the user in a manner they see fit.
+  *
   */
 
 class DividerOnlyClockGenerator(pllName: String)(implicit p: Parameters, valName: ValName) extends LazyModule {
@@ -87,13 +91,8 @@ class DividerOnlyClockGenerator(pllName: String)(implicit p: Parameters, valName
     for (((sinkBName, sinkB), sinkP) <- outClocks.member.elements.zip(outSinkParams.members)) {
       val div = pllConfig.sinkDividerMap(sinkP)
       sinkB.clock := dividedClocks.getOrElse(div, instantiateDivider(div))
-      if (sinkBName.contains("dram")) {
-        sinkB.reset := refClock.reset
-      } else if (sinkBName.contains("core")) {
-        sinkB.reset := ResetCatchAndSync(sinkB.clock, refClock.reset.asBool, sync=4)
-      } else {
-        sinkB.reset := ResetCatchAndSync(sinkB.clock, refClock.reset.asBool, sync=2)
-      }
+      // Reset handling and synchronization is expected to be handled by a downstream node
+      sinkB.reset := refClock.reset
     }
   }
 }

--- a/generators/chipyard/src/main/scala/clocking/ResetSynchronizer.scala
+++ b/generators/chipyard/src/main/scala/clocking/ResetSynchronizer.scala
@@ -1,0 +1,30 @@
+
+package chipyard.clocking
+
+import chisel3._
+
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.prci._
+import freechips.rocketchip.util.{ResetCatchAndSync}
+
+/**
+  * Instantiates a reset synchronizer on all clock-reset pairs in a clock group
+  */
+class ClockGroupResetSynchronizer(implicit p: Parameters) extends LazyModule {
+  val node = ClockGroupIdentityNode()
+  lazy val module = new LazyRawModuleImp(this) {
+    (node.out zip node.in).map { case ((oG, _), (iG, _)) =>
+      (oG.member.data zip iG.member.data).foreach { case (o, i) =>
+        o.clock := i.clock
+        o.reset := ResetCatchAndSync(i.clock, i.reset.asBool)
+      }
+    }
+  }
+}
+
+object ClockGroupResetSynchronizer {
+  def apply()(implicit p: Parameters, valName: ValName) = LazyModule(new ClockGroupResetSynchronizer()).node
+}
+
+

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -178,7 +178,7 @@ class DividedClockRocketConfig extends Config(
   new chipyard.config.WithTileFrequency(200.0) ++
   new chipyard.config.WithDRAMControllerFrequency(50.0) ++
   new freechips.rocketchip.subsystem.WithRationalRocketTiles ++   // Add rational crossings between RocketTile and uncore
-  new chipyard.config.WithRationalDRAMController ++   // Add async crossings between mbus and DRAM controllers
+  new chipyard.config.WithRationalDRAMControllerXing ++   // Add rational crossings between mbus and DRAM controllers
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -176,7 +176,9 @@ class MMIORocketConfig extends Config(
 
 class DividedClockRocketConfig extends Config(
   new chipyard.config.WithTileFrequency(200.0) ++
+  new chipyard.config.WithDRAMControllerFrequency(50.0) ++
   new freechips.rocketchip.subsystem.WithRationalRocketTiles ++   // Add rational crossings between RocketTile and uncore
+  new chipyard.config.WithRationalDRAMController ++   // Add async crossings between mbus and DRAM controllers
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -73,6 +73,12 @@ class WithFireSimConfigTweaks extends Config(
   // Optional*: Removing this will require adjusting the UART baud rate and
   // potential target-software changes to properly capture UART output
   new WithPeripheryBusFrequency(BigInt(3200000000L)) ++
+  // Optional: Removing these two configs will result in the FASED timing model running
+  // at the pbus freq (above, 3.2 GHz), which is outside the range of valid DDR3 speedgrades.
+  // 1 GHz matches the FASED default, using some other frequency will require
+  // runnings the FASED runtime configuration generator to generate faithful DDR3 timing values.
+  new chipyard.config.WithDRAMControllerFrequency(1000.0) ++
+  new chipyard.config.WithAsyncDRAMControllerXing ++
   // Required: Existing FAME-1 transform cannot handle black-box clock gates
   new WithoutClockGating ++
   // Required*: Removes thousands of assertions that would be synthesized (* pending PriorityMux bugfix)


### PR DESCRIPTION
Adds an extension of CanHaveMasterAXI4MemPort that allows the user to place the memory controller (and abutted diplomatic widgets) in a separate clock domain for performance modelling purposes. I intend for this to be a placeholder until something is decided upstream.

Other changes:

- Adds a ResetSynchronizer diplonode that acts on ClockGroups. Now uniformly synchronizes all outputs from the divider-only clock generator
- Places the FASED memory model in a 1GHz async domain for FireChip targets. This has the effect of making all default targets in FireSim multiclock. 

Questions:
- Should i add a sychronizer node for ClockNodes too?
- Should we keep the IO binders that matched on the old trait?  
- By default i put everything i could in CY, let me know what i should push into testchipip and where. 
- Should there be a ClockedIO and ClockedAndResetIO? Perhaps just the latter? Maybe reset can be made an `Option`.
- Renaming clocking package -> prci to mirror RC? 


**Type of change**: new feature
**Impact**: rtl change
**Release Notes**: Add support for putting DRAM memory systems in their own clock domains. 
