### PR TITLE
Remove conda from build-toolchains-extra.sh

### DIFF
--- a/.github/actions/create-conda-env/action.yml
+++ b/.github/actions/create-conda-env/action.yml
@@ -23,10 +23,10 @@ runs:
           if [[ "${{ inputs.install-collateral }}" == 'true' ]]; then
             echo "Add extra toolchain collateral to RISC-V install area"
             conda activate ${{ env.conda-env-name-no-time }}-$(date --date "${{ env.workflow-timestamp }}" +%Y%m%d)-riscv-tools
-            ./scripts/build-toolchain-extra.sh riscv-tools
+            ./scripts/build-toolchain-extra.sh riscv-tools -p $CONDA_PREFIX/riscv-tools
             conda deactivate
             conda activate ${{ env.conda-env-name-no-time }}-$(date --date "${{ env.workflow-timestamp }}" +%Y%m%d)-esp-tools
-            ./scripts/build-toolchain-extra.sh esp-tools
+            ./scripts/build-toolchain-extra.sh esp-tools -p $CONDA_PREFIX/esp-tools
             conda deactivate
           fi
         fi

--- a/scripts/build-setup.sh
+++ b/scripts/build-setup.sh
@@ -117,7 +117,16 @@ if do_skip "2"; then
 fi
 
 if do_skip "3"; then
-    $RDIR/scripts/build-toolchain-extra.sh $FORCE_FLAG $TOOLCHAIN_TYPE
+    if do_skip "1"; then
+        PREFIX=$CONDA_PREFIX/$TOOLCHAIN_TYPE
+    else
+        if [ -z "$RISCV" ] ; then
+            error "ERROR: If conda initialization skipped, \$RISCV variable must be defined."
+            exit 1
+        fi
+        PREFIX=$RISCV
+    fi
+    $RDIR/scripts/build-toolchain-extra.sh $TOOLCHAIN_TYPE -p $PREFIX
 fi
 
 if do_skip "4"; then

--- a/scripts/build-toolchain-extra.sh
+++ b/scripts/build-toolchain-extra.sh
@@ -23,11 +23,8 @@ usage() {
     echo "   esp-tools: if set, builds esp-tools toolchain used for the hwacha vector accelerator"
     echo ""
     echo "Options"
-    echo "   --prefix PREFIX       : Install destination. If unset, defaults to $CONDA_PREFIX/riscv-tools"
-    echo "                           or $CONDA_PREFIX/esp-tools"
+    echo "   --prefix -p PREFIX    : Install destination."
     echo "   --clean-after-install : Run make clean in calls to module_make and module_build"
-    echo "   --force -f            : Skip prompt checking for conda"
-    echo "   --skip-validate       : DEPRECATED: Same functionality as --force"
     echo "   --help -h             : Display this message"
     exit "$1"
 }
@@ -50,9 +47,6 @@ do
             CLEANAFTERINSTALL="true" ;;
         riscv-tools | esp-tools)
             TOOLCHAIN=$1 ;;
-        --force | -f | --skip-validate)
-            FORCE=true;
-            ;;
         * )
             error "invalid option $1"
             usage 1 ;;
@@ -60,15 +54,8 @@ do
     shift
 done
 
-if [ "$FORCE" = false ]; then
-    if [ -z ${CONDA_DEFAULT_ENV+x} ]; then
-        error "ERROR: No conda environment detected. Did you activate the conda environment (e.x. 'conda activate chipyard')?"
-        exit 1
-    fi
-fi
-
 if [ -z "$RISCV" ] ; then
-    RISCV="$CONDA_PREFIX/$TOOLCHAIN"
+    error "ERROR: Prefix not given. If conda is sourced, do you mean $CONDA_PREFIX/$TOOLCHAIN?"
 fi
 
 XLEN=64
@@ -108,7 +95,7 @@ echo '==> Installing espresso logic minimizer'
     git submodule update --init --checkout generators/constellation
     cd generators/constellation
     scripts/install-espresso.sh $RISCV
-)   
+)
 
 # Common tools (not in any particular toolchain dir)
 


### PR DESCRIPTION
Rework of #1259 to better support non-conda users. Removes conda variables from `build-toolchain-extra.sh`. `build-setup.sh` now needs `RISCV` defined if users are skipping conda.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [x] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [x] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] (If applicable) Did you mark the PR as `Please Backport`?
