### PR TITLE
Add 16-core LargeBOOM config to firechip

### DIFF
--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -200,3 +200,14 @@ class FireSimMulticlockRocketConfig extends Config(
   new WithFireSimConfigTweaks ++
   new chipyard.DividedClockRocketConfig)
 
+//**********************************************************************************
+// System with 16 LargeBOOMs that can be simulated with Golden Gate optimizations
+// - Requires MTModels and MCRams mixins as prefixes to the platform config
+// - May require larger build instances or JVM memory footprints
+//*********************************************************************************/
+class FireSim16LargeBoomConfig extends Config(
+  new WithDefaultFireSimBridges ++
+  new WithDefaultMemModel ++
+  new WithFireSimConfigTweaks ++
+  new boom.common.WithNLargeBooms(16) ++
+  new chipyard.config.AbstractConfig)


### PR DESCRIPTION
**Type of change**: other enhancement
**Impact**: new target config

**Release Notes**
To highlight the resource-optimizing platform configurations added to FireSim in firesim/firesim#636, a 16-core LargeBOOM configuration has been added to FireChip.
