### PR TITLE
Cleanup how to override SBT + `make help` documentation update

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,7 @@ HELP_COMPILATION_VARIABLES += \
 "   EXTRA_SIM_LDFLAGS      = additional LDFLAGS for building simulators" \
 "   EXTRA_SIM_SOURCES      = additional simulation sources needed for simulator" \
 "   EXTRA_SIM_REQS         = additional make requirements to build the simulator" \
-"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client (works best when overridding SBT_BIN with sbt script)" \
+"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client (works best when overridding SBT_BIN with the mainline sbt script)" \
 "   EXTRA_CHISEL_OPTIONS   = additional options to pass to the Chisel compiler" \
 "   EXTRA_FIRRTL_OPTIONS   = additional options to pass to the FIRRTL compiler"
 
@@ -41,13 +41,14 @@ NUMA_PREFIX = $(if $(filter $(NUMACTL),0),,$(shell $(base_dir)/scripts/numa_pref
 
 #----------------------------------------------------------------------------
 HELP_COMMANDS += \
-"   run-binary             = run [./$(shell basename $(sim))] and log instructions to file" \
-"   run-binary-fast        = run [./$(shell basename $(sim))] and don't log instructions" \
-"   run-binary-debug       = run [./$(shell basename $(sim_debug))] and log instructions and waveform to files" \
-"   verilog                = generate intermediate verilog files from chisel elaboration and firrtl passes" \
-"   firrtl                 = generate intermediate firrtl files from chisel elaboration" \
-"   run-tests              = run all assembly and benchmark tests" \
-"   launch-sbt             = start sbt terminal"
+"   run-binary                  = run [./$(shell basename $(sim))] and log instructions to file" \
+"   run-binary-fast             = run [./$(shell basename $(sim))] and don't log instructions" \
+"   run-binary-debug            = run [./$(shell basename $(sim_debug))] and log instructions and waveform to files" \
+"   verilog                     = generate intermediate verilog files from chisel elaboration and firrtl passes" \
+"   firrtl                      = generate intermediate firrtl files from chisel elaboration" \
+"   run-tests                   = run all assembly and benchmark tests" \
+"   launch-sbt                  = start sbt terminal" \
+"   {shutdown,start}-sbt-server = shutdown or start sbt server if using ENABLE_SBT_THIN_CLIENT" \
 
 #########################################################################################
 # include additional subproject make fragments
@@ -105,7 +106,7 @@ $(FIRRTL_FILE) $(ANNO_FILE): generator_temp
 	@echo "" > /dev/null
 
 # AG: must re-elaborate if cva6 sources have changed... otherwise just run firrtl compile
-generator_temp: $(SCALA_SOURCES) $(sim_files) $(EXTRA_GENERATOR_REQS)
+generator_temp: $(SCALA_SOURCES) $(sim_files) $(SCALA_BUILDTOOL_DEPS) $(EXTRA_GENERATOR_REQS)
 	mkdir -p $(build_dir)
 	$(call run_scala_main,$(SBT_PROJECT),$(GENERATOR_PACKAGE).Generator,\
 		--target-dir $(build_dir) \
@@ -279,6 +280,7 @@ SBT_COMMAND ?= shell
 launch-sbt:
 	cd $(base_dir) && $(SBT_NON_THIN) "$(SBT_COMMAND)"
 
+.PHONY: check-thin-client
 check-thin-client:
 ifeq (,$(ENABLE_SBT_THIN_CLIENT))
 	$(error ENABLE_SBT_THIN_CLIENT not set.)

--- a/common.mk
+++ b/common.mk
@@ -18,7 +18,7 @@ HELP_COMPILATION_VARIABLES += \
 "   EXTRA_SIM_LDFLAGS      = additional LDFLAGS for building simulators" \
 "   EXTRA_SIM_SOURCES      = additional simulation sources needed for simulator" \
 "   EXTRA_SIM_REQS         = additional make requirements to build the simulator" \
-"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client (works best with sbtn or sbt script)" \
+"   ENABLE_SBT_THIN_CLIENT = if set, use sbt's experimental thin client (works best when overridding SBT_BIN with sbt script)" \
 "   EXTRA_CHISEL_OPTIONS   = additional options to pass to the Chisel compiler" \
 "   EXTRA_FIRRTL_OPTIONS   = additional options to pass to the FIRRTL compiler"
 

--- a/variables.mk
+++ b/variables.mk
@@ -175,7 +175,8 @@ override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
 SBT_CLIENT_FLAG = --client
 endif
 
-SBT ?= java $(JAVA_TOOL_OPTIONS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar $(SBT_OPTS) $(SBT_CLIENT_FLAG)
+SBT_BIN ?= java $(JAVA_TOOL_OPTIONS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar $(SBT_OPTS)
+SBT ?= $(SBT_BIN) $(SBT_CLIENT_FLAG)
 SBT_NON_THIN ?= $(subst $(SBT_CLIENT_FLAG),,$(SBT))
 
 define run_scala_main

--- a/variables.mk
+++ b/variables.mk
@@ -3,7 +3,13 @@
 # - to use the help text, your Makefile should have a 'help' target that just
 #   prints all the HELP_LINES
 #########################################################################################
-HELP_COMPILATION_VARIABLES =
+HELP_COMPILATION_VARIABLES = \
+"   JAVA_HEAP_SIZE    = if overridden, set the default java heap size (default is 8G)" \
+"   JAVA_TOOL_OPTIONS = if overridden, set underlying java tool options (default sets misc. sizes and tmp dir)" \
+"   SBT_OPTS          = if overridden, set underlying sbt options (default uses options in .sbtopts)" \
+"   SBT_BIN           = if overridden, used to invoke sbt (default is to invoke sbt by sbt-launch.jar)" \
+"   FIRRTL_LOGLEVEL   = if overridden, set firrtl log level (default is error)"
+
 HELP_PROJECT_VARIABLES = \
 "   SUB_PROJECT            = use the specific subproject default variables [$(SUB_PROJECT)]" \
 "   SBT_PROJECT            = the SBT project that you should find the classes/packages in [$(SBT_PROJECT)]" \
@@ -169,15 +175,16 @@ SCALA_BUILDTOOL_DEPS = $(SBT_SOURCES)
 SBT_THIN_CLIENT_TIMESTAMP = $(base_dir)/project/target/active.json
 
 ifdef ENABLE_SBT_THIN_CLIENT
-override SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
+SCALA_BUILDTOOL_DEPS += $(SBT_THIN_CLIENT_TIMESTAMP)
 # enabling speeds up sbt loading
 # use with sbt script or sbtn to bypass error code issues
 SBT_CLIENT_FLAG = --client
 endif
 
-SBT_BIN ?= java $(JAVA_TOOL_OPTIONS) -jar $(ROCKETCHIP_DIR)/sbt-launch.jar $(SBT_OPTS)
-SBT ?= $(SBT_BIN) $(SBT_CLIENT_FLAG)
-SBT_NON_THIN ?= $(subst $(SBT_CLIENT_FLAG),,$(SBT))
+# passes $(JAVA_TOOL_OPTIONS) from env to java
+SBT_BIN ?= java -jar $(ROCKETCHIP_DIR)/sbt-launch.jar $(SBT_OPTS)
+SBT = $(SBT_BIN) $(SBT_CLIENT_FLAG)
+SBT_NON_THIN = $(subst $(SBT_CLIENT_FLAG),,$(SBT))
 
 define run_scala_main
 	cd $(base_dir) && $(SBT) ";project $(1); runMain $(2) $(3)"


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
`ENABLE_SBT_THIN_CLIENT` flag is best used with a pre-installed SBT (aka best with the SBT script). This allows you to just override the SBT binary/script with `SBT_BIN` and have the `--client` flag be handled by Chipyard's Makefile. This also adds more `make help` documentation, fixes an issue with the SBT server not being depended on, and removes unnecessary `?=`s and `override`s in `variables.mk` (this was done to properly enforce that the only way to modify the CY build system SBT is to change `SBT_BIN`).

Side note: When using the SBT script to launch things, the thin client acts nicely; properly exits on errors, displays colors, etc.
