### PR TITLE
Fix build-toolchains for conda-free users

### DIFF
--- a/scripts/build-toolchain-extra.sh
+++ b/scripts/build-toolchain-extra.sh
@@ -60,16 +60,22 @@ do
     shift
 done
 
-if [ "$FORCE" = false ]; then
+if [ "$FORCE" = true ]; then
+    if [ -z "$RISCV" ] ; then
+        error "ERROR: -f/--f requires also passing --prefix"
+        exit 1
+    fi
+else
     if [ -z ${CONDA_DEFAULT_ENV+x} ]; then
         error "ERROR: No conda environment detected. Did you activate the conda environment (e.x. 'conda activate chipyard')?"
         exit 1
     fi
+    if [ -z "$RISCV" ] ; then
+        RISCV="$CONDA_PREFIX/$TOOLCHAIN"
+    fi
 fi
 
-if [ -z "$RISCV" ] ; then
-    RISCV="$CONDA_PREFIX/$TOOLCHAIN"
-fi
+
 
 XLEN=64
 


### PR DESCRIPTION
Don't merge until after 1.8.1

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
