### PR TITLE
Remove extra spaces in FPGA makefile

### DIFF
--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -118,7 +118,7 @@ $(BIT_FILE): $(synth_list_f)
 		-tclargs \
 			-top-module "$(MODEL)" \
 			-F "$(synth_list_f)" \
-			-board "$(BOARD)" \			
+			-board "$(BOARD)" \
 			-ip-vivado-tcls "$(shell find '$(build_dir)' -name '*.vivado.tcl')"
 
 .PHONY: bitstream


### PR DESCRIPTION
**Related PRs / Issues **:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bug fix that should be applied to master -->
- [ ] (If applicable) Did you mark the PR as "Please Backport"?

**Release Notes**
This fixes the FPGA prototyping makefile so that it doesn't error out with "unknown option".
