### PR TITLE
Runs `make clean` after `make-install` to reduce used disk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 parameters:
     tools-cache-version:
         type: string
-        default: "v6"
+        default: "v7"
 
 # default execution env.s
 executors:

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -39,6 +39,7 @@ EC2FASTINSTALL="false"
 IGNOREQEMU=""
 RISCV=""
 ARCH=""
+CLEANAFTERINSTALL=""
 
 # getopts does not support long options, and is inflexible
 while [ "$1" != "" ];
@@ -51,16 +52,19 @@ do
             RISCV=$(realpath $1) ;;
         --ignore-qemu )
             IGNOREQEMU="true" ;;
-	-a | --arch )
-	    shift
-	    ARCH=$1 ;;
-        riscv-tools | esp-tools)
-            TOOLCHAIN=$1 ;;
-        ec2fast )
-            EC2FASTINSTALL="true" ;;
-        * )
-            error "invalid option $1"
-            usage 1 ;;
+        --clean-after-install )
+            shift
+            CLEANAFTERINSTALL="--clean-after-install" ;;
+        -a | --arch )
+            shift
+            ARCH=$1 ;;
+              riscv-tools | esp-tools)
+                  TOOLCHAIN=$1 ;;
+              ec2fast )
+                  EC2FASTINSTALL="true" ;;
+              * )
+                  error "invalid option $1"
+                  usage 1 ;;
     esac
     shift
 done
@@ -132,7 +136,7 @@ else
     esac
 
     module_prepare riscv-gnu-toolchain qemu
-    module_build riscv-gnu-toolchain --prefix="${RISCV}" --with-cmodel=medany ${ARCH:+--with-arch=${ARCH}}
+    module_build riscv-gnu-toolchain $CLEANAFTERINSTALL --prefix="${RISCV}" --with-cmodel=medany ${ARCH:+--with-arch=${ARCH}}
     echo '==>  Building GNU/Linux toolchain'
     module_make riscv-gnu-toolchain linux
 fi

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -39,7 +39,6 @@ EC2FASTINSTALL="false"
 IGNOREQEMU=""
 RISCV=""
 ARCH=""
-CLEANAFTERINSTALL=""
 
 # getopts does not support long options, and is inflexible
 while [ "$1" != "" ];
@@ -52,9 +51,6 @@ do
             RISCV=$(realpath $1) ;;
         --ignore-qemu )
             IGNOREQEMU="true" ;;
-        --clean-after-install )
-            shift
-            CLEANAFTERINSTALL="--clean-after-install" ;;
         -a | --arch )
             shift
             ARCH=$1 ;;
@@ -136,7 +132,7 @@ else
     esac
 
     module_prepare riscv-gnu-toolchain qemu
-    module_build riscv-gnu-toolchain $CLEANAFTERINSTALL --prefix="${RISCV}" --with-cmodel=medany ${ARCH:+--with-arch=${ARCH}}
+    module_build riscv-gnu-toolchain --prefix="${RISCV}" --with-cmodel=medany ${ARCH:+--with-arch=${ARCH}}
     echo '==>  Building GNU/Linux toolchain'
     module_make riscv-gnu-toolchain linux
 fi

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -18,11 +18,12 @@ usage() {
     echo "   ec2fast: if set, pulls in a pre-compiled RISC-V toolchain for an EC2 manager instance"
     echo ""
     echo "Options"
-    echo "   --prefix PREFIX : Install destination. If unset, defaults to $(pwd)/riscv-tools-install"
-    echo "                     or $(pwd)/esp-tools-install"
-    echo "   --ignore-qemu   : Ignore installing QEMU"
-    echo "   --arch -a       : Architecture (e.g., rv64gc)"
-    echo "   --help -h       : Display this message"
+    echo "   --prefix PREFIX       : Install destination. If unset, defaults to $(pwd)/riscv-tools-install"
+    echo "                           or $(pwd)/esp-tools-install"
+    echo "   --ignore-qemu         : Ignore installing QEMU"
+    echo "   --clean-after-install : Run make clean in calls to module_make and module_build"
+    echo "   --arch -a             : Architecture (e.g., rv64gc)"
+    echo "   --help -h             : Display this message"
     exit "$1"
 }
 
