### PR TITLE
Bump installed versions of python to 3.8

### DIFF
--- a/scripts/centos-req.sh
+++ b/scripts/centos-req.sh
@@ -8,11 +8,11 @@ curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm
 sudo yum install -y sbt texinfo gengetopt
 sudo yum install -y expat-devel libusb1-devel ncurses-devel cmake "perl(ExtUtils::MakeMaker)"
 # deps for poky
-sudo yum install -y python36 patch diffstat texi2html texinfo subversion chrpath git wget
+sudo yum install -y python38 patch diffstat texi2html texinfo subversion chrpath git wget
 # deps for qemu
 sudo yum install -y gtk3-devel
 # deps for firemarshal
-sudo yum install -y python36-pip python36-devel rsync libguestfs-tools makeinfo expat ctags
+sudo yum install -y python38-pip python38-devel rsync libguestfs-tools makeinfo expat ctags
 # Install GNU make 4.x (needed to cross-compile glibc 2.28+)
 sudo yum install -y centos-release-scl
 sudo yum install -y devtoolset-8-make

--- a/scripts/ubuntu-req.sh
+++ b/scripts/ubuntu-req.sh
@@ -12,11 +12,11 @@ sudo apt-get install -y sbt
 sudo apt-get install -y texinfo gengetopt
 sudo apt-get install -y libexpat1-dev libusb-dev libncurses5-dev cmake
 # deps for poky
-sudo apt-get install -y python3.6 patch diffstat texi2html texinfo subversion chrpath git wget
+sudo apt-get install -y python3.8 patch diffstat texi2html texinfo subversion chrpath git wget
 # deps for qemu
 sudo apt-get install -y libgtk-3-dev gettext
 # deps for firemarshal
-sudo apt-get install -y python3-pip python3.6-dev rsync libguestfs-tools expat ctags
+sudo apt-get install -y python3-pip python3.8-dev rsync libguestfs-tools expat ctags
 # install DTC
 sudo apt-get install -y device-tree-compiler
 


### PR DESCRIPTION
Ubuntu 20.04 LTS (the most recent LTS release) stopped shipping Python 3.6 in their default repositories.

Upping it to Python 3.8 does not seem to have broken the
design/elaboration process. I tested re-building Chipyard and the default Rocket design, and everything appears to have remained the same.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: version bump

<!-- choose one -->
**Impact**: software change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
