### PR TITLE
Fixes UART portmap for Arty.

### DIFF
--- a/fpga/src/main/scala/arty/HarnessBinders.scala
+++ b/fpga/src/main/scala/arty/HarnessBinders.scala
@@ -72,8 +72,8 @@ class WithArtyJTAGHarnessBinder extends OverrideHarnessBinder({
 class WithArtyUARTHarnessBinder extends OverrideHarnessBinder({
   (system: HasPeripheryUARTModuleImp, th: ArtyFPGATestHarness, ports: Seq[UARTPortIO]) => {
     withClockAndReset(th.clock_32MHz, th.ck_rst) {
-      IOBUF(th.uart_txd_in,  ports.head.txd)
-      ports.head.rxd := IOBUF(th.uart_rxd_out)
+      IOBUF(th.uart_rxd_out,  ports.head.txd)
+      ports.head.rxd := IOBUF(th.uart_txd_in)
     }
   }
 })


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl change
**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
Swap uart txd and rxd connection to match the constraint file. This has been tested on Arty A7 100T devkit.