### PR TITLE
Missing option for VCS KDB and Verdi pli

### DIFF
--- a/vcs.mk
+++ b/vcs.mk
@@ -1,5 +1,5 @@
 ifdef USE_FSDB
-WAVEFORM_FLAG=+fsdbfile=$(sim_out_name).fsdb
+WAVEFORM_FLAG=+fsdbfile=$(sim_out_name).fsdb -kdb -P ${VERDI_HOME}/share/PLI/VCS/LINUX64/novas.tab ${VERDI_HOME}/share/PLI/VCS/LINUX64/pli.a
 else
 WAVEFORM_FLAG=+vcdplusfile=$(sim_out_name).vpd
 endif


### PR DESCRIPTION
**Related issue**: <!-- if applicable --> https://github.com/ucb-bar/chipyard/issues/1070

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**: software change

**Release Notes**
Add fsdb support for VCS waveform dump
