### PR TITLE
Add options for command-line arguments for Chisel and FIRRTL compilers

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -128,7 +128,24 @@ $(TOP_TARGETS) $(HARNESS_TARGETS): firrtl_temp
 	@echo "" > /dev/null
 
 firrtl_temp: $(FIRRTL_FILE) $(ANNO_FILE) $(VLOG_SOURCES)
-	$(call run_scala_main,tapeout,barstools.tapeout.transforms.GenerateTopAndHarness,-o $(TOP_FILE) -tho $(HARNESS_FILE) -i $(FIRRTL_FILE) --syn-top $(TOP) --harness-top $(VLOG_MODEL) -faf $(ANNO_FILE) -tsaof $(TOP_ANNO) -tdf $(sim_top_blackboxes) -tsf $(TOP_FIR) -thaof $(HARNESS_ANNO) -hdf $(sim_harness_blackboxes) -thf $(HARNESS_FIR) $(REPL_SEQ_MEM) $(HARNESS_CONF_FLAGS) -td $(build_dir) -ll $(FIRRTL_LOGLEVEL)) && touch $(sim_top_blackboxes) $(sim_harness_blackboxes)
+	$(call run_scala_main,tapeout,barstools.tapeout.transforms.GenerateTopAndHarness,\
+		-o $(TOP_FILE) \
+		-tho $(HARNESS_FILE) \
+		-i $(FIRRTL_FILE) \
+		--syn-top $(TOP) \
+		--harness-top $(VLOG_MODEL) \
+		-faf $(ANNO_FILE) \
+		-tsaof $(TOP_ANNO) \
+		-tdf $(sim_top_blackboxes) \
+		-tsf $(TOP_FIR) \
+		-thaof $(HARNESS_ANNO) \
+		-hdf $(sim_harness_blackboxes) \
+		-thf $(HARNESS_FIR) \
+		$(REPL_SEQ_MEM) \
+		$(HARNESS_CONF_FLAGS) \
+		-td $(build_dir) \
+		-ll $(FIRRTL_LOGLEVEL))
+	touch $(sim_top_blackboxes) $(sim_harness_blackboxes)
 # DOC include end: FirrtlCompiler
 
 # This file is for simulation only. VLSI flows should replace this file with one containing hard SRAMs

--- a/common.mk
+++ b/common.mk
@@ -129,22 +129,22 @@ $(TOP_TARGETS) $(HARNESS_TARGETS): firrtl_temp
 
 firrtl_temp: $(FIRRTL_FILE) $(ANNO_FILE) $(VLOG_SOURCES)
 	$(call run_scala_main,tapeout,barstools.tapeout.transforms.GenerateTopAndHarness,\
-		-o $(TOP_FILE) \
-		-tho $(HARNESS_FILE) \
-		-i $(FIRRTL_FILE) \
+		--output-file $(TOP_FILE) \
+		--harness-o $(HARNESS_FILE) \
+		--input-file $(FIRRTL_FILE) \
 		--syn-top $(TOP) \
 		--harness-top $(VLOG_MODEL) \
-		-faf $(ANNO_FILE) \
-		-tsaof $(TOP_ANNO) \
-		-tdf $(sim_top_blackboxes) \
-		-tsf $(TOP_FIR) \
-		-thaof $(HARNESS_ANNO) \
-		-hdf $(sim_harness_blackboxes) \
-		-thf $(HARNESS_FIR) \
+		--annotation-file $(ANNO_FILE) \
+		--top-anno-out $(TOP_ANNO) \
+		--top-dotf-out $(sim_top_blackboxes) \
+		--top-fir $(TOP_FIR) \
+		--harness-anno-out $(HARNESS_ANNO) \
+		--harness-dotf-out $(sim_harness_blackboxes) \
+		--harness-fir $(HARNESS_FIR) \
 		$(REPL_SEQ_MEM) \
 		$(HARNESS_CONF_FLAGS) \
-		-td $(build_dir) \
-		-ll $(FIRRTL_LOGLEVEL))
+		--target-dir $(build_dir) \
+		--log-level $(FIRRTL_LOGLEVEL))
 	touch $(sim_top_blackboxes) $(sim_harness_blackboxes)
 # DOC include end: FirrtlCompiler
 

--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,9 @@ HELP_COMPILATION_VARIABLES += \
 "   EXTRA_SIM_LDFLAGS      = additional LDFLAGS for building simulators" \
 "   EXTRA_SIM_SOURCES      = additional simulation sources needed for simulator" \
 "   EXTRA_SIM_REQS         = additional make requirements to build the simulator" \
-"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client (works best with sbtn or sbt script)"
+"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client (works best with sbtn or sbt script)" \
+"   EXTRA_CHISEL_OPTIONS   = additional options to pass to the Chisel compiler" \
+"   EXTRA_FIRRTL_OPTIONS   = additional options to pass to the FIRRTL compiler"
 
 EXTRA_GENERATOR_REQS ?= $(BOOTROM_TARGETS)
 EXTRA_SIM_CXXFLAGS   ?=
@@ -107,7 +109,8 @@ generator_temp: $(SCALA_SOURCES) $(sim_files) $(EXTRA_GENERATOR_REQS)
 		--target-dir $(build_dir) \
 		--name $(long_name) \
 		--top-module $(MODEL_PACKAGE).$(MODEL) \
-		--legacy-configs $(CONFIG_PACKAGE):$(CONFIG))
+		--legacy-configs $(CONFIG_PACKAGE):$(CONFIG) \
+		$(EXTRA_CHISEL_OPTIONS))
 
 .PHONY: firrtl
 firrtl: $(FIRRTL_FILE)
@@ -144,7 +147,8 @@ firrtl_temp: $(FIRRTL_FILE) $(ANNO_FILE) $(VLOG_SOURCES)
 		$(REPL_SEQ_MEM) \
 		$(HARNESS_CONF_FLAGS) \
 		--target-dir $(build_dir) \
-		--log-level $(FIRRTL_LOGLEVEL))
+		--log-level $(FIRRTL_LOGLEVEL) \
+		$(EXTRA_FIRRTL_OPTIONS))
 	touch $(sim_top_blackboxes) $(sim_harness_blackboxes)
 # DOC include end: FirrtlCompiler
 


### PR DESCRIPTION
**Related issue**: N/A

<!-- choose one -->
**Type of change**: new feature

I wanted to make use of the Rocket Chip lint framework (https://github.com/chipsalliance/rocket-chip/pull/2435), and this lets users do that by setting `EXTRA_CHISEL_OPTIONS`. Here's an example of invoking the Rocket Chip lint framework:

```
$ EXTRA_CHISEL_OPTIONS="--lint * --lint-options display:*=5" make -C sims/vcs CONFIG=RocketConfig
...
[info] running chipyard.Generator
...
[info] running barstools.tapeout.transforms.GenerateTopAndHarness ...
...
[error] (run-main-0) freechips.rocketchip.linting.LintException:
[error] Lint rule anon-regs: 1 exceptions!
[error]  - Recommended fix:
[error]      Use named intermediate val, or if that fails use @chiselName or *.suggestName(...)
[error]  - Whitelist file via Chisel cmdline arg:
[error]      --lint-whitelist:anon-regs RocketCore.scala
[error]  - Whitelist file via Chisel scala API:
[error]      whitelist("anon-regs", Set("RocketCore.scala"))
[error]  - Disable this linting check:
[error]      Omit anon-regs from --lint option
[error]  - Modify display settings with:
[error]      --lint-options ...,display:anon-regs=<number>,...
[error] anon-regs.1: @[RocketCore.scala 1001:25]  in Set(Rocket)
[error]
[error] Lint rule trunc-widths: 383 exceptions!
[error]  - Recommended fix:
[error]      Truncate width prior to connections
[error]  - Whitelist file via Chisel cmdline arg:
[error]      --lint-whitelist:trunc-widths BTB.scala,BundleMap.scala,CSR.scala,CacheCork.scala,Counters.scala,Custom.scala,DCache.scala,Debug.scala,DivSqrtRecFN_small.scala,Edges.scala,FIFOFixer.scala,FPU.scala,Fragmenter.scala,Frontend.scala,HellaCache.scala,HellaCacheArbiter.scala,IBuf.scala,InclusiveCache.scala,ListBuffer.scala,Monitor.scala,MulAddRecFN.scala,PMP.scala,PTW.scala,Periphery.scala,Plic.scala,PlusArg.scala,RegisterRouter.scala,Replacement.scala,RocketCore.scala,Serdes.scala,SerialAdapter.scala,SinkA.scala,SinkC.scala,SourceB.scala,TLB.scala,UARTRx.scala,UARTTx.scala
[error]  - Whitelist file via Chisel scala API:
[error]      whitelist("trunc-widths", Set("BTB.scala","BundleMap.scala","CSR.scala","CacheCork.scala","Counters.scala","Custom.scala","DCache.scala","Debug.scala","DivSqrtRecFN_small.scala","Edges.scala","FIFOFixer.scala","FPU.scala","Fragmenter.scala","Frontend.scala","HellaCache.scala","HellaCacheArbiter.scala","IBuf.scala","InclusiveCache.scala","ListBuffer.scala","Monitor.scala","MulAddRecFN.scala","PMP.scala","PTW.scala","Periphery.scala","Plic.scala","PlusArg.scala","RegisterRouter.scala","Replacement.scala","RocketCore.scala","Serdes.scala","SerialAdapter.scala","SinkA.scala","SinkC.scala","SourceB.scala","TLB.scala","UARTRx.scala","UARTTx.scala"))
[error]  - Disable this linting check:
[error]      Omit trunc-widths from --lint option
[error]  - Modify display settings with:
[error]      --lint-options ...,display:trunc-widths=<number>,...
[error] trunc-widths.1: @[BTB.scala 268:21] _idxPages_waddr <= _idxPages_T // Connecting width 4 to width 3 in Set(BTB)
[error] trunc-widths.2: @[BTB.scala 271:13] isValid <= _isValid_T_3 // Connecting width 32 to width 28 in Set(BTB)
[error] trunc-widths.3: @[BTB.scala 273:20] _brIdx_waddr <= _brIdx_T // Connecting width 38 to width 1 in Set(BTB)
[error] trunc-widths.4: @[BTB.scala 286:15] pageValid <= _pageValid_T_1 // Connecting width 8 to width 6 in Set(BTB)
[error] trunc-widths.5: @[BTB.scala 294:21] io.resp.bits.mask <= _io_resp_bits_mask_T_5 // Connecting width 3 to width 2 in Set(BTB)
...
[error] stack trace is suppressed; run last Compile / bgRunMain for the full output
[error] Nonzero exit code: 1
[error] (Compile / runMain) Nonzero exit code: 1
[error] Total time: 69 s (01:09), completed Jul 14, 2021, 2:13:28 PM
...
```

For some reason, it prints the `freechips.rocketchip.linting.LintException` twice for me, but I trimmed it from the output above.

Breaking up the FIRRTL command into multiple lines and using the long-forms of the options is a style choice, let me know if that's not a desirable change.

<!-- choose one -->
**Impact**: other

**Release Notes**
Add `make` variables to let users add extra arguments to the Chisel and FIRRTL compiler invocations.
