### PR TITLE
FSDB support in VLSI flow

### DIFF
--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -174,7 +174,16 @@ $(SIM_DEBUG_CONF): $(VLSI_RTL) $(HARNESS_FILE) $(HARNESS_SMEMS_FILE) $(sim_commo
 	echo "  saif.mode: 'time'" >> $@
 	echo "  saif.start_time: '0ns'" >> $@
 	echo "  saif.end_time: '`bc <<< $(timeout_cycles)*$(CLOCK_PERIOD)`ns'" >> $@
+ifdef USE_FSDB
+	echo "  options:" >> $@
+	echo '    - "-debug_access+all"' >> $@
+	echo '    - "-kdb"' >> $@
+	echo '    - "-lca"' >> $@
+	echo "  options_meta: 'append'" >> $@
+	echo "sim.outputs.waveforms: ['$(sim_out_name).fsdb']" >> $@
+else
 	echo "sim.outputs.waveforms: ['$(sim_out_name).vpd']" >> $@
+endif
 
 $(SIM_TIMING_CONF): $(VLSI_RTL) $(HARNESS_FILE) $(HARNESS_SMEMS_FILE) $(sim_common_files)
 	mkdir -p $(dir $@)


### PR DESCRIPTION
**Related issue**: #1072<!-- if applicable -->

<!-- choose one -->
**Type of change**: new feature

<!-- choose one -->
**Impact**:  other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
- #1072 added support for FSDB with VCS. This enables it for VCS using the Hammer flow as well.
