### PR TITLE
Don't initialize nvdla-workload with init-submodules

### DIFF
--- a/docs/Software/index.rst
+++ b/docs/Software/index.rst
@@ -13,6 +13,15 @@ official RISC-V ISA reference implementation. Qemu is a high-performance
 functional simulator that can run nearly as fast as native code, but can be
 challenging to modify.
 
+To initialize additional software repositories, such as wrappers for Coremark,
+SPEC2017, and workloads for the NVDLA, run the following script. The
+submodules are located in the ``software`` directory.
+
+.. code-block:: shell
+
+    ./scripts/init-software.sh
+
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/scripts/init-software.sh
+++ b/scripts/init-software.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# exit script if any command fails
+set -e
+set -o pipefail
+
+# Enable submodule update for software submodules
+git config --unset submodule.software/nvdla-workload.update || :
+git config --unset submodule.software/coremark.update || :
+git config --unset submodule.software/spec2017.update || :
+
+# Initialize local software submodules
+git submodule update --init --recursive software/nvdla-workload
+git submodule update --init --recursive software/coremark
+git submodule update --init --recursive software/spec2017

--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -47,11 +47,13 @@ cd "$CHIPYARD_DIR"
             generators/sha3 \
             generators/gemmini \
             sims/firesim \
-            software/nvdla-workload
+            software/nvdla-workload \
+            software/coremark \
+            software/firemarshal \
+            software/spec2017 \
             vlsi/hammer-cadence-plugins \
             vlsi/hammer-synopsys-plugins \
             vlsi/hammer-mentor-plugins \
-            software/firemarshal \
             fpga/fpga-shells
         do
             "$1" "${name%/}"

--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -47,6 +47,7 @@ cd "$CHIPYARD_DIR"
             generators/sha3 \
             generators/gemmini \
             sims/firesim \
+            software/nvdla-workload
             vlsi/hammer-cadence-plugins \
             vlsi/hammer-synopsys-plugins \
             vlsi/hammer-mentor-plugins \


### PR DESCRIPTION
nvdla-workload is very large, results in long init times. Make users initialize this explicitly (like we do with gemmini-software)

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: software change

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
NVDLA-workload submodule is not longer initialized with init-submodules script