### PR TITLE
WithFireSimFAME5 to allow non Rocket/BOOM build

### DIFF
--- a/generators/firechip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/src/main/scala/BridgeBinders.scala
@@ -170,6 +170,7 @@ class WithFireSimFAME5 extends ComposeIOBinder({
         annotate(EnableModelMultiThreadingAnnotation(b.module))
       case r: RocketTile =>
         annotate(EnableModelMultiThreadingAnnotation(r.module))
+      case _ => Nil
     }
     (Nil, Nil)
   }


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
Fix WithFireSimFAME5 to allow build on FireSim non-Rocket/BOOM builds such as CVA6 or Sodor.
