### PR TITLE
Update comment on GenerateReset

### DIFF
--- a/generators/chipyard/src/main/scala/Clocks.scala
+++ b/generators/chipyard/src/main/scala/Clocks.scala
@@ -17,8 +17,8 @@ import chipyard.clocking._
 
 /**
  * A simple reset implementation that punches out reset ports
- * for standard Module classes. Three basic reset schemes
- * are provided. See [[GlobalResetScheme]].
+ * for standard Module classes. The ChipTop reset pin is Async.
+ * Synchronization is performed in the ClockGroupResetSynchronizer
  */
 object GenerateReset {
   def apply(chiptop: ChipTop, clock: Clock): Reset = {


### PR DESCRIPTION
ChipTop reset was standardized to be async for 1.4.0
Resolves #741 