### PR TITLE
Fix custom MODEL feature

### DIFF
--- a/vcs.mk
+++ b/vcs.mk
@@ -50,6 +50,7 @@ PREPROC_DEFINES = \
 	+define+RESET_DELAY=$(RESET_DELAY) \
 	+define+PRINTF_COND=$(TB).printf_cond \
 	+define+STOP_COND=!$(TB).reset \
+	+define+MODEL=$(MODEL) \
 	+define+RANDOMIZE_MEM_INIT \
 	+define+RANDOMIZE_REG_INIT \
 	+define+RANDOMIZE_GARBAGE_ASSIGN \


### PR DESCRIPTION
Previously, the TestDriver would set MODEL to TestHarness if unset. This fixes the feature to let us set MODEL from the Makefile.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: rtl change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
