### PR TITLE
DROMAJO_ROM variable fix

### DIFF
--- a/tools/dromajo/dromajo.mk
+++ b/tools/dromajo/dromajo.mk
@@ -7,7 +7,7 @@ DROMAJO_LIB_NAME = dromajo_cosim
 DROMAJO_LIB = $(DROMAJO_DIR)/lib$(DROMAJO_LIB_NAME).a
 
 # Dromajo assumes using the default bootrom
-DROMAJO_ROM = $(base_dir)/generators/testchipip/src/main/resources/testchipip/bootrom/bootrom.rv64.img
+DROMAJO_ROM = $(build_dir)/bootrom.rv64.img
 
 DTS_FILE = $(build_dir)/$(long_name).dts
 DROMAJO_DTB = $(build_dir)/$(long_name).dtb

--- a/tools/dromajo/dromajo.mk
+++ b/tools/dromajo/dromajo.mk
@@ -7,7 +7,7 @@ DROMAJO_LIB_NAME = dromajo_cosim
 DROMAJO_LIB = $(DROMAJO_DIR)/lib$(DROMAJO_LIB_NAME).a
 
 # Dromajo assumes using the default bootrom
-DROMAJO_ROM = $(base_dir)/bootrom/bootrom.rv64.img
+DROMAJO_ROM = $(base_dir)/generators/testchipip/src/main/resources/testchipip/bootrom/bootrom.rv64.img
 
 DTS_FILE = $(build_dir)/$(long_name).dts
 DROMAJO_DTB = $(build_dir)/$(long_name).dtb


### PR DESCRIPTION
`DROMAJO_ROM `needs to point at `bootrom.rv64.img` which exists at `$(base_dir)/generators/testchipip/src/main/resources/testchipip/bootrom/bootrom.rv64.img` instead of `$(base_dir)/bootrom/bootrom.rv64.img`

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [x] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] (If applicable) Did you mark the PR as `Please Backport`?