@@ -37,6 +38,7 @@ die() {
 TOOLCHAIN="riscv-tools"
 EC2FASTINSTALL="false"
 IGNOREQEMU=""
+CLEANAFTERINSTALL=""
 RISCV=""
 ARCH=""
 
@@ -54,6 +56,8 @@ do
         -a | --arch )
             shift
             ARCH=$1 ;;
+        --clean-after-install )
+            CLEANAFTERINSTALL="true" ;;
         riscv-tools | esp-tools)
             TOOLCHAIN=$1 ;;
         ec2fast )

--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -58,13 +58,13 @@ do
         -a | --arch )
             shift
             ARCH=$1 ;;
-              riscv-tools | esp-tools)
-                  TOOLCHAIN=$1 ;;
-              ec2fast )
-                  EC2FASTINSTALL="true" ;;
-              * )
-                  error "invalid option $1"
-                  usage 1 ;;
+        riscv-tools | esp-tools)
+            TOOLCHAIN=$1 ;;
+        ec2fast )
+            EC2FASTINSTALL="true" ;;
+        * )
+            error "invalid option $1"
+            usage 1 ;;
     esac
     shift
 done

--- a/scripts/build-util.sh
+++ b/scripts/build-util.sh
@@ -81,6 +81,7 @@ module_build() ( # <submodule> [configure-arg..]
         "${MAKE}"
         echo "==>  Installing ${name}"
         "${MAKE}" install
+        "${MAKE}" clean  # get rid of intermediate files
     } 2>&1 | tee build.log
 )
 

--- a/scripts/build-util.sh
+++ b/scripts/build-util.sh
@@ -51,10 +51,15 @@ module_make() ( # <submodule> <target..>
     "${MAKE}" "$@" | tee "build-${1:-make}.log"
 )
 
-module_build() ( # <submodule> [configure-arg..]
+module_build() ( # <submodule> [--clean-after-install] [configure-arg..]
     set -e -o pipefail
     name=$1
     shift
+    clean_after_install=false
+    if [ "$1" = "--clean-after-install" ] ; then
+      clean_after_install=true
+      shift
+    fi
 
     cd "${SRCDIR}/${name}"
 
@@ -81,7 +86,9 @@ module_build() ( # <submodule> [configure-arg..]
         "${MAKE}"
         echo "==>  Installing ${name}"
         "${MAKE}" install
-        "${MAKE}" clean  # get rid of intermediate files
+        if [ "$clean_after_install" = "true" ] ; then
+          "${MAKE}" clean  # get rid of intermediate files
+        fi
     } 2>&1 | tee build.log
 )
 

--- a/scripts/build-util.sh
+++ b/scripts/build-util.sh
@@ -49,17 +49,15 @@ module_make() ( # <submodule> <target..>
     cd "${SRCDIR}/${1}/build"
     shift
     "${MAKE}" "$@" | tee "build-${1:-make}.log"
+    if [ -n "$CLEANAFTERINSTALL" ] ; then
+      "${MAKE}" clean  # get rid of intermediate files
+    fi
 )
 
-module_build() ( # <submodule> [--clean-after-install] [configure-arg..]
+module_build() ( # <submodule> [configure-arg..]
     set -e -o pipefail
     name=$1
     shift
-    clean_after_install=false
-    if [ "$1" = "--clean-after-install" ] ; then
-      clean_after_install=true
-      shift
-    fi
 
     cd "${SRCDIR}/${name}"
 
@@ -86,7 +84,7 @@ module_build() ( # <submodule> [--clean-after-install] [configure-arg..]
         "${MAKE}"
         echo "==>  Installing ${name}"
         "${MAKE}" install
-        if [ "$clean_after_install" = "true" ] ; then
+        if [ -n "$CLEANAFTERINSTALL" ] ; then
           "${MAKE}" clean  # get rid of intermediate files
         fi
     } 2>&1 | tee build.log


### PR DESCRIPTION
Make install leaves many .o and other files laying around
Fixes problems with disk space on Github Actions runner

**Type of change**: other enhancement

**Impact**: other
Reduces used disk space after toolchain build

**Release Notes**
Intermediate .o and other files are removed after building toolchain components.
Reduces disk requirements
