### PR TITLE
Small CI Cleanup + CI Fix

### DIFF
--- a/.circleci/check-commit.sh
+++ b/.circleci/check-commit.sh
@@ -124,19 +124,25 @@ search
 # turn off verbose printing to make this easier to read
 set +x
 
-# print all result strings
+# print 0's
 for str in "${all_names[@]}";
 do
-    echo "$str"
+    if [ 0 = $(echo "$str" | awk '{print$3}') ]; then
+        echo "$str"
+    fi
 done
 
-# check if there was a non-zero return code
+echo ""
+
+# check if there was a non-zero return code and print 1's
+EXIT=0
 for str in "${all_names[@]}";
 do
     if [ ! 0 = $(echo "$str" | awk '{print$3}') ]; then
-        exit 1
+        echo "$str"
+        EXIT=1
     fi
 done
 
 echo "Done checking all submodules"
-
+exit $EXIT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ commands:
             - add_ssh_keys:
                 fingerprints:
                     - "3e:c3:02:5b:ed:64:8c:b7:b0:04:43:bc:83:43:73:1e"
+                    - "32:d6:89:d2:97:fa:db:de:a8:2d:2a:f2:70:dd:80:89"
             - checkout
 
     setup-tools:

--- a/.circleci/defaults.sh
+++ b/.circleci/defaults.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 copy () {
-    rsync -avzp -e 'ssh' $1 $2
+    rsync -avzp -e 'ssh' --exclude '.git' $1 $2
 }
 
 run () {

--- a/.circleci/do-rtl-build.sh
+++ b/.circleci/do-rtl-build.sh
@@ -56,6 +56,7 @@ run "export RISCV=\"$TOOLS_DIR\"; \
 
 read -a keys <<< ${grouping[$1]}
 
+# need to set the PATH to use the new verilator (with the new verilator root)
 for key in "${keys[@]}"
 do
     run "export RISCV=\"$TOOLS_DIR\"; \


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
Small changes to improve CI a bit. First, when looking at the `check-commit` printout, split it into all 0's (valid) and all 1's (invalid, not on `master` branch) so that it is less annoying trying to find the 1 in the sea of 0's. Second, don't transfer `.git` folder on copies since we don't do `git` operations on the build server. Additionally, it adds a new SSH key to login to the build server.