### PR TITLE
Update smartelf2hex to use MemSiz instead of FileSiz

### DIFF
--- a/scripts/smartelf2hex.sh
+++ b/scripts/smartelf2hex.sh
@@ -8,7 +8,7 @@ binary=$1
 segments=`readelf --segments --wide $binary`
 entry_hex=`echo -e "$segments" | grep "Entry point" | cut -f3 -d' ' | sed 's/0x//' | tr [:lower:] [:upper:]`
 entry_dec=`bc <<< "ibase=16;$entry_hex"`
-length_hex=`echo "$segments" | grep "LOAD\|TLS" | tail -n 1 | tr -s [:space:] | cut -f4,6 -d' '`
+length_hex=`echo "$segments" | grep "LOAD\|TLS" | tail -n 1 | tr -s [:space:] | cut -f4,7 -d' '`
 length_dec=`echo $length_hex | tr -d x | tr [:lower:] [:upper:] | tr ' ' + | sed 's/^/ibase=16;/' | sed "s/$/-$entry_hex/" | bc`
 power_2_length=`echo "x=l($length_dec)/l(2); scale=0; 2^((x+1)/1)" | bc -l`
 width=64


### PR DESCRIPTION
elf2hex writes zeros to a segment for which MemSize > FileSize, which adheres to the ELF spec. 
Thus, we should calculate the total size of the file from the MemSize of the last segment, rather than the FileSize.

From `man elf`: 
```
                        The array element specifies a loadable segment,
                        described by p_filesz and p_memsz.  The bytes from
                        the file are mapped to the beginning of the memory
                        segment.  If the segment's memory size p_memsz is
                        larger than the file size p_filesz, the "extra"
                        bytes are defined to hold the value 0 and to follow
                        the segment's initialized area.  The file size may
                        not be larger than the memory size.  Loadable seg‐
                        ment entries in the program header table appear in
                        ascending order, sorted on the p_vaddr member.
```

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: software change 

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
