### PR TITLE
remove objectmodule

### DIFF
--- a/generators/chipyard/src/main/scala/Subsystem.scala
+++ b/generators/chipyard/src/main/scala/Subsystem.scala
@@ -13,8 +13,8 @@ import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.devices.debug.{HasPeripheryDebug, HasPeripheryDebugModuleImp, ExportDebug, DebugModuleKey}
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.model.{OMInterrupt}
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{RocketTileLogicalTreeNode, LogicalModuleTree}
+
+
 import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.interrupts._

--- a/generators/chipyard/src/main/scala/example/TutorialTile.scala
+++ b/generators/chipyard/src/main/scala/example/TutorialTile.scala
@@ -7,7 +7,7 @@ import freechips.rocketchip.config._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink._
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.diplomaticobjectmodel.logicaltree.{LogicalTreeNode}
+
 import freechips.rocketchip.rocket._
 import freechips.rocketchip.subsystem.{RocketCrossingParams}
 import freechips.rocketchip.tilelink._


### PR DESCRIPTION
This is needed for RC bumping after chipsalliance/rocket-chip#2967 get merged. 