### PR TITLE
Bump Dromajo | Optional ignore QEMU toolchain flag

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -107,14 +107,18 @@ if [ "${EC2FASTINSTALL}" = true ] ; then
     git submodule deinit "${module}" || :
 
 else
-    "${MAKE}" --version | (
-        read -r makever
-        case ${makever} in
-        'GNU Make '[4-9]\.*|'GNU Make '[1-9][0-9]) ;;
-        *) false ;;
-        esac; ) || die 'obsolete make version; need GNU make 4.x or later'
+    MAKE_VER=$("${MAKE}" --version) || true
+    case ${MAKE_VER} in
+        'GNU Make '[4-9]\.*)
+            ;;
+        'GNU Make '[1-9][0-9])
+            ;;
+        *)
+            die 'obsolete make version; need GNU make 4.x or later'
+            ;;
+    esac
 
-    module_prepare riscv-gnu-toolchain
+    module_prepare riscv-gnu-toolchain qemu
     module_build riscv-gnu-toolchain --prefix="${RISCV}" --with-cmodel=medany
     echo '==>  Building GNU/Linux toolchain'
     module_make riscv-gnu-toolchain linux

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -35,7 +35,7 @@ die() {
 
 TOOLCHAIN="riscv-tools"
 EC2FASTINSTALL="false"
-IGNOREQEMU="false"
+IGNOREQEMU=""
 RISCV=""
 
 # getopts does not support long options, and is inflexible
@@ -133,7 +133,7 @@ module_all riscv-tests --prefix="${RISCV}/riscv64-unknown-elf"
 
 SRCDIR="$(pwd)/toolchains" module_all libgloss --prefix="${RISCV}/riscv64-unknown-elf" --host=riscv64-unknown-elf
 
-if [ "${IGNOREQEMU}" = false ] ; then
+if [ -z "$IGNOREQEMU" ] ; then
 SRCDIR="$(pwd)/toolchains" module_all qemu --prefix="${RISCV}" --target-list=riscv64-softmmu
 fi
 


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature + bug fix

<!-- choose one -->
**Impact**: software change

**Release Notes**
Small changes to allow Dromajo to be built with an older version of `glibc` and adding an "ignore QEMU" flag to the build toolchains script (default is to still build QEMU).
