### PR TITLE
Support firesim distributed elaboration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bootrom/*
 docs/warnings.txt
 /Makefrag.pkgs
 target

--- a/build.sbt
+++ b/build.sbt
@@ -4,14 +4,73 @@ import Tests._
 // implicit one
 lazy val chipyardRoot = Project("chipyardRoot", file("."))
 
+def filenames(tempDir: File, fs: Seq[File]): Seq[String] =
+for(f <- fs) yield {
+  sbtassembly.AssemblyUtils.sourceOfFileForMerge(tempDir, f) match {
+    case (path, base, subDirPath, false) => subDirPath
+    case (jar, base, subJarPath, true) => jar + ":" + subJarPath
+  }
+}
+
+// custom sbtassemblly.MergeStrategy
+// removes merge candidates that have 'rocketchip' in the name of their JAR
+// hopefully leaving only a single candidate to be chosen as the member of 
+// our assembly JAR.  If there's still multiple candidates, error.
+val notRocketMergeStrategy = new sbtassembly.MergeStrategy {
+  val name = "notRocket"
+  def apply(tempDir: File, path: String, files: Seq[File]) = {
+    val filtered = files collect { f =>
+      sbtassembly.AssemblyUtils.sourceOfFileForMerge(tempDir, f) match {
+        case (jar, _, _, true) if !jar.toString.contains("rocketchip") => f
+      }
+    }
+    if (filtered.size == 1) Right(Seq(filtered.head -> path))
+    else Left("still have multiple files after removing rocketchip for same target path:" +
+      filenames(tempDir, filtered).mkString("\n", "\n", "")
+      )
+  }
+}
+
+// custom sbtassemblly.MergeStrategy
+// keeps merge candidates that have 'rocketchip' in the name of their JAR
+// hopefully leaving only a single candidate to be chosen as the member of 
+// our assembly JAR.  If there's still multiple candidates, error.
+val useRocketMergeStrategy = new sbtassembly.MergeStrategy {
+  val name = "useRocket"
+  def apply(tempDir: File, path: String, files: Seq[File]) = {
+    val filtered = files collect { f =>
+      sbtassembly.AssemblyUtils.sourceOfFileForMerge(tempDir, f) match {
+        case (jar, _, _, true) if jar.toString.contains("rocketchip") => f
+      }
+    }
+    if (filtered.size == 1) Right(Seq(filtered.head -> path))
+    else Left("multiple candidates have rocketchip in their jar name for target:" +
+      filenames(tempDir, filtered).mkString("\n", "\n", "")
+      )
+  }
+}
+
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
   version := "1.3",
   scalaVersion := "2.12.10",
   test in assembly := {},
-  assemblyMergeStrategy in assembly := { _ match {
-    case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
-    case _ => MergeStrategy.first}},
+  assemblyMergeStrategy in assembly := {
+    case PathList("META-INF", "services", xs @ _*) => MergeStrategy.concat
+    // Discard Metadata, it's irrelevant
+    case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+    // When any of our dependencies are different versions than those of firrtl.jar, there will be conflicts
+    // When this occurs, pick last one which is stuff in .ivy2 (ie. not firrtl.jar)
+    case PathList(xs @ _*) if xs.last.endsWith(".class") || xs.last.endsWith(".properties") => MergeStrategy.last
+    // Just take the last matching joda/time/tz/data resource files
+    case PathList("org", "joda", "time", "tz", "data", xs @ _*) => MergeStrategy.last
+    // Use the file that doesn't come from rocketchip because we've overridden it
+    case PathList(xs @ _*) if xs.last.equals("emulator.cc") => notRocketMergeStrategy
+    case PathList("vsrc", "SimDTM.v") => useRocketMergeStrategy
+    case x =>
+      val oldStrategy = (assemblyMergeStrategy in assembly).value
+      oldStrategy(x)
+  },
   scalacOptions ++= Seq("-deprecation","-unchecked","-Xsource:2.11"),
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
   unmanagedBase := (chipyardRoot / unmanagedBase).value,

--- a/common.mk
+++ b/common.mk
@@ -60,7 +60,7 @@ include $(base_dir)/tools/dromajo/dromajo.mk
 #########################################################################################
 # Returns a list of files in directory $1 with file extension $2.
 # If available, use 'fd' to find the list of files, which is faster than 'find'.
-ifeq ($(shell which fd),)
+ifeq ($(shell which fd 2>/dev/null),)
 	lookup_srcs = $(shell find -L $(1)/ -name target -prune -o -iname "*.$(2)" -print 2> /dev/null)
 else
 	lookup_srcs = $(shell fd -L ".*\.$(2)" $(1))

--- a/common.mk
+++ b/common.mk
@@ -6,7 +6,7 @@ SHELL=/bin/bash
 ifndef RISCV
 $(error RISCV is unset. You must set RISCV yourself, or through the Chipyard auto-generated env file)
 else
-$(info Running with RISCV=$(RISCV))
+$(info #Running with RISCV=$(RISCV))
 endif
 
 #########################################################################################

--- a/generators/chipyard/src/main/scala/ConfigFragments.scala
+++ b/generators/chipyard/src/main/scala/ConfigFragments.scala
@@ -15,6 +15,7 @@ import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams
 import freechips.rocketchip.tilelink.{HasTLBusParams}
 import freechips.rocketchip.util.{AsyncResetReg, Symmetric}
 import freechips.rocketchip.prci._
+import freechips.rocketchip.stage.phases.TargetDirKey
 
 import testchipip._
 import tracegen.{TraceGenSystem}
@@ -36,7 +37,7 @@ import chipyard._
 // -----------------------
 
 class WithBootROM extends Config((site, here, up) => {
-  case BootROMLocated(x) => up(BootROMLocated(x), site).map(_.copy(contentFileName = s"./bootrom/bootrom.rv${site(XLen)}.img"))
+  case BootROMLocated(x) => up(BootROMLocated(x), site).map(_.copy(contentFileName = s"${site(TargetDirKey)}/bootrom.rv${site(XLen)}.img"))
 })
 
 // DOC include start: gpio config fragment

--- a/generators/chipyard/src/main/scala/stage/ChipyardAnnotations.scala
+++ b/generators/chipyard/src/main/scala/stage/ChipyardAnnotations.scala
@@ -13,7 +13,7 @@ private[stage] object UnderscoreDelimitedConfigsAnnotation extends HasShellOptio
       longOption = "legacy-configs",
       toAnnotationSeq = a => {
         val split = a.split(':')
-        assert(split.length == 2)
+        assert(split.length == 2, s"'${a}' split by ':' doesn't yield two things")
         val packageName = split.head
         val configs     = split.last.split("_")
         Seq(new ConfigsAnnotation(configs map { config => if (config contains ".") s"${config}" else s"${packageName}.${config}" } ))

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -4,6 +4,7 @@ import java.io.File
 
 import chisel3._
 import chisel3.util.{log2Up}
+import chipyard.config.WithBootROM
 import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.groundtest.TraceGenParams
 import freechips.rocketchip.tile._
@@ -23,19 +24,6 @@ import testchipip.WithRingSystemBus
 import firesim.bridges._
 import firesim.configs._
 
-class WithBootROM extends Config((site, here, up) => {
-  case BootROMLocated(x) => {
-    val chipyardBootROM = new File(s"./generators/testchipip/bootrom/bootrom.rv${site(XLen)}.img")
-    val firesimBootROM = new File(s"./target-rtl/chipyard/generators/testchipip/bootrom/bootrom.rv${site(XLen)}.img")
-
-    val bootROMPath = if (chipyardBootROM.exists()) {
-      chipyardBootROM.getAbsolutePath()
-    } else {
-      firesimBootROM.getAbsolutePath()
-    }
-    up(BootROMLocated(x), site).map(_.copy(contentFileName = bootROMPath))
-  }
-})
 
 // Disables clock-gating; doesn't play nice with our FAME-1 pass
 class WithoutClockGating extends Config((site, here, up) => {
@@ -65,8 +53,6 @@ class WithFireSimDesignTweaks extends Config(
   new WithDefaultMemModel ++
   // Required*: Uses FireSim ClockBridge and PeekPokeBridge to drive the system with a single clock/reset
   new WithFireSimSimpleClocks ++
-  // Required*: When using FireSim-as-top to provide a correct path to the target bootrom source
-  new WithBootROM ++
   // Required: Existing FAME-1 transform cannot handle black-box clock gates
   new WithoutClockGating ++
   // Required*: Removes thousands of assertions that would be synthesized (* pending PriorityMux bugfix)

--- a/generators/utilities/src/main/scala/Simulator.scala
+++ b/generators/utilities/src/main/scala/Simulator.scala
@@ -122,15 +122,15 @@ object GenerateSimFiles extends App with HasGenerateSimConfig {
       case None => Seq()
     })
 
-  def writeBootrom(): Unit = {
-    firrtl.FileUtils.makeDirectory("./bootrom/")
-    writeResource("/testchipip/bootrom/bootrom.rv64.img", "./bootrom/")
-    writeResource("/testchipip/bootrom/bootrom.rv32.img", "./bootrom/")
-    writeResource("/bootrom/bootrom.img", "./bootrom/")
+  def writeBootrom(cfg: GenerateSimConfig): Unit = {
+    firrtl.FileUtils.makeDirectory(cfg.targetDir)
+    writeResource("/testchipip/bootrom/bootrom.rv64.img", cfg.targetDir)
+    writeResource("/testchipip/bootrom/bootrom.rv32.img", cfg.targetDir)
+    writeResource("/bootrom/bootrom.img", cfg.targetDir)
   }
 
   def writeFiles(cfg: GenerateSimConfig): Unit = {
-    writeBootrom()
+    writeBootrom(cfg)
     firrtl.FileUtils.makeDirectory(cfg.targetDir)
     val files = resources(cfg.simulator).map { writeResource(_, cfg.targetDir) }
     writeDotF(files.map(addOption(_, cfg)), cfg)

--- a/variables.mk
+++ b/variables.mk
@@ -170,6 +170,7 @@ SBT_NON_THIN ?= $(subst $(SBT_CLIENT_FLAG),,$(SBT))
 define run_scala_main
 	cd $(base_dir) && $(SBT) ";project $(1); runMain $(2) $(3)"
 endef
+run_main = cd $(base_dir) && java $(JAVA_ARGS) -cp $(FAT_JAR) $(2) $(3)
 
 FIRRTL_LOGLEVEL ?= error
 

--- a/variables.mk
+++ b/variables.mk
@@ -170,7 +170,6 @@ SBT_NON_THIN ?= $(subst $(SBT_CLIENT_FLAG),,$(SBT))
 define run_scala_main
 	cd $(base_dir) && $(SBT) ";project $(1); runMain $(2) $(3)"
 endef
-run_main = cd $(base_dir) && java $(JAVA_ARGS) -cp $(FAT_JAR) $(2) $(3)
 
 FIRRTL_LOGLEVEL ?= error
 


### PR DESCRIPTION
**Related issue**: firesim/firesim#646
This is #716 re-incarnated using a local branch so that the CI will run (and rebased several months forward).

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: rtl change & infrastructure change
Do you guys consider changes to the makefiles as 'software' change or is that target software?
RTL change removes the FireSim/firechip duplication of `WithBootROM` and instead 

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
* Updates sbt-assembly config so that assembly is able to merge everything into a fat jar once again.
* Adds a message to assertion in `chipyard.Generator` `--legacy-config` parser.  Error without message was confusing.
* Squelch message about not finding `fd`,  if it isn't found, makefiles fall back to `find`.
* Adjust makefiles to support elaborating with assembly JAR and FireSim's new `gen-replace-rtl-script` target