### PR TITLE
Timing annotated targets for post-syn sim + docs

### DIFF
--- a/docs/VLSI/Advanced-Usage.rst
+++ b/docs/VLSI/Advanced-Usage.rst
@@ -49,6 +49,28 @@ Say you need to update some power straps settings in ``example.yml`` and want to
 
    make redo-par HAMMER_REDO_ARGS='-p example.yml --only_step power_straps'
 
-RTL and Gate-level Simulation
------------------------------
-With the Synopsys plugin, RTL and gate-level simulation is supported using VCS. While this example does not implement any simulation, refer to Hammer's documentation for how to set it up for your design.
+RTL/Gate-level Simulation, Power Estimation
+-------------------------------------------
+With the Synopsys plugin, RTL and gate-level simulation is supported using VCS at the chip-level. Also, post-par power estimation with Voltus in the Cadence plugin is also supported. While the provided example does not implement any simulation, some Make targets are provided in the ``vlsi/`` directory. Here is a brief description:
+
+* ``sim-rtl``: RTL-level simulation
+
+  * ``sim-rtl-debug``: Also write a VPD waveform
+
+* ``sim-syn``: Post-synthesis gate-level simulation
+
+  * ``sim-syn-debug``: Also write a VPD waveform
+  * ``sim-syn-timing-debug``: Timing-annotated with VPD waveform
+
+* ``sim-par``: Post-par gate-level simulation
+
+  * ``sim-par-debug``: Also write a VPD waveform
+  * ``sim-par-timing-debug``: Timing-annotated with VPD waveform
+
+* ``power-par``: Post-par power estimation
+
+  * Note: this will run ``sim-par`` first
+
+* ``redo-`` can be appended to all above targets to break dependency tracking, like described above.
+
+The simulation configuration (e.g. binaries) can be edited for your design. See the Makefile and refer to Hammer's documentation for how to set up simulation parameters for your design.

--- a/docs/VLSI/Tutorial.rst
+++ b/docs/VLSI/Tutorial.rst
@@ -50,11 +50,11 @@ Prerequisites
 -------------
 
 * Python 3.4+
-* numpy and gdspy packages
+* numpy and gdspy packages. gdspy must be version 1.4.
 * Genus, Innovus, and Calibre licenses
 * For ASAP7 specifically:
 
-  * Download the `ASAP7 PDK <http://asap.asu.edu/asap/>`__ tarball to a directory of choice but do not extract it. The tech plugin is configured to extract the PDK into a cache directory for you.
+  * Download the `ASAP7 PDK v1p5 <http://asap.asu.edu/asap/>`__ tarball to a directory of choice but do not extract it. The tech plugin is configured to extract the PDK into a cache directory for you.
   * If you have additional ASAP7 hard macros, their LEF & GDS need to be 4x upscaled @ 4000 DBU precision. They may live outside ``extra_libraries`` at your discretion.
   * Innovus version must be >= 15.2 or <= 18.1 (ISRs excluded).
 

--- a/vlsi/sim.mk
+++ b/vlsi/sim.mk
@@ -11,6 +11,8 @@ redo-sim-syn: override HAMMER_EXTRA_ARGS += -p $(SIM_CONF)
 redo-sim-syn: override HAMMER_SIM_RUN_DIR = sim-syn-rundir
 redo-sim-syn-debug: $(SIM_DEBUG_CONF) redo-sim-syn
 redo-sim-syn-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
+redo-sim-syn-timing-debug: $(SIM_TIMING_CONF) redo-sim-par-debug
+redo-sim-syn-timing-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_TIMING_CONF)
 
 redo-sim-par: $(SIM_CONF)
 redo-sim-par: override HAMMER_EXTRA_ARGS += -p $(SIM_CONF)
@@ -32,6 +34,8 @@ sim-syn: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_CONF)
 sim-syn: override HAMMER_SIM_RUN_DIR = sim-syn-rundir
 sim-syn-debug: $(SIM_DEBUG_CONF) sim-syn
 sim-syn-debug: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
+sim-syn-timing-debug: $(SIM_TIMING_CONF) sim-syn-debug
+sim-syn-timing-debug: override HAMMER_SIM_EXTRA_ARGS += -p $(SIM_TIMING_CONF)
 $(OBJ_DIR)/sim-syn-rundir/sim-output-full.json: private override HAMMER_EXTRA_ARGS += $(HAMMER_SIM_EXTRA_ARGS)
 
 sim-par: $(SIM_CONF)

--- a/vlsi/sim.mk
+++ b/vlsi/sim.mk
@@ -11,7 +11,7 @@ redo-sim-syn: override HAMMER_EXTRA_ARGS += -p $(SIM_CONF)
 redo-sim-syn: override HAMMER_SIM_RUN_DIR = sim-syn-rundir
 redo-sim-syn-debug: $(SIM_DEBUG_CONF) redo-sim-syn
 redo-sim-syn-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_DEBUG_CONF)
-redo-sim-syn-timing-debug: $(SIM_TIMING_CONF) redo-sim-par-debug
+redo-sim-syn-timing-debug: $(SIM_TIMING_CONF) redo-sim-syn-debug
 redo-sim-syn-timing-debug: override HAMMER_EXTRA_ARGS += -p $(SIM_TIMING_CONF)
 
 redo-sim-par: $(SIM_CONF)


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->
Timing-annotated post-synthesis simulation targets were not configured and documentation for how to use all the sim/power targets was missing. Small clarification to ASAP7 PDK & compatible tool versions.

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
Added post-synthesis timing-annotated sim targets
