### PR TITLE
[firechip] Properly string interpolate exit failure in ScalaTestSuite

### DIFF
--- a/generators/firechip/src/test/scala/ScalaTestSuite.scala
+++ b/generators/firechip/src/test/scala/ScalaTestSuite.scala
@@ -65,7 +65,7 @@ abstract class FireSimTestSuite(
           Await result (Future sequence subresults, Duration.Inf)
         }
         results.flatten foreach { case (name, exitcode) =>
-          assert(exitcode == 0, "Failed $name")
+          assert(exitcode == 0, s"Failed $name")
         }
       }
     } else {


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix 

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
