### PR TITLE
Hide `which` warning when `fd` isn't installed

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -65,7 +65,7 @@ include $(base_dir)/tools/torture.mk
 #########################################################################################
 # Returns a list of files in directory $1 with file extension $2.
 # If available, use 'fd' to find the list of files, which is faster than 'find'.
-ifeq ($(shell which fd),)
+ifeq ($(shell which fd 2> /dev/null),)
 	lookup_srcs = $(shell find -L $(1)/ -name target -prune -o -iname "*.$(2)" -print 2> /dev/null)
 else
 	lookup_srcs = $(shell fd -L ".*\.$(2)" $(1))


### PR DESCRIPTION
**Related issue**: N/A

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
Hide `make` warning message about `fd` not being found.
