### PR TITLE
Escape $1 in awk command

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -173,7 +173,7 @@ harness_macro_temp: $(HARNESS_SMEMS_CONF) | top_macro_temp
 # remove duplicate files and headers in list of simulation file inputs
 ########################################################################################
 $(sim_common_files): $(sim_files) $(sim_top_blackboxes) $(sim_harness_blackboxes)
-	awk '{print $1;}' $^ | sort -u | grep -v '.*\.\(svh\|h\)$$' > $@
+	awk '{print $$1;}' $^ | sort -u | grep -v '.*\.\(svh\|h\)$$' > $@
 
 #########################################################################################
 # helper rule to just make verilog files


### PR DESCRIPTION
I'm not really sure how this ever worked before, but this `$1` needs to be escaped in `common.mk`

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
- Fixed awk print bug in common.mk