### PR TITLE
Fixed TLFragmenter argument list in Docs

### DIFF
--- a/docs/Prototyping/VCU118.rst
+++ b/docs/Prototyping/VCU118.rst
@@ -110,7 +110,7 @@ The 1st partition will be used to store the Linux binary (created with FireMarsh
 Additionally, these instructions assume you are using Linux with ``sudo`` privileges and ``gdisk``, but you can follow a similar set of steps on Mac (using ``gpt`` or another similar program).
 
 1. Wipe the GPT on the card using ``gdisk``.
-   Use the `z` command to zap everything from the expert menu (opened with 'x', closed with 'm').
+   Use the `z` command from the expert menu (opened with 'x', closed with 'm') to zap everything.
    For rest of these instructions, we assume the SDCard path is ``/dev/sdc`` (replace this with the path to your SDCard).
 
 .. code-block:: shell

--- a/docs/TileLink-Diplomacy-Reference/Widgets.rst
+++ b/docs/TileLink-Diplomacy-Reference/Widgets.rst
@@ -178,7 +178,7 @@ transactions.
     - ``EarlyAck.PutFulls`` - acknowledge on first beat if PutFull, otherwise acknowledge on last beat.
     - ``EarlyAck.None`` - always acknowledge on last beat.
 
- - ``holdFirstDenied: Boolean`` - (optional) Allow the Fragmenter to unsafely combine multibeat Gets by taking the first denied for the whole burst. (default: false)
+ - ``holdFirstDeny: Boolean`` - (optional) Allow the Fragmenter to unsafely combine multibeat Gets by taking the first denied for the whole burst. (default: false)
 
 **Example Usage:**
 


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**:  Documentation enhancement

<!-- choose one -->
**Impact**:  Documentation

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
Fixed a minor grammar bug into the VCU118 docs. `TLFragmenter` argument list referred to `holdFirstDenied` when it probably meant the `holdFirstDeny` argument. 
