### PR TITLE
Fix DefaultClockFrequencyKey rounding

### DIFF
--- a/generators/chipyard/src/main/scala/config/fragments/ClockingFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/ClockingFragments.scala
@@ -38,17 +38,17 @@ class WithTileFrequency(fMHz: Double, hartId: Option[Int] = None) extends ClockN
   fMHz)
 
 class WithPeripheryBusFrequencyAsDefault extends Config((site, here, up) => {
-  case DefaultClockFrequencyKey => (site(PeripheryBusKey).dtsFrequency.get / (1000 * 1000)).toDouble
+  case DefaultClockFrequencyKey => (site(PeripheryBusKey).dtsFrequency.get.toDouble / (1000 * 1000))
 })
 
 class WithSystemBusFrequencyAsDefault extends Config((site, here, up) => {
-  case DefaultClockFrequencyKey => (site(SystemBusKey).dtsFrequency.get / (1000 * 1000)).toDouble
+  case DefaultClockFrequencyKey => (site(SystemBusKey).dtsFrequency.get.toDouble / (1000 * 1000))
 })
 
 class BusFrequencyAssignment[T <: HasTLBusParams](re: Regex, key: Field[T]) extends Config((site, here, up) => {
   case ClockFrequencyAssignersKey => up(ClockFrequencyAssignersKey, site) ++
     Seq((cName: String) => site(key).dtsFrequency.flatMap { f =>
-      re.findFirstIn(cName).map {_ => (f / (1000 * 1000)).toDouble }
+      re.findFirstIn(cName).map {_ => (f.toDouble / (1000 * 1000)) }
     })
 })
 


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

This pull request fixes the frequency rounding for `DefaultClockFrequencyKey`. Before this change, setting the PBus frequency to a non integer value and using the `WithPeripheryBusFrequencyAsDefault` trait would make the default clock frequency and the PBus frequency differ when they should be the same.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
