### PR TITLE
Avoid permissions conflict on shared protocjar.webcache

### DIFF
--- a/.java_tmp/.gitignore
+++ b/.java_tmp/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/variables.mk
+++ b/variables.mk
@@ -146,7 +146,7 @@ sim_common_files       ?= $(build_dir)/sim_files.common.f
 # java arguments used in sbt
 #########################################################################################
 JAVA_HEAP_SIZE ?= 8G
-JAVA_OPTS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -XX:MaxPermSize=256M
+JAVA_OPTS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -XX:MaxPermSize=256M -Djava.io.tmpdir=$(base_dir)/.java_tmp
 
 #########################################################################################
 # default sbt launch command


### PR DESCRIPTION
The Java protoc plugin (part of FIRRTL) by default caches protoc in /tmp, and does not delete it afterwards.
This causes permissions failures when multiple users try to install Chipyard on the same machine, due to permissions failures over accessing the same cache in /tmp.

A solution is to place the tmpdir within the Chipyard repo. No other files besides protocjar.webcache currently use that directory, so I believe this should be safe.

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: software change
