### PR TITLE
added gettext dependency for qemu build

### DIFF
--- a/scripts/ubuntu-req.sh
+++ b/scripts/ubuntu-req.sh
@@ -14,7 +14,7 @@ sudo apt-get install -y libexpat1-dev libusb-dev libncurses5-dev cmake
 # deps for poky
 sudo apt-get install -y python3.6 patch diffstat texi2html texinfo subversion chrpath git wget
 # deps for qemu
-sudo apt-get install -y libgtk-3-dev
+sudo apt-get install -y libgtk-3-dev gettext
 # deps for firemarshal
 sudo apt-get install -y python3-pip python3.6-dev rsync libguestfs-tools expat ctags
 # install DTC


### PR DESCRIPTION
Qemu build failed on Ubuntu 18.04/20.04 hosted on google cloud without this.

 bug fix | other


