### PR TITLE
[fix]incorrect place of SBT_OPTS cause `workspaceDirectory` point to wrong place

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -164,7 +164,7 @@ override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
 SBT_CLIENT_FLAG = --client
 endif
 
-SBT ?= java $(JAVA_OPTS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar $(SBT_OPTS) $(SBT_CLIENT_FLAG)
+SBT ?= java $(JAVA_OPTS) $(SBT_OPTS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar $(SBT_CLIENT_FLAG)
 SBT_NON_THIN ?= $(subst $(SBT_CLIENT_FLAG),,$(SBT))
 
 define run_scala_main


### PR DESCRIPTION
**Related issue**: Incorrect `SBT_OPTS` cause compilation error

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**

Compilation error:
java.lang.RuntimeException: Invalid build URI (no handler available): file:///home/username/workspace/chisel3/

Place `SBT_OPTS` before `-jar` will fix this