### PR TITLE
Increase default SerialTL width to 32 

### DIFF
--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -42,6 +42,7 @@ class AbstractConfig extends Config(
   new chipyard.iobinders.WithCustomBootPin ++
   new chipyard.iobinders.WithDividerOnlyClockGenerator ++
 
+  new testchipip.WithSerialTLWidth(32) ++                        // fatten the serialTL interface to improve testing performance
   new testchipip.WithDefaultSerialTL ++                          // use serialized tilelink port to external serialadapter/harnessRAM
   new chipyard.config.WithBootROM ++                             // use default bootrom
   new chipyard.config.WithUART ++                                // add a UART

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -64,6 +64,8 @@ class WithNVDLASmall extends nvidia.blocks.dla.WithNVDLA("small")
 
 // Non-frequency tweaks that are generally applied to all firesim configs
 class WithFireSimDesignTweaks extends Config(
+  // Optional: reduce the width of the Serial TL interface
+  new testchipip.WithSerialTLWidth(4) ++
   // Required: Bake in the default FASED memory model
   new WithDefaultMemModel ++
   // Required*: Uses FireSim ClockBridge and PeekPokeBridge to drive the system with a single clock/reset


### PR DESCRIPTION
This should improve the performance of `run-binary`, `run-asm-tests`, `run-bmark-tests`, at the expense of making the default config less tapeout-friendly. However, its expected that tapeout users will need to adjust the SerialTL settings for a chip anyways, so this is a small cost.

The FireSim configs are not affected. The SerialTL width is set to be 4, as before, so no AGFI regeneration is needed.

<!-- choose one -->
**Type of change**:  other enhancement

<!-- choose one -->
**Impact**: rtl change 

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
Increased default SerialTL width to 32 from 4.