### PR TITLE
Bump chisel-testers back to freechipsproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,7 +76,7 @@
 	url = https://github.com/ucb-bar/dsptools.git
 [submodule "tools/chisel-testers"]
 	path = tools/chisel-testers
-	url = https://github.com/ucb-bar/chisel-testers.git
+	url = https://github.com/freechipsproject/chisel-testers.git
 [submodule "tools/treadle"]
 	path = tools/treadle
 	url = https://github.com/freechipsproject/treadle.git


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
#719 changed `chisel-testers` to `ucb-bar` since there was an outstanding PR in the mainline repo (`freechipsproject`). Now that it is merged we can return to mainline (`freechipsproject`).
