### PR TITLE
.sbtopts file added + Check for `BINARY/THIN_CLIENT` flags

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,2 @@
+-Dsbt.sourcemode=true
+-Dsbt.workspace=$PWD/tools

--- a/common.mk
+++ b/common.mk
@@ -247,12 +247,17 @@ SBT_COMMAND ?= shell
 launch-sbt:
 	cd $(base_dir) && $(SBT_NON_THIN) "$(SBT_COMMAND)"
 
+check-thin-client:
+ifeq (,$(ENABLE_SBT_THIN_CLIENT))
+	$(error ENABLE_SBT_THIN_CLIENT not set.)
+endif
+
 .PHONY: shutdown-sbt-server
-shutdown-sbt-server:
+shutdown-sbt-server: check-thin-client
 	cd $(base_dir) && $(SBT) "shutdown"
 
 .PHONY: start-sbt-server
-start-sbt-server:
+start-sbt-server: check-thin-client
 	cd $(base_dir) && $(SBT) "exit"
 
 #########################################################################################

--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,7 @@ HELP_COMPILATION_VARIABLES += \
 "   EXTRA_SIM_LDFLAGS      = additional LDFLAGS for building simulators" \
 "   EXTRA_SIM_SOURCES      = additional simulation sources needed for simulator" \
 "   EXTRA_SIM_REQS         = additional make requirements to build the simulator" \
-"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client"
+"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client (works best with sbtn or sbt script)"
 
 EXTRA_GENERATOR_REQS ?=
 EXTRA_SIM_CXXFLAGS   ?=

--- a/common.mk
+++ b/common.mk
@@ -162,16 +162,21 @@ verilog: $(sim_vsrcs)
 #########################################################################################
 .PHONY: run-binary run-binary-fast run-binary-debug run-fast
 
+check-binary:
+ifndef BINARY
+	$(error BINARY variable is not set. Set it to the simulation binary)
+endif
+
 # run normal binary with hardware-logged insn dissassembly
-run-binary: $(output_dir) $(sim)
+run-binary: $(output_dir) $(sim) $(check-binary)
 	(set -o pipefail && $(NUMA_PREFIX) $(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(SEED_FLAG) $(VERBOSE_FLAGS) $(PERMISSIVE_OFF) $(BINARY) </dev/null 2> >(spike-dasm > $(sim_out_name).out) | tee $(sim_out_name).log)
 
 # run simulator as fast as possible (no insn disassembly)
-run-binary-fast: $(output_dir) $(sim)
+run-binary-fast: $(output_dir) $(sim) $(check-binary)
 	(set -o pipefail && $(NUMA_PREFIX) $(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(SEED_FLAG) $(PERMISSIVE_OFF) $(BINARY) </dev/null | tee $(sim_out_name).log)
 
 # run simulator with as much debug info as possible
-run-binary-debug: $(output_dir) $(sim_debug)
+run-binary-debug: $(output_dir) $(sim_debug) $(check-binary)
 	(set -o pipefail && $(NUMA_PREFIX) $(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(SEED_FLAG) $(VERBOSE_FLAGS) $(WAVEFORM_FLAG) $(PERMISSIVE_OFF) $(BINARY) </dev/null 2> >(spike-dasm > $(sim_out_name).out) | tee $(sim_out_name).log)
 
 run-fast: run-asm-tests-fast run-bmark-tests-fast
@@ -182,16 +187,19 @@ run-fast: run-asm-tests-fast run-bmark-tests-fast
 $(binary_hex): $(output_dir) $(BINARY)
 	$(base_dir)/scripts/smartelf2hex.sh $(BINARY) > $(binary_hex)
 
+run-binary-hex: $(check-binary)
 run-binary-hex: $(output_dir) $(sim) $(binary_hex)
 run-binary-hex: run-binary
 run-binary-hex: override LOADMEM_ADDR = 80000000
 run-binary-hex: override LOADMEM = $(binary_hex)
 run-binary-hex: override SIM_FLAGS += +loadmem=$(LOADMEM) +loadmem_addr=$(LOADMEM_ADDR)
+run-binary-debug-hex: $(check-binary)
 run-binary-debug-hex: $(output_dir) $(sim) $(binary_hex)
 run-binary-debug-hex: run-binary-debug
 run-binary-debug-hex: override LOADMEM_ADDR = 80000000
 run-binary-debug-hex: override LOADMEM = $(binary_hex)
 run-binary-debug-hex: override SIM_FLAGS += +loadmem=$(LOADMEM) +loadmem_addr=$(LOADMEM_ADDR)
+run-binary-fast-hex: $(check-binary)
 run-binary-fast-hex: $(output_dir) $(sim) $(binary_hex)
 run-binary-fast-hex: run-binary-fast
 run-binary-fast-hex: override LOADMEM_ADDR = 80000000

--- a/common.mk
+++ b/common.mk
@@ -163,20 +163,20 @@ verilog: $(sim_vsrcs)
 .PHONY: run-binary run-binary-fast run-binary-debug run-fast
 
 check-binary:
-ifndef BINARY
+ifeq (,$(BINARY))
 	$(error BINARY variable is not set. Set it to the simulation binary)
 endif
 
 # run normal binary with hardware-logged insn dissassembly
-run-binary: $(output_dir) $(sim) $(check-binary)
+run-binary: $(output_dir) $(sim) check-binary
 	(set -o pipefail && $(NUMA_PREFIX) $(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(SEED_FLAG) $(VERBOSE_FLAGS) $(PERMISSIVE_OFF) $(BINARY) </dev/null 2> >(spike-dasm > $(sim_out_name).out) | tee $(sim_out_name).log)
 
 # run simulator as fast as possible (no insn disassembly)
-run-binary-fast: $(output_dir) $(sim) $(check-binary)
+run-binary-fast: $(output_dir) $(sim) check-binary
 	(set -o pipefail && $(NUMA_PREFIX) $(sim) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(SEED_FLAG) $(PERMISSIVE_OFF) $(BINARY) </dev/null | tee $(sim_out_name).log)
 
 # run simulator with as much debug info as possible
-run-binary-debug: $(output_dir) $(sim_debug) $(check-binary)
+run-binary-debug: $(output_dir) $(sim_debug) check-binary
 	(set -o pipefail && $(NUMA_PREFIX) $(sim_debug) $(PERMISSIVE_ON) $(SIM_FLAGS) $(EXTRA_SIM_FLAGS) $(SEED_FLAG) $(VERBOSE_FLAGS) $(WAVEFORM_FLAG) $(PERMISSIVE_OFF) $(BINARY) </dev/null 2> >(spike-dasm > $(sim_out_name).out) | tee $(sim_out_name).log)
 
 run-fast: run-asm-tests-fast run-bmark-tests-fast
@@ -187,19 +187,19 @@ run-fast: run-asm-tests-fast run-bmark-tests-fast
 $(binary_hex): $(output_dir) $(BINARY)
 	$(base_dir)/scripts/smartelf2hex.sh $(BINARY) > $(binary_hex)
 
-run-binary-hex: $(check-binary)
+run-binary-hex: check-binary
 run-binary-hex: $(output_dir) $(sim) $(binary_hex)
 run-binary-hex: run-binary
 run-binary-hex: override LOADMEM_ADDR = 80000000
 run-binary-hex: override LOADMEM = $(binary_hex)
 run-binary-hex: override SIM_FLAGS += +loadmem=$(LOADMEM) +loadmem_addr=$(LOADMEM_ADDR)
-run-binary-debug-hex: $(check-binary)
+run-binary-debug-hex: check-binary
 run-binary-debug-hex: $(output_dir) $(sim) $(binary_hex)
 run-binary-debug-hex: run-binary-debug
 run-binary-debug-hex: override LOADMEM_ADDR = 80000000
 run-binary-debug-hex: override LOADMEM = $(binary_hex)
 run-binary-debug-hex: override SIM_FLAGS += +loadmem=$(LOADMEM) +loadmem_addr=$(LOADMEM_ADDR)
-run-binary-fast-hex: $(check-binary)
+run-binary-fast-hex: check-binary
 run-binary-fast-hex: $(output_dir) $(sim) $(binary_hex)
 run-binary-fast-hex: run-binary-fast
 run-binary-fast-hex: override LOADMEM_ADDR = 80000000

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.4.9

--- a/variables.mk
+++ b/variables.mk
@@ -152,7 +152,10 @@ JAVA_OPTS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -XX:MaxPermSize=256M -Djava.io.tmpdir=
 # default sbt launch command
 #########################################################################################
 # by default build chisel3/firrtl and other subprojects from source
-override SBT_OPTS += -Dsbt.sourcemode=true -Dsbt.workspace=$(base_dir)/tools
+SBT_OPTS_FILE := $(base_dir)/.sbtopts
+ifneq (,$(wildcard $(SBT_OPTS_FILE)))
+override SBT_OPTS += $(subst $$PWD,$(base_dir),$(shell cat $(SBT_OPTS_FILE)))
+endif
 
 SCALA_BUILDTOOL_DEPS = $(SBT_SOURCES)
 

--- a/variables.mk
+++ b/variables.mk
@@ -164,6 +164,7 @@ SBT_THIN_CLIENT_TIMESTAMP = $(base_dir)/project/target/active.json
 ifdef ENABLE_SBT_THIN_CLIENT
 override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
 # enabling speeds up sbt loading
+# use with sbt script or sbtn to bypass error code issues
 SBT_CLIENT_FLAG = --client
 endif
 


### PR DESCRIPTION
**Related issue**: #833 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
It seems like using the `.sbtopts` file helps with the thin SBT client (sets up the Chisel/Firrtl path properly). This PR changes Chipyard to be more similar to Rocket Chip and hopefully fixes #833 (or some subset of its problems). Additionally, this adds small check to make sure the `BINARY` flag is present when doing `run-*` targets. 
