### PR TITLE
Fix parsing of --ignore-qemu option

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -48,7 +48,6 @@ do
             shift
             RISCV=$(realpath $1) ;;
         --ignore-qemu )
-            shift
             IGNOREQEMU="true" ;;
         riscv-tools | esp-tools)
             TOOLCHAIN=$1 ;;


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

Remove an extra `shift` that breaks parsing of subsequent arguments.  The positional parameters are already shifted once at the end of the loop body.
