### PR TITLE
swap the two arguments to resolve bug

### DIFF
--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -118,8 +118,8 @@ $(BIT_FILE): $(synth_list_f)
 		-tclargs \
 			-top-module "$(MODEL)" \
 			-F "$(synth_list_f)" \
-			-ip-vivado-tcls "$(shell find '$(build_dir)' -name '*.vivado.tcl')" \
-			-board "$(BOARD)"
+			-board "$(BOARD)" \
+			-ip-vivado-tcls "$(shell find '$(build_dir)' -name '*.vivado.tcl')"
 
 .PHONY: bitstream
 bitstream: $(BIT_FILE)


### PR DESCRIPTION
**Related issue**: N/A

**Type of change**: bug fix

**Impact**: other

**Release Notes**
The string of path for "-ip-vivado-tcls" could be empty ("")
For example, run "make SUB_PROJECT=arty bitstream" will get errors due the argument parsing in [prologue.tcl](https://github.com/sifive/fpga-shells/blob/d4b3878e4f5cf5c4621dbfe9b0bda1ed0dd3b995/xilinx/common/tcl/prologue.tcl)
Swaping the two arguments can resolve bug.