### PR TITLE
Fix IOCell generation for clock and reset to use IOCellKey

### DIFF
--- a/generators/chipyard/src/main/scala/Clocks.scala
+++ b/generators/chipyard/src/main/scala/Clocks.scala
@@ -14,6 +14,7 @@ import barstools.iocell.chisel._
 import testchipip.{TLTileResetCtrl}
 
 import chipyard.clocking._
+import chipyard.iobinders._
 
 /**
  * A simple reset implementation that punches out reset ports
@@ -25,7 +26,7 @@ object GenerateReset {
     implicit val p = chiptop.p
     // this needs directionality so generateIOFromSignal works
     val async_reset_wire = Wire(Input(AsyncReset()))
-    val (reset_io, resetIOCell) = IOCell.generateIOFromSignal(async_reset_wire, "reset",
+    val (reset_io, resetIOCell) = IOCell.generateIOFromSignal(async_reset_wire, "reset", p(IOCellKey),
       abstractResetAsAsync = true)
 
     chiptop.iocells ++= resetIOCell
@@ -94,7 +95,7 @@ object ClockingSchemeGenerators {
     InModuleBody {
       val clock_wire = Wire(Input(Clock()))
       val reset_wire = GenerateReset(chiptop, clock_wire)
-      val (clock_io, clockIOCell) = IOCell.generateIOFromSignal(clock_wire, "clock")
+      val (clock_io, clockIOCell) = IOCell.generateIOFromSignal(clock_wire, "clock", p(IOCellKey))
       chiptop.iocells ++= clockIOCell
 
       referenceClockSource.out.unzip._1.map { o =>


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->
Fixes #823 

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
Use IOCellKey to generate IO Cells for clock and reset