### PR TITLE
Add default support for I2C and PWM IOs.

### DIFF
--- a/generators/chipyard/src/main/scala/DigitalTop.scala
+++ b/generators/chipyard/src/main/scala/DigitalTop.scala
@@ -19,6 +19,8 @@ class DigitalTop(implicit p: Parameters) extends ChipyardSystem
   with testchipip.CanHaveBackingScratchpad // Enables optionally adding a backing scratchpad
   with testchipip.CanHavePeripheryBlockDevice // Enables optionally adding the block device
   with testchipip.CanHavePeripheryTLSerial // Enables optionally adding the backing memory and serial adapter
+  with sifive.blocks.devices.i2c.HasPeripheryI2C // Enables optionally adding the sifive I2C
+  with sifive.blocks.devices.pwm.HasPeripheryPWM // Enables optionally adding the sifive PWM
   with sifive.blocks.devices.uart.HasPeripheryUART // Enables optionally adding the sifive UART
   with sifive.blocks.devices.gpio.HasPeripheryGPIO // Enables optionally adding the sifive GPIOs
   with sifive.blocks.devices.spi.HasPeripherySPIFlash // Enables optionally adding the sifive SPI flash controller
@@ -35,6 +37,8 @@ class DigitalTop(implicit p: Parameters) extends ChipyardSystem
 
 class DigitalTopModule[+L <: DigitalTop](l: L) extends ChipyardSystemModule(l)
   with testchipip.CanHaveTraceIOModuleImp
+  with sifive.blocks.devices.i2c.HasPeripheryI2CModuleImp
+  with sifive.blocks.devices.pwm.HasPeripheryPWMModuleImp
   with sifive.blocks.devices.uart.HasPeripheryUARTModuleImp
   with sifive.blocks.devices.gpio.HasPeripheryGPIOModuleImp
   with sifive.blocks.devices.spi.HasPeripherySPIFlashModuleImp


### PR DESCRIPTION
Default generator now supports I2C and PWM periphery blocks.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
