### PR TITLE
Remove MaxPermSize from java flags

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -153,7 +153,7 @@ sim_common_files       ?= $(build_dir)/sim_files.common.f
 # java arguments used in sbt
 #########################################################################################
 JAVA_HEAP_SIZE ?= 8G
-JAVA_OPTS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -XX:MaxPermSize=256M -Djava.io.tmpdir=$(base_dir)/.java_tmp
+JAVA_OPTS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -Djava.io.tmpdir=$(base_dir)/.java_tmp
 
 #########################################################################################
 # default sbt launch command


### PR DESCRIPTION
See https://github.com/ucb-bar/chipyard/issues/1079. This option ceased doing things after Java 8 (released in 2014), and openJDK considers having it included an error.

**Related issue**: [<!-- if applicable -->](https://github.com/ucb-bar/chipyard/issues/1079)

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: none

**Release Notes**
Removed obsolete Java flags that caused issues with OpenJDK.
