### PR TITLE
Remove deprecatation.

### DIFF
--- a/generators/chipyard/src/main/scala/IOBinders.scala
+++ b/generators/chipyard/src/main/scala/IOBinders.scala
@@ -231,7 +231,7 @@ class WithDebugIOCells extends OverrideLazyIOBinder({
           d.disableDebug.foreach { d => d := false.B }
           // Drive JTAG on-chip IOs
           d.systemjtag.map { j =>
-            j.reset := ResetCatchAndSync(j.jtag.TCK, clockBundle.reset.toBool)
+            j.reset := ResetCatchAndSync(j.jtag.TCK, clockBundle.reset.asBool)
             j.mfr_id := p(JtagDTMKey).idcodeManufId.U(11.W)
             j.part_number := p(JtagDTMKey).idcodePartNum.U(16.W)
             j.version := p(JtagDTMKey).idcodeVersion.U(4.W)


### PR DESCRIPTION
Chisel 3.5 won't have toBool anymore.

**Related issue**: <!-- if applicable -->
chipsalliance/chisel3#1730

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: software change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->