### PR TITLE
Disable CC and CXX overrides for libgloss build

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -135,7 +135,7 @@ module_all riscv-tests --prefix="${RISCV}/riscv64-unknown-elf"
 
 # Common tools (not in any particular toolchain dir)
 
-SRCDIR="$(pwd)/toolchains" module_all libgloss --prefix="${RISCV}/riscv64-unknown-elf" --host=riscv64-unknown-elf
+CC= CXX= SRCDIR="$(pwd)/toolchains" module_all libgloss --prefix="${RISCV}/riscv64-unknown-elf" --host=riscv64-unknown-elf
 
 if [ -z "$IGNOREQEMU" ] ; then
 SRCDIR="$(pwd)/toolchains" module_all qemu --prefix="${RISCV}" --target-list=riscv64-softmmu


### PR DESCRIPTION
**Related issue**: #735

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

This permits users to specify `CC` and `CXX` for building the host software without impacting cross-compilation of libgloss-htif, same as how riscv-pk is handled.