### PR TITLE
Fix formatting typo in PR_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-**Related PRs / Issues **:
+**Related PRs / Issues**:
 <!-- List any related PRs/issues here, if applicable -->
 
 <!-- choose one -->


### PR DESCRIPTION
Extra space character prevents the first heading from rendering bold.


