### PR TITLE
Sane FireSim Default Target Freqs

### DIFF
--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.rocket.DCacheParams
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink.{BootROMLocated, BootROMParams}
 import freechips.rocketchip.devices.debug.{DebugModuleParams, DebugModuleKey}
-import freechips.rocketchip.diplomacy.LazyModule
+import freechips.rocketchip.diplomacy.{LazyModule, AsynchronousCrossing}
 import testchipip.{BlockDeviceKey, BlockDeviceConfig, TracePortKey, TracePortParams}
 import sifive.blocks.devices.uart.{PeripheryUARTKey, UARTParams}
 import scala.math.{min, max}
@@ -85,8 +85,46 @@ class WithFireSimDesignTweaks extends Config(
 
 // Tweaks to modify target clock frequencies / crossings to firesim defaults
 class WithFireSimDefaultFrequencyTweaks extends Config(
-  // Optional*: Removing this will require adjusting the UART baud rate and
-  // potential target-software changes to properly capture UART output
+  // Optional: This sets the default frequency for all buses in the system to 2 GHz
+  // (since unspecified bus frequencies will use the pbus frequency)
+  new chipyard.config.WithPeripheryBusFrequency(2000.0) ++
+  // Optional: These three configs will put the system bus at a frequency of 1 GHz
+  // Which is more representative of on uncore working at a lower frequency than the tiles
+  new chipyard.config.WithSystemBusFrequency(1000.0) ++
+  new chipyard.config.WithSbusToCbusCrossingType(AsynchronousCrossing()) ++ // Add Async crossing between SBUS and CBUS
+  new chipyard.config.WithFbusToSbusCrossingType(AsynchronousCrossing()) ++ // Add Async crossing between FBUS and SBUS
+  // Optional: These three configs put the DRAM memory system in it's own clock domian.
+  // Removing the first config will result in the FASED timing model running
+  // at the pbus freq (above, 3.2 GHz), which is outside the range of valid DDR3 speedgrades.
+  // 1 GHz matches the FASED default, using some other frequency will require
+  // runnings the FASED runtime configuration generator to generate faithful DDR3 timing values.
+  new chipyard.config.WithMemoryBusFrequency(1000.0) ++
+  new chipyard.config.WithAsynchrousMemoryBusCrossing ++
+  new testchipip.WithAsynchronousSerialSlaveCrossing
+)
+
+// Tweaks to modify target clock frequencies / crossings to testchip defaults
+class WithFireSimTestchipFrequencyTweaks extends Config(
+  // Optional: This sets the default frequency for all buses in the system to 1 GHz
+  // (since unspecified bus frequencies will use the pbus frequency).
+  // This frequency is representative of Rocket/BOOM-based test chips
+  new chipyard.config.WithPeripheryBusFrequency(1000.0) ++
+  // Optional: These three configs put the DRAM memory system in it's own clock domian.
+  // Removing the first config will result in the FASED timing model running
+  // at the pbus freq (above, 3.2 GHz), which is outside the range of valid DDR3 speedgrades.
+  // 1 GHz matches the FASED default, using some other frequency will require
+  // runnings the FASED runtime configuration generator to generate faithful DDR3 timing values.
+  new chipyard.config.WithMemoryBusFrequency(1000.0) ++
+  new chipyard.config.WithAsynchrousMemoryBusCrossing ++
+  new testchipip.WithAsynchronousSerialSlaveCrossing
+)
+
+// Tweaks to modify target clock frequencies / crossings to legacy firesim defaults
+class WithFireSimHighPerfFrequencyTweaks extends Config(
+  // Optional: This sets the default frequency for all buses in the system to 3.2 GHz
+  // (since unspecified bus frequencies will use the pbus frequency)
+  // This frequency selection matches FireSim's legacy selection and is required
+  // to support 200Gb NIC performance. You may select a smaller value.
   new chipyard.config.WithPeripheryBusFrequency(3200.0) ++
   // Optional: These three configs put the DRAM memory system in it's own clock domian.
   // Removing the first config will result in the FASED timing model running
@@ -101,6 +139,18 @@ class WithFireSimDefaultFrequencyTweaks extends Config(
 // Tweaks that are generally applied to all firesim configs
 class WithFireSimConfigTweaks extends Config(
   new WithFireSimDefaultFrequencyTweaks ++
+  new WithFireSimDesignTweaks
+)
+
+// Tweak more representative of testchip configs
+class WithFireSimTestchipConfigTweaks extends Config(
+  new WithFireSimTestchipFrequencyTweaks ++
+  new WithFireSimDesignTweaks
+)
+
+// Tweaks for legacy FireSim configs.
+class WithFireSimHighPerfConfigTweaks extends Config(
+  new WithFireSimHighPerfFrequencyTweaks ++
   new WithFireSimDesignTweaks
 )
 


### PR DESCRIPTION
**Related issue**: N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
Update FireSim default frequencies for better tile/system/memory ratios.

This PR changes the default FireSim target tile frequency from 3.2 GHz to 2 GHz (with a memory bus of 1 GHz), because 3.2 GHz generates an unrealistic Tile/Memory cycles ratio.
The default configs are also updated with a slower system bus (1 GHz).

The PR also adds two additional packaged config tweaks which are representative of High-Perf (Legacy) target configs, and test-chip target configs (1 GHz tile instead of 2 GHz). 

- [ ] Upon approval, need to generate new pre-built AGFIs.