### PR TITLE
Filter CI on PR contents + Mergify support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,9 @@ contact_links:
   - name: Chipyard Mailing List
     url: https://groups.google.com/forum/#!forum/chipyard
     about: Please ask and answer questions here.
+  - name: FireSim Mailing List
+    url: https://groups.google.com/forum/#!forum/firesim
+    about: Please ask and answer questions here.
   - name: Rocket Chip Support
     url: https://github.com/chipsalliance/rocket-chip/issues
     about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -15,7 +15,7 @@ body:
   - type: textarea
     attributes:
       label: Feature Description
-      description: Description of feature wanted
+      description: Description of desired feature.
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,19 @@
+<!--
+First, please ensure that the title of your PR is sufficient to include in the next changelog.
+Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.
+
+Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
+of the changelog should contain this PR's title:
+  changelog:added
+  changelog:changed
+  changelog:fixed
+  changelog:removed
+
+If you feel that this PR should not be included in the changelog, you must still label it with
+changelog:omit
+
+Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
+
 **Related PRs / Issues**:
 <!-- List any related PRs/issues here, if applicable -->
 
@@ -17,11 +33,11 @@
 <!-- must be filled out completely to be considered for merging -->
 **Contributor Checklist**:
 - [ ] Did you set `main` as the base branch?
+- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
+- [ ] Did you state the type-of-change/impact?
 - [ ] Did you delete any extraneous prints/debugging code?
+- [ ] Did you mark the PR with a `changelog:` label?
 - [ ] (If applicable) Did you add documentation for the feature?
 - [ ] (If applicable) Did you add a test demonstrating the PR?
-<!-- Do this if this PR is a bug fix that should be applied to master -->
-- [ ] (If applicable) Did you mark the PR as "Please Backport"?
-
-**Release Notes**
-<!-- Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request. -->
+<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
+- [ ] (If applicable) Did you mark the PR as `Please Backport`?

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -1,10 +1,11 @@
 name: chipyard-ci-process
 
 on:
-  # run ci on pull requests targeting main only (since the ci runs on the merge commit)
+  # run ci on pull requests targeting following branches (runs on the merge commit)
   pull_request:
     branches:
       - main
+      - '1.[0-9]*.x'
 
 env:
   tools-cache-version: v13
@@ -24,8 +25,42 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+  # Set up a set of boolean conditions to control which branches of the CI
+  # workflow will execute This is based off the conditional job execution
+  # example here: https://github.com/dorny/paths-filter#examples
+  change-filters:
+    name: filter-jobs-on-changes
+    runs-on: ubuntu-latest
+    # Queried by downstream jobs to determine if they should run.
+    outputs:
+      needs-docs:    ${{ steps.filter.outputs.docs }}
+      needs-rtl-build: ${{ steps.filter.outputs.all_count != steps.filter.outputs.skip-rtl_count }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            all:
+              - '**'
+
+            # If any of the files changed match, do a doc build
+            docs: &docs-filter
+              - 'docs/**'
+              - '.readthedocs.yml'
+
+            # If all files match to this filter, skip the main ci pipeline
+            skip-rtl:
+              - *docs-filter
+              - '**/*.md'
+              - '**/.gitignore'
+              - '.github/ISSUE_TEMPLATE/**'
+
   commit-on-master-check:
     name: commit-on-master-check
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-rtl == 'true'
     runs-on: ubuntu-latest
     container:
       image: ucbbar/chipyard-ci-image:554b436
@@ -44,6 +79,8 @@ jobs:
 
   tutorial-setup-check:
     name: tutorial-setup-check
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-rtl == 'true'
     runs-on: ubuntu-latest
     container:
       image: ucbbar/chipyard-ci-image:554b436
@@ -62,6 +99,8 @@ jobs:
 
   documentation-check:
     name: documentation-check
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-docs == 'true'
     runs-on: ubuntu-latest
     container:
       image: ucbbar/chipyard-ci-image:554b436
@@ -87,6 +126,8 @@ jobs:
 
   install-toolchains:
     name: install-toolchains
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-rtl == 'true'
     runs-on: ubuntu-latest
     container:
       image: ucbbar/chipyard-ci-image:554b436
@@ -105,6 +146,8 @@ jobs:
 
   build-extra-tests:
     name: build-extra-tests
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-rtl == 'true'
     needs: install-toolchains
     runs-on: ubuntu-latest
     container:
@@ -136,6 +179,8 @@ jobs:
 
   install-verilator-knight:
     name: install-verilator-knight
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-rtl == 'true'
     runs-on: knight
     needs: cancel-prior-workflows
     steps:
@@ -152,6 +197,8 @@ jobs:
 
   install-verilator-ferry:
     name: install-verilator-ferry
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-rtl == 'true'
     runs-on: ferry
     needs: cancel-prior-workflows
     steps:
@@ -171,6 +218,8 @@ jobs:
   # When adding new prep jobs, please add them to `needs` below
   setup-complete:
     name: setup-complete
+    needs: change-filters
+    if: needs.change-filters.outputs.needs-rtl == 'true'
     needs: [install-toolchains, install-verilator-knight, install-verilator-ferry, build-extra-tests]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -146,9 +146,8 @@ jobs:
 
   build-extra-tests:
     name: build-extra-tests
-    needs: change-filters
+    needs: [change-filters, install-toolchains]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    needs: install-toolchains
     runs-on: ubuntu-latest
     container:
       image: ucbbar/chipyard-ci-image:554b436
@@ -179,10 +178,9 @@ jobs:
 
   install-verilator-knight:
     name: install-verilator-knight
-    needs: change-filters
+    needs: [change-filters, cancel-prior-workflows]
     if: needs.change-filters.outputs.needs-rtl == 'true'
     runs-on: knight
-    needs: cancel-prior-workflows
     steps:
       - name: Delete old checkout
         run: |
@@ -197,10 +195,9 @@ jobs:
 
   install-verilator-ferry:
     name: install-verilator-ferry
-    needs: change-filters
+    needs: [change-filters, cancel-prior-workflows]
     if: needs.change-filters.outputs.needs-rtl == 'true'
     runs-on: ferry
-    needs: cancel-prior-workflows
     steps:
       - name: Delete old checkout
         run: |
@@ -218,8 +215,6 @@ jobs:
   # When adding new prep jobs, please add them to `needs` below
   setup-complete:
     name: setup-complete
-    needs: change-filters
-    if: needs.change-filters.outputs.needs-rtl == 'true'
     needs: [install-toolchains, install-verilator-knight, install-verilator-ferry, build-extra-tests]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -34,7 +34,7 @@ jobs:
     # Queried by downstream jobs to determine if they should run.
     outputs:
       needs-docs:    ${{ steps.filter.outputs.docs }}
-      needs-rtl-build: ${{ steps.filter.outputs.all_count != steps.filter.outputs.skip-rtl_count }}
+      needs-rtl: ${{ steps.filter.outputs.all_count != steps.filter.outputs.skip-rtl_count }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     # Queried by downstream jobs to determine if they should run.
     outputs:
-      needs-docs:    ${{ steps.filter.outputs.docs }}
       needs-rtl: ${{ steps.filter.outputs.all_count != steps.filter.outputs.skip-rtl_count }}
 
     steps:
@@ -100,7 +99,6 @@ jobs:
   documentation-check:
     name: documentation-check
     needs: change-filters
-    if: needs.change-filters.outputs.needs-docs == 'true'
     runs-on: ubuntu-latest
     container:
       image: ucbbar/chipyard-ci-image:554b436

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,24 @@
+pull_request_rules:
+  # For Chipyard version 1.x.y, here let x = minor, y = patch
+  # Only support backporting to the last minor release branch.
+  # This rule will need to be updated on minor releases.
+  - name: backport to latest minor release
+    conditions:
+      - merged
+      - base=main
+      - label="Please Backport"
+    actions:
+      backport:
+        branches:
+          - 1.13.x
+        ignore_conflicts: True
+        label_conflicts: "bp-conflict"
+      label:
+        add: [Backported]
+
+  - name: label Mergify backport PR
+    conditions:
+      - body~=This is an automated backport of pull request \#\d+ d
+    actions:
+      label:
+        add: [Backport]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,7 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - 1.13.x
+          - 1.6.x
         ignore_conflicts: True
         label_conflicts: "bp-conflict"
       label:


### PR DESCRIPTION
**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Did you delete any extraneous prints/debugging code?
- [x] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bug fix that should be applied to master -->
- [x] (If applicable) Did you mark the PR as "Please Backport"?

**Release Notes**
This PR is copying FireSim's automation for CI which does the following:
- Selectively run certain parts of the CI pipeline based on the files added
- If a backport request is asked, have mergify automate the backport PR (if a label called "Please Backport" is added)
- Use labels to determine what to put in a future changelog (not implemented yet, but figured it would be good to copy this)

Additionally, this PR changes a bit of the wording of the issue/PR templates (in addition to adding new fields specifying what users should do for automation).

Not necessarily part of this PR... but I created a new `1.6.x` branch which should be updated with the "Please backport" label.