### PR TITLE
Remove duplicate `WithUARTIOCells` [ci skip]

### DIFF
--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -35,7 +35,6 @@ class AbstractConfig extends Config(
   new chipyard.iobinders.WithDebugIOCells ++
   new chipyard.iobinders.WithUARTIOCells ++
   new chipyard.iobinders.WithGPIOCells ++
-  new chipyard.iobinders.WithUARTIOCells ++
   new chipyard.iobinders.WithSPIIOCells ++
   new chipyard.iobinders.WithTraceIOPunchthrough ++
   new chipyard.iobinders.WithExtInterruptIOCells ++


### PR DESCRIPTION
**Related issue**: Fixes #1043 

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
Removes duplicate `WithUARTIOCells` in the `AbstractConfig`
