### PR TITLE
Fix memory alignment in character count RoCC test

### DIFF
--- a/tests/charcount.c
+++ b/tests/charcount.c
@@ -1,6 +1,6 @@
 #include "rocc.h"
 
-char string[64] = "The quick brown fox jumped over the lazy dog";
+char string[64] __attribute__ ((aligned (64))) = "The quick brown fox jumped over the lazy dog";
 
 static inline unsigned long count_chars(char *start, char needle)
 {


### PR DESCRIPTION
The character count RoCC accelerator performs aligned (CacheBlockBytes) TL accesses to get input data.  However, the test application does not enforce such alignment, and the accelerator may end up processing values outside the input string.  If this happens and a ```'\0'``` is detected before the actual string starts, the accelerator sets its ```finished``` flag and returns a wrong result.

**Related issue**: #839

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: software change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
