### PR TITLE
Fix readlink on macOS

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -6,9 +6,16 @@
 set -e
 set -o pipefail
 
+# On macOS, use GNU readlink from 'coreutils' package in Homebrew/MacPorts
+if [ "$(uname -s)" = "Darwin" ] ; then
+    READLINK=greadlink
+else
+    READLINK=readlink
+fi
+
 # If BASH_SOURCE is undefined, we may be running under zsh, in that case
 # provide a zsh-compatible alternative
-DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]:-${(%):-%x}}")")"
+DIR="$(dirname "$($READLINK -f "${BASH_SOURCE[0]:-${(%):-%x}}")")"
 CHIPYARD_DIR="$(dirname "$DIR")"
 
 usage() {

--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -17,9 +17,16 @@ if [ "$MINGIT" != "$(echo -e "$MINGIT\n$MYGIT" | sort -V | head -n1)" ]; then
   false
 fi
 
+# On macOS, use GNU readlink from 'coreutils' package in Homebrew/MacPorts
+if [ "$(uname -s)" = "Darwin" ] ; then
+    READLINK=greadlink
+else
+    READLINK=readlink
+fi
+
 # If BASH_SOURCE is undefined we may be running under zsh, in that case
 # provide a zsh-compatible alternative
-DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]:-${(%):-%x}}")")"
+DIR="$(dirname "$($READLINK -f "${BASH_SOURCE[0]:-${(%):-%x}}")")"
 CHIPYARD_DIR="$(dirname "$DIR")"
 
 cd "$CHIPYARD_DIR"


### PR DESCRIPTION
**Related issue**: N/A

Use GNU readlink on macOS, since BSD readlink doesn't work in the same way. This was resulting in the auto-generated `.sbtopts` file having the wrong contents (in the `sbt.workspace` setting).

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: script change

**Release Notes**
Fix `.sbtopts` generation on macOS
