### PR TITLE
Fix SAIF & Waveforms for Post-P&R Power

### DIFF
--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -158,7 +158,7 @@ $(SIM_CONF): $(VLSI_RTL) $(HARNESS_FILE) $(HARNESS_SMEMS_FILE) $(sim_common_file
 ifneq ($(BINARY), )
 	echo "  benchmarks: ['$(BINARY)']" >> $@
 endif
-	echo "  tb_dut: 'testHarness.$(VLSI_HARNESS_DUT_NAME)'" >> $@
+	echo "  tb_dut: 'TestDriver.testHarness.$(VLSI_HARNESS_DUT_NAME)'" >> $@
 
 $(SIM_DEBUG_CONF): $(VLSI_RTL) $(HARNESS_FILE) $(HARNESS_SMEMS_FILE) $(sim_common_files)
 	mkdir -p $(dir $@)
@@ -200,11 +200,12 @@ $(POWER_CONF): $(VLSI_RTL) $(HARNESS_FILE) $(HARNESS_SMEMS_FILE) $(sim_common_fi
 	echo "  tb_dut: 'testHarness/$(VLSI_HARNESS_DUT_NAME)'" >> $@
 	echo "  database: '$(OBJ_DIR)/par-rundir/$(VLSI_TOP)_FINAL'" >> $@
 ifneq ($(BINARY), )
-	echo "  saifs: [" >> $@
-	echo "    '$(OBJ_DIR)/sim-par-rundir/$(notdir $(BINARY))/ucli.saif'" >> $@
-	echo "  ]" >> $@
 	echo "  waveforms: [" >> $@
-	#echo "    '$(OBJ_DIR)/sim-par-rundir/$(notdir $(BINARY))/$(sim_out_name).vcd'" >> $@
+ifdef USE_FSDB
+	echo "    '$(sim_out_name).fsdb'" >> $@
+else
+	echo "    '$(sim_out_name).vpd'" >> $@
+endif
 	echo "  ]" >> $@
 endif
 	echo "  start_times: ['0ns']" >> $@

--- a/vlsi/power.mk
+++ b/vlsi/power.mk
@@ -1,6 +1,6 @@
 .PHONY: $(POWER_CONF)
-power-par: $(POWER_CONF) sim-par
-power-par-$(VLSI_TOP): $(POWER_CONF) sim-par-$(VLSI_TOP)
+power-par: $(POWER_CONF) sim-par-debug
+power-par-$(VLSI_TOP): $(POWER_CONF) sim-par-debug-$(VLSI_TOP)
 power-par: override HAMMER_POWER_EXTRA_ARGS += -p $(POWER_CONF)
 power-par-$(VLSI_TOP): override HAMMER_POWER_EXTRA_ARGS += -p $(POWER_CONF)
 redo-power-par: $(POWER_CONF)


### PR DESCRIPTION
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: other

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->

- `TestDriver` is now the top-level module in testbenches, so the scope for SAIF dumping must include `TestDriver`
- Post-P&R power analysis features are most useful with SAIFs and waveforms, so it should depend on the `sim-par-debug` target rather than just `sim-par`
- SAIF passing from simulation to power is handled automatically by Hammer, no need to include in Makefile
- Waveforms now passed to power target correctly