### PR TITLE
Stage: avoid naming targets listed in RocketChiselStage

### DIFF
--- a/generators/chipyard/src/main/scala/stage/ChipyardStage.scala
+++ b/generators/chipyard/src/main/scala/stage/ChipyardStage.scala
@@ -19,14 +19,8 @@ class ChipyardStage extends ChiselStage {
     Dependency[freechips.rocketchip.stage.phases.Checks],
     Dependency[freechips.rocketchip.stage.phases.TransformAnnotations],
     Dependency[freechips.rocketchip.stage.phases.PreElaboration],
-    Dependency[chisel3.stage.phases.Checks],
-    Dependency[chisel3.stage.phases.Elaborate],
-    Dependency[freechips.rocketchip.stage.phases.GenerateROMs],
-    Dependency[chisel3.stage.phases.AddImplicitOutputFile],
-    Dependency[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
-    Dependency[chisel3.stage.phases.MaybeAspectPhase],
-    Dependency[chisel3.stage.phases.Emitter],
-    Dependency[chisel3.stage.phases.Convert],
+    // Note: Dependency[RocketChiselStage] is not listed here because it is
+    // package private, however it is named as a prereq for the passes below.
     Dependency[freechips.rocketchip.stage.phases.GenerateFirrtlAnnos],
     Dependency[freechips.rocketchip.stage.phases.AddDefaultTests],
     Dependency[chipyard.stage.phases.AddDefaultTests],


### PR DESCRIPTION
With the previous list of targets some phases are reinvoked when RocketChiselStage is run, namely the convert phase, which results in double emission of each elaboration-generated FIRRTL annotation.  So I removed all of the targets that will be run by the RocketChiselStage.

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
