### PR TITLE
Remove MaxPermSize

### DIFF
--- a/variables.mk
+++ b/variables.mk
@@ -160,7 +160,7 @@ sim_common_files       ?= $(build_dir)/sim_files.common.f
 # java arguments used in sbt
 #########################################################################################
 JAVA_HEAP_SIZE ?= 8G
-export JAVA_TOOL_OPTIONS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -XX:MaxPermSize=256M -Djava.io.tmpdir=$(base_dir)/.java_tmp
+export JAVA_TOOL_OPTIONS ?= -Xmx$(JAVA_HEAP_SIZE) -Xss8M -Djava.io.tmpdir=$(base_dir)/.java_tmp
 
 #########################################################################################
 # default sbt launch command


### PR DESCRIPTION
See ucb-bar#1079. This option ceased doing things after Java 8 (released in 2014), and openJDK considers having it included an error.
This commit is a redo of a previous one.

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: none

**Release Notes**
Removed obsolete java option.