### PR TITLE
Force FIRRTL 1.4.1

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -169,6 +169,10 @@ SBT_OPTS_FILE := $(base_dir)/.sbtopts
 ifneq (,$(wildcard $(SBT_OPTS_FILE)))
 override SBT_OPTS += $(subst $$PWD,$(base_dir),$(shell cat $(SBT_OPTS_FILE)))
 endif
+# Workaround: Specify a firrtl version in system properties so that Treadle uses a
+# compatible version of FIRRTL and not 1.5-SNAPSHOT (which is the default
+# specified in it's build.sbt, and is not overridden by Chipyard's build.sbt)
+override SBT_OPTS += -DfirrtlVersion=1.4.1
 
 SCALA_BUILDTOOL_DEPS = $(SBT_SOURCES)
 


### PR DESCRIPTION
**Related issue**: https://github.com/firesim/firesim/pull/887/files  https://github.com/firesim/firesim/issues/888

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**

 Modified from the equivalent FireSim PR:

Unfortunately, our firrtl-dependency overriding in chipyard's build.sbt has a hole wherein treadle pulls in a 1.5-SNAPSHOT from maven instead of our desired version of 1.4.1. Recently, a slew of deprecated APIs were removed in the 1.5-SNAPSHOT recently, leading treadle compilation to fail. As a result, Chipyard master and dev are broken.

Workaround this problem by specifying a FIRRTL version through the java system properties, which treadle will pick up to override the 1.5-SNAPSHOT default. We could do Chisel too. 

The right solution to this (IMO) is to just use published dependencies for the big 5 instead of trying to build from source. 

This will need to be back-ported to master.