### PR TITLE
test whether git.qemu.org rewrite still needed

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -165,6 +165,15 @@ if [ -z "$IGNOREQEMU" ] ; then
     # in the local config so that any further commands by the user have the rewrite. uggh. git, why you so ugly?
     git -C "$dir" config --local url.https://github.com/qemu.insteadOf https://git.qemu.org/git
     git -C "$dir" submodule foreach --recursive 'git config --local url.https://github.com/qemu.insteadOf https://git.qemu.org/git'
+
+    # check to see whether the rewrite rules are needed any more
+    # If you find git.qemu.org in any .gitmodules file below qemu, you still need them
+    # the /dev/null redirection in the submodule grepping is to quiet non-existance of further .gitmodules
+    ! grep -q 'git\.qemu\.org' "$dir/.gitmodules" && \
+    git -C "$dir" submodule foreach --quiet --recursive '! grep -q "git\.qemu\.org" .gitmodules 2>/dev/null' && \
+    echo "==>  PLEASE REMOVE qemu URL-REWRITING from scripts/build-toolchains.sh. It is no longer needed!" && exit 1
+
+    # now actually do the build
     SRCDIR="$(pwd)/toolchains" module_build qemu --prefix="${RISCV}" --target-list=riscv${XLEN}-softmmu
 fi
 


### PR DESCRIPTION

**Related issue**: #876 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**

In https://github.com/ucb-bar/chipyard/pull/876#issuecomment-831639151
it was requested that we add a note to build-toolchains.sh saying that the
url rewrites can be removed.  I went a step further and made it self-checking.

Once qemu is bumped far enough that none of it's submodules come from
git.qemu.org, then the test added in this commit will fail CI during the bump PR
and everyone will be reminded to remove the url renaming rules and change
module_build back to module_all for qemu.

