### PR TITLE
Print entire line in `sim_files.f` for Verilator 

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -173,7 +173,7 @@ harness_macro_temp: $(HARNESS_SMEMS_CONF) | top_macro_temp
 # remove duplicate files and headers in list of simulation file inputs
 ########################################################################################
 $(sim_common_files): $(sim_files) $(sim_top_blackboxes) $(sim_harness_blackboxes)
-	awk '{print $$1;}' $^ | sort -u | grep -v '.*\.\(svh\|h\)$$' > $@
+	awk '{print}' $^ | sort -u | grep -v '.*\.\(svh\|h\)$$' > $@
 
 #########################################################################################
 # helper rule to just make verilog files

--- a/common.mk
+++ b/common.mk
@@ -173,7 +173,7 @@ harness_macro_temp: $(HARNESS_SMEMS_CONF) | top_macro_temp
 # remove duplicate files and headers in list of simulation file inputs
 ########################################################################################
 $(sim_common_files): $(sim_files) $(sim_top_blackboxes) $(sim_harness_blackboxes)
-	awk '{print}' $^ | sort -u | grep -v '.*\.\(svh\|h\)$$' > $@
+	sort -u $^ | grep -v '.*\.\(svh\|h\)$$' > $@
 
 #########################################################################################
 # helper rule to just make verilog files


### PR DESCRIPTION
**Related issue**: #963 

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
The Verilator makefile adds a `-FI` to header files before they get filtered out. Thus, when you print by `$$1` you print each word of a line one-by-one causing parsing issues (ex. `-FI` then `<long_file>` then `-FI` then `<next_file>` etc). This fix removes the `$$1` which tells `awk` to print the entire line at once (this was the previous functionality because the make variable `$1` resolved to nothing before).
