### PR TITLE
Add WithMultiRoCCFromBuildRoCC to make heterogeneous accelerator configs easier

### DIFF
--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -84,6 +84,17 @@ class WithMultiRoCC extends Config((site, here, up) => {
 })
 
 /**
+ * Assigns what was previously in the BuildRoCC key to specific harts with MultiRoCCKey
+ * Must be paired with WithMultiRoCC
+ */
+class WithMultiRoCCFromBuildRoCC(harts: Int*) extends Config((site, here, up) => {
+  case BuildRoCC => Nil
+  case MultiRoCCKey => up(MultiRoCCKey, site) ++ harts.distinct.map { i =>
+    (i -> up(BuildRoCC, site))
+  }
+})
+
+/**
  * Config fragment to add Hwachas to cores based on hart
  *
  * For ex:


### PR DESCRIPTION
This fragment basically lets you copy the contents of the BuildRoCC key into a MultiRoCC hart mapping, so you no longer have to define custom `WithMultiRoCCX` fragments for each accelerator you want to use with MultiRoCC

**Type of change**: new feature
