### PR TITLE
Update `git` in Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
 executors:
     main-env:
         docker:
-            - image: ucbbar/chipyard-ci-image:9c650dea
+            - image: ucbbar/chipyard-ci-image:ab57b7d
         environment:
             JVM_OPTS: -Xmx3200m # Customize the JVM maximum heap limit
 

--- a/scripts/ubuntu-req.sh
+++ b/scripts/ubuntu-req.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-sudo apt-get install -y build-essential bison flex
+sudo apt-get install -y build-essential bison flex software-properties-common
 sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev zlib1g-dev vim default-jdk default-jre
 # install sbt: https://www.scala-sbt.org/release/docs/Installing-sbt-on-Linux.html
 echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list

--- a/scripts/ubuntu-req.sh
+++ b/scripts/ubuntu-req.sh
@@ -3,7 +3,7 @@
 set -ex
 
 sudo apt-get install -y build-essential bison flex
-sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev zlib1g-dev vim git default-jdk default-jre
+sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev zlib1g-dev vim default-jdk default-jre
 # install sbt: https://www.scala-sbt.org/release/docs/Installing-sbt-on-Linux.html
 echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
 curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
@@ -12,7 +12,7 @@ sudo apt-get install -y sbt
 sudo apt-get install -y texinfo gengetopt
 sudo apt-get install -y libexpat1-dev libusb-dev libncurses5-dev cmake
 # deps for poky
-sudo apt-get install -y python3.6 patch diffstat texi2html texinfo subversion chrpath git wget
+sudo apt-get install -y python3.6 patch diffstat texi2html texinfo subversion chrpath wget
 # deps for qemu
 sudo apt-get install -y libgtk-3-dev gettext
 # deps for firemarshal
@@ -20,6 +20,10 @@ sudo apt-get install -y python3-pip python3.6-dev rsync libguestfs-tools expat c
 # install DTC
 sudo apt-get install -y device-tree-compiler
 sudo apt-get install -y python
+# install git >= 2.17
+sudo add-apt-repository ppa:git-core/ppa -y
+sudo apt-get update
+sudo apt-get install git -y
 
 # install verilator
 git clone http://git.veripool.org/git/verilator


### PR DESCRIPTION
**Related issue**: 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: software change

**Release Notes**
This bumps the docker image to use a newer version of Git (specifically `2.31.1`). This change applies only to the `ucbbar/chipyard-ci-image:ab57b7d` for now.

https://hub.docker.com/repository/docker/ucbbar/chipyard-ci-image