### PR TITLE
Clean old repo contents in CI

### DIFF
--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -31,6 +31,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Check commits of each submodule
@@ -43,6 +49,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Check that the tutorial-setup patches apply
@@ -55,6 +67,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Check that documentation builds with no warnings/errors
@@ -74,6 +92,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RISC-V toolchains
@@ -87,6 +111,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RISC-V toolchains
@@ -109,6 +139,12 @@ jobs:
     runs-on: knight
     needs: cancel-prior-workflows
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build verilator on knight CI machine
@@ -119,6 +155,12 @@ jobs:
     runs-on: ferry
     needs: cancel-prior-workflows
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build verilator on ferry CI machine
@@ -142,6 +184,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RTL on self-hosted
@@ -154,6 +202,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RTL on self-hosted
@@ -166,6 +220,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RTL on self-hosted
@@ -178,6 +238,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RTL on self-hosted
@@ -190,6 +256,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RTL on self-hosted
@@ -202,6 +274,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build RTL on self-hosted
@@ -220,6 +298,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -236,6 +320,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -252,6 +342,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -268,6 +364,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -284,6 +386,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -300,6 +408,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -316,6 +430,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -332,6 +452,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -348,6 +474,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -364,6 +496,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -380,6 +518,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -396,6 +540,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -412,6 +562,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -428,6 +584,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -444,6 +606,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -460,6 +628,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -476,6 +650,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -492,6 +672,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -508,6 +694,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -524,6 +716,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -540,6 +738,12 @@ jobs:
       image: ucbbar/chipyard-ci-image:554b436
       options: --entrypoint /bin/bash
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests
@@ -553,6 +757,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests on self-hosted
@@ -567,6 +777,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests on self-hosted
@@ -581,6 +797,12 @@ jobs:
     needs: setup-complete
     runs-on: self-hosted
     steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ./* || true
+            rm -rf ./.* || true
+            ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run tests on self-hosted

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -52,8 +52,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -70,8 +70,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -95,8 +95,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -114,8 +114,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -142,8 +142,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -158,8 +158,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -187,8 +187,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -205,8 +205,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -223,8 +223,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -241,8 +241,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -259,8 +259,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -277,8 +277,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -301,8 +301,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -323,8 +323,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -345,8 +345,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -367,8 +367,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -389,8 +389,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -411,8 +411,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -433,8 +433,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -455,8 +455,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -477,8 +477,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -499,8 +499,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -521,8 +521,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -543,8 +543,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -565,8 +565,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -587,8 +587,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -609,8 +609,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -631,8 +631,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -653,8 +653,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -675,8 +675,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -697,8 +697,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -719,8 +719,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -741,8 +741,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -760,8 +760,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -780,8 +780,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2
@@ -800,8 +800,8 @@ jobs:
       - name: Delete old checkout
         run: |
             ls -alh .
-            rm -rf ./* || true
-            rm -rf ./.* || true
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
             ls -alh .
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
(@agebonzalez) This PR is now modified to try and fix CI for self-hosted runners. The main issue is that since we are running on self-hosted runners, self-hosted runners reuse a git clone across multiple runs (it does clean the top-level repo with `git clean -ffdx`). Normally this isn't an issue (if you have no submodules / don't change sub-submodule URLs). However, in the case that you change a sub-submodule URL (and probably other cases), you need to run a `git clean -ffdx` in all submodules recursively - which the `checkout@v2` action doesn't do. Since this is basically just deleting the clone completely, I opt for just deleting the repo contents which forces the `checkout` action to reclone the repo.