### PR TITLE
Run CI only on dev/master/main branches/PRs

### DIFF
--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -1,6 +1,18 @@
 name: chipyard-ci-process
 
-on: [push]
+on:
+  # run ci when pushing to dev, master, and main only
+  push:
+    branches:
+      - dev
+      - master
+      - main
+  # run ci on pull requests targeting dev, master, main only
+  pull_request:
+    branches:
+      - dev
+      - master
+      - main
 
 env:
   tools-cache-version: v13


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
Current CI runs on any branch that is pushed to in the repo. This reduces the amount of CI runs to only be on pushes/PRs to `dev`, `master` and `main`.
