### PR TITLE
Use "tile" instead of "core" to assign freq's in WithTileFrequency config. fragment

### DIFF
--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -193,7 +193,7 @@ class WithTLBackingMemory extends Config((site, here, up) => {
   case ExtTLMem => up(ExtMem, site) // enable TL backing memory
 })
 
-class WithTileFrequency(fMHz: Double) extends ClockNameContainsAssignment("core", fMHz)
+class WithTileFrequency(fMHz: Double) extends ClockNameContainsAssignment("tile", fMHz)
 
 class WithPeripheryBusFrequencyAsDefault extends Config((site, here, up) => {
   case DefaultClockFrequencyKey => (site(PeripheryBusKey).dtsFrequency.get / (1000 * 1000)).toDouble


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
Fixes an issue where `WithTileFrequency` wouldn't modify the frequency of all tiles since clock names are based on the `TileParams` name (which defaults to `tile` and `boom_tile` for Rocket/BOOM respectively).

Tested with 2 configs:

1. `MulticlockRocketConfig`:
![image](https://user-images.githubusercontent.com/8823803/109259015-4295e000-77b0-11eb-8aae-b22969ddd3ee.png)

2. `DoubleRocketAndBoomConfig` (custom config that only used `WithTileFrequency(600)` - no other freq's changed):
![image](https://user-images.githubusercontent.com/8823803/109259289-c059eb80-77b0-11eb-954d-fae353aa27fc.png)

