### PR TITLE
Mergify Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,6 +380,14 @@ jobs:
                 group-key: "group-fpga"
                 build-type: "fpga"
 
+    success:
+        executor: main-env
+        steps:
+            - run:
+                name: Completed CI!
+                command: |
+                    echo "Completed CI!"
+
 # Order and dependencies of jobs to run
 workflows:
     version: 2
@@ -522,3 +530,33 @@ workflows:
             - prepare-chipyard-fpga:
                 requires:
                     - install-riscv-toolchain
+
+            # Signal success
+            - success:
+                requires:
+                    - tutorial-setup-check
+                    - documentation-check
+                    - commit-on-master-check
+                    - chipyard-rocket-run-tests
+                    - chipyard-hetero-run-tests
+                    - chipyard-boom-run-tests
+                    - chipyard-cva6-run-tests
+                    - chipyard-sodor-run-tests
+                    - chipyard-dmirocket-run-tests
+                    - chipyard-spiflashwrite-run-tests
+                    - chipyard-spiflashread-run-tests
+                    - chipyard-lbwif-run-tests
+                    - chipyard-sha3-run-tests
+                    - chipyard-streaming-fir-run-tests
+                    - chipyard-streaming-passthrough-run-tests
+                    - chipyard-hwacha-run-tests
+                    - chipyard-gemmini-run-tests
+                    - chipyard-nvdla-run-tests
+                    - tracegen-run-tests
+                    - tracegen-boom-run-tests
+                    - icenet-run-tests
+                    - testchipip-run-tests
+                    - firesim-run-tests
+                    - firesim-multiclock-run-tests
+                    - fireboom-run-tests
+                    - prepare-chipyard-fpga

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,44 @@
+pull_request_rules:
+    - name: automatic merge on all ci success and review
+      conditions:
+          - "check-success=ci/circleci: success"
+          - "#approved-reviews-by>=1"
+          - base=dev
+          - label!="DO NOT MERGE"
+      actions:
+          merge:
+              method: merge
+              strict: smart
+              strict_method: merge
+
+    - name: automatically merge on just docs ci success and review (just docs)
+      conditions:
+          - check-success=ci/circleci: documentation-check
+          - -files~=^(!?docs/)
+          - "#approved-reviews-by>=1"
+          - base=dev
+          - label!="DO NOT MERGE"
+      actions:
+          merge:
+              method: merge
+              strict: smart
+              strict_method: merge
+
+    - name: label docs changes
+      conditions:
+          - -files~=^(!?docs/)
+      actions:
+          label:
+              add:
+                - docs
+
+    - name: add comment to warn that base branch isn't dev (ignore backports and releases)
+      conditions:
+          - -base=dev
+          - -body~=Dev -> Master
+          - -title~=Dev -> Master
+          - label!="backport"
+      actions:
+          comment:
+              message: |
+                  Please change the base branch of the PR to dev

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
     - name: automatic merge on all ci success and review
       conditions:
-          - "check-success=success"
+          - "check-success=ci/circleci: success"
           - "#approved-reviews-by>=1"
           - "#review-requested=0"
           - "#changes-requested-reviews-by=0"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,10 @@
 pull_request_rules:
     - name: automatic merge on all ci success and review
       conditions:
-          - "check-success=ci/circleci: success"
+          - "check-success=success"
           - "#approved-reviews-by>=1"
+          - "#review-requested=0"
+          - "#changes-requested-reviews-by=0"
           - base=dev
           - label!="DO NOT MERGE"
       actions:
@@ -11,11 +13,16 @@ pull_request_rules:
               strict: smart
               strict_method: merge
 
-    - name: automatically merge on just docs ci success and review (just docs)
+    - name: automatically merge on just docs ci success and review (just docs/md files)
       conditions:
-          - check-success=ci/circleci: documentation-check
-          - -files~=^(!?docs/)
+          - or:
+              - and:
+                  - "check-success=ci/circleci: documentation-check"
+                  - -files~=^((?!docs\/).)*$
+              - -files~=^((?!\.md).)*$
           - "#approved-reviews-by>=1"
+          - "#review-requested=0"
+          - "#changes-requested-reviews-by=0"
           - base=dev
           - label!="DO NOT MERGE"
       actions:
@@ -26,7 +33,11 @@ pull_request_rules:
 
     - name: label docs changes
       conditions:
-          - -files~=^(!?docs/)
+          - or:
+              - and:
+                  - "check-success=ci/circleci: documentation-check"
+                  - -files~=^((?!docs\/).)*$
+              - -files~=^((?!\.md).)*$
       actions:
           label:
               add:
@@ -42,3 +53,4 @@ pull_request_rules:
           comment:
               message: |
                   Please change the base branch of the PR to dev
+


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: other

**Release Notes**
This adds a bot to handle some PR request merging automatically and add `dev` comments. We can also add future functionality to make the bot backport changes to `master` if need be. For this to work, the PR needs to be backported to the `master` branch (since the configuration file is only picked up on the default branch). Maybe we need to quickly rediscuss having `dev` be the main branch because now 2 things depend on it, the GH issue/PR templates and this.

Changes
- Add CI success job that runs at the end
- Add mergify bot
  - Merge when all reviews approve
  - Merge when its just docs and the CI passes for just docs
  - Label docs changes
  - Add comment to change base branch if it's not dev targeted
