### PR TITLE
disable all the boosts for spike

### DIFF
--- a/scripts/build-toolchains.sh
+++ b/scripts/build-toolchains.sh
@@ -156,7 +156,7 @@ fi
 
 # disable boost explicitly for https://github.com/riscv-software-src/riscv-isa-sim/issues/834
 # since we don't have it in our requirements
-module_all riscv-isa-sim --prefix="${RISCV}" --with-boost=no
+module_all riscv-isa-sim --prefix="${RISCV}" --with-boost=no --with-boost-asio=no --with-boost-regex=no
 # build static libfesvr library for linking into firesim driver (or others)
 echo '==>  Installing libfesvr static library'
 module_make riscv-isa-sim libfesvr.a


### PR DESCRIPTION
It's configure script is weird and you have to set three options to 'no' to disable
boost otherwise it will fail to configure in the presence of conda's boost.

We don't want or need the boost optional features of spike, so really disable it.

The disable I did in #1140 is enough when Boost is not installed.  However, when it is installed, you really do need to have all three options set to `no`.  Boost is now pulled in transitively when xilinx-xrt is installed into the conda environment.

I imagine that others may have run into this when using a system that had Boost installed via something other than the Firesim machine-launch-script.sh.

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [X] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [X] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `main` as the base branch?
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you mark the PR with a `changelog:` label?
- [X] (If applicable) Did you add documentation for the feature?
- [X] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
