### PR TITLE
Ensure git config changes are reverted on failure

### DIFF
--- a/scripts/init-fpga.sh
+++ b/scripts/init-fpga.sh
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 # Enable submodule update for FPGA tools.
-git config --unset submodule.fpga/fpga-shells.update
+git config --unset submodule.fpga/fpga-shells.update || :
 # Initialize local FPGA tools.
 git submodule update --init --recursive fpga/fpga-shells
 # Disable submodule update for FPGA tools.


### PR DESCRIPTION
**Related issue**: #595

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
This ensures that the temporary `git config` settings for excluding certain submodules from the recursive update are properly reverted if the submodule update fails or is interrupted by SIGINT or SIGTERM.

The git commands have been refactored to loop over a centralized blacklist, which should reduce the potential for human errors when updating this script in the future.
