### PR TITLE
Bump cva6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 parameters:
     tools-cache-version:
         type: string
-        default: "v11"
+        default: "v12"
 
 # default execution env.s
 executors:


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: software change

**Release Notes**
Update CVA6 submodule to 6000e32. 
Add support for PMP and updated makefile to include new/renamed includes and vsrcs.
Pull request within wrapper: https://github.com/ucb-bar/cva6-wrapper/pull/12
With these changes, the CVA6 core is now able to boot Linux from FireSim (single node, no network simulation). See attached screenshot.
![image](https://user-images.githubusercontent.com/53250063/123533191-2fe0d880-d6c8-11eb-9474-110631907b60.png)

<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
