### PR TITLE
qemu: build without -Werror

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -176,7 +176,7 @@ if [ -z "$IGNOREQEMU" ] ; then
     echo "==>  PLEASE REMOVE qemu URL-REWRITING from scripts/build-toolchains.sh. It is no longer needed!" && exit 1
 
     # now actually do the build
-    SRCDIR="$(pwd)/toolchains" module_build qemu --prefix="${RISCV}" --target-list=riscv${XLEN}-softmmu
+    SRCDIR="$(pwd)/toolchains" module_build qemu --prefix="${RISCV}" --target-list=riscv${XLEN}-softmmu --disable-werror
 fi
 
 # make Dromajo


### PR DESCRIPTION
While -Werror is nice for developer builds, it can easily lead to breakage when people use newer compilers which add new warnings.


**Type of change**: bug fix 

**Impact**: tools chain now compiles qemu without -Werror

With this change, I am able to successfully build the risc-v tools on my Fedora 34 machine.
