### PR TITLE
Add define for MAKE variable

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -11,6 +11,10 @@ set -o pipefail
 DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]:-${(%):-%x}}")")"
 CHIPYARD_DIR="$(dirname "$DIR")"
 
+# Allow user to override MAKE
+[ -n "${MAKE:+x}" ] || MAKE=$(command -v gnumake || command -v gmake || command -v make)
+readonly MAKE
+
 usage() {
     echo "usage: ${0} [OPTIONS] [riscv-tools | esp-tools | ec2fast]"
     echo ""


### PR DESCRIPTION
Currently there is no define for MAKE. Running script always throws `obsolete make version; need GNU make 4.x or later` error.

This config is from [`build-util.sh` script](https://github.com/ucb-bar/chipyard/blob/9d055fdac638ab90735cbde42fd2d86355eb260b/scripts/build-util.sh#L17-L19)

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl change | software change | unknown | other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
