### PR TITLE
Only run CI on pull_requests

### DIFF
--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -1,13 +1,7 @@
 name: chipyard-ci-process
 
 on:
-  # run ci when pushing to dev, master, and main only
-  push:
-    branches:
-      - dev
-      - master
-      - main
-  # run ci on pull requests targeting dev, master, main only
+  # run ci on pull requests targeting dev, master, main only (since the ci runs on the merge commit)
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: other

**Release Notes**
Since the `pull_request` CI event basically checks out the merge commit of the PR against the base branch (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) I'm deleting the `push` event CI (since that is redundant and we expect people to PR into `dev/main/master` first).
