### PR TITLE
Don't annotate cores with FAMEModelAnnotations

### DIFF
--- a/generators/firechip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/src/main/scala/BridgeBinders.scala
@@ -18,7 +18,7 @@ import icenet.{CanHavePeripheryIceNIC, SimNetwork, NicLoopback, NICKey, NICIOvon
 
 import junctions.{NastiKey, NastiParameters}
 import midas.models.{FASEDBridge, AXI4EdgeSummary, CompleteConfig}
-import midas.targetutils.{FAMEModelAnnotation, MemModelAnnotation, EnableModelMultiThreadingAnnotation}
+import midas.targetutils.{MemModelAnnotation, EnableModelMultiThreadingAnnotation}
 import firesim.bridges._
 import firesim.configs.MemModelKey
 import tracegen.{TraceGenSystemModuleImp}
@@ -161,10 +161,8 @@ class WithFireSimFAME5 extends ComposeIOBinder({
   (system: HasTilesModuleImp) => {
     system.outer.tiles.map {
       case b: BoomTile =>
-        annotate(FAMEModelAnnotation(b.module))
         annotate(EnableModelMultiThreadingAnnotation(b.module))
       case r: RocketTile =>
-        annotate(FAMEModelAnnotation(r.module))
         annotate(EnableModelMultiThreadingAnnotation(r.module))
     }
     (Nil, Nil)


### PR DESCRIPTION
This will make multi-threading a bit harder to use until firesim/firesim#647 is merged and makes it back to CY, but it doesn't break any code, so it's fine to merge any time.