### PR TITLE
Have PRCI control registers be clocked by the bus they hang off of

### DIFF
--- a/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
+++ b/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
@@ -72,8 +72,8 @@ trait HasChipyardPRCI { this: BaseSubsystem with InstantiatesTiles =>
     := ClockGroupFrequencySpecifier(p(ClockFrequencyAssignersKey), p(DefaultClockFrequencyKey))
     := ClockGroupCombiner()
     := ClockGroupResetSynchronizer()
-    := TileClockGater(prciParams.baseAddress + 0x00000, tlbus, prciParams.enableTileClockGating)
-    := TileResetSetter(prciParams.baseAddress + 0x10000, tlbus, tile_prci_domains.map(_.tile_reset_domain.clockNode.portParams(0).name.get), Nil)
+    := prci_ctrl_domain { TileClockGater(prciParams.baseAddress + 0x00000, tlbus, prciParams.enableTileClockGating) }
+    := prci_ctrl_domain { TileResetSetter(prciParams.baseAddress + 0x10000, tlbus, tile_prci_domains.map(_.tile_reset_domain.clockNode.portParams(0).name.get), Nil) }
     := allClockGroupsNode)
 }
 


### PR DESCRIPTION
This was technically correct before if the CBUS clock was the implicit clock. but this change makes it correct when that is not the case

**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug fix 
<!-- choose one -->
**Impact**: rtl change 

**Release Notes**
<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
