### PR TITLE
Config finder `make` target

### DIFF
--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -81,6 +81,19 @@ jobs:
           export MAKEFLAGS="-j32"
           ./build-setup.sh -f
 
+  run-cfg-finder:
+    name: run-cfg-finder
+    needs: [setup-repo]
+    runs-on: ferry
+    steps:
+      - name: Run config finder
+        run: |
+          cd ${{ env.REMOTE_WORK_DIR }}
+          eval "$(conda shell.bash hook)"
+          source env.sh
+          cd sims/verilator
+          make find-config-fragments
+
   run-tutorial:
     name: run-tutorial
     needs: [setup-repo]

--- a/common.mk
+++ b/common.mk
@@ -48,7 +48,7 @@ HELP_COMMANDS += \
 "   run-tests                   = run all assembly and benchmark tests" \
 "   launch-sbt                  = start sbt terminal" \
 "   {shutdown,start}-sbt-server = shutdown or start sbt server if using ENABLE_SBT_THIN_CLIENT" \
-"   find-config-fragments       = list all config. fragments and their locations"
+"   find-config-fragments       = list all config. fragments and their locations (recursive up to CONFIG_FRAG_LEVELS=$(CONFIG_FRAG_LEVELS))"
 
 #########################################################################################
 # include additional subproject make fragments
@@ -378,10 +378,18 @@ start-sbt-server: check-thin-client
 #########################################################################################
 # print help text (and other help)
 #########################################################################################
+# helper to add newlines (avoid bash argument too long)
+define \n
+
+
+endef
+
 CONFIG_FRAG_LEVELS ?= 3
 .PHONY: find-config-fragments
 find-config-fragments: $(SCALA_SOURCES)
-	@$(base_dir)/scripts/config-finder.py -l $(CONFIG_FRAG_LEVELS) $^
+	rm -rf /tmp/scala_files.f
+	@$(foreach file,$(SCALA_SOURCES),echo $(file) >> /tmp/scala_files.f${\n})
+	$(base_dir)/scripts/config-finder.py -l $(CONFIG_FRAG_LEVELS) /tmp/scala_files.f
 
 .PHONY: help
 help:

--- a/common.mk
+++ b/common.mk
@@ -48,6 +48,7 @@ HELP_COMMANDS += \
 "   run-tests                   = run all assembly and benchmark tests" \
 "   launch-sbt                  = start sbt terminal" \
 "   {shutdown,start}-sbt-server = shutdown or start sbt server if using ENABLE_SBT_THIN_CLIENT" \
+"   find-config-fragments       = list all config. fragments and their locations"
 
 #########################################################################################
 # include additional subproject make fragments
@@ -375,8 +376,12 @@ start-sbt-server: check-thin-client
 	cd $(base_dir) && $(SBT) "exit"
 
 #########################################################################################
-# print help text
+# print help text (and other help)
 #########################################################################################
+.PHONY: find-config-fragments
+find-config-fragments: $(SCALA_SOURCES)
+	@$(base_dir)/scripts/config-finder.py $^
+
 .PHONY: help
 help:
 	@for line in $(HELP_LINES); do echo "$$line"; done

--- a/common.mk
+++ b/common.mk
@@ -378,9 +378,10 @@ start-sbt-server: check-thin-client
 #########################################################################################
 # print help text (and other help)
 #########################################################################################
+CONFIG_FRAG_LEVELS ?= 3
 .PHONY: find-config-fragments
 find-config-fragments: $(SCALA_SOURCES)
-	@$(base_dir)/scripts/config-finder.py $^
+	@$(base_dir)/scripts/config-finder.py -l $(CONFIG_FRAG_LEVELS) $^
 
 .PHONY: help
 help:

--- a/docs/Customization/Keys-Traits-Configs.rst
+++ b/docs/Customization/Keys-Traits-Configs.rst
@@ -75,3 +75,9 @@ We can use this config fragment when composing our configs.
 
 .. note::
    Readers who want more information on the configuration system may be interested in reading :ref:`cdes`.
+
+Chipyard Config Fragments
+-------------------------
+
+For discoverability, users can run ``make find-config-fragments`` to see a list of config. fragments and their file path
+in a fully initialized Chipyard repository.

--- a/docs/Customization/Keys-Traits-Configs.rst
+++ b/docs/Customization/Keys-Traits-Configs.rst
@@ -79,5 +79,5 @@ We can use this config fragment when composing our configs.
 Chipyard Config Fragments
 -------------------------
 
-For discoverability, users can run ``make find-config-fragments`` to see a list of config. fragments and their file path
-in a fully initialized Chipyard repository.
+For discoverability, users can run ``make find-config-fragments`` to see a list of config. fragments
+(config. fragments that match "class NAME extends CONFIG\n" on a single line and a subset of their children) and their file path in a fully initialized Chipyard repository.

--- a/scripts/config-finder.py
+++ b/scripts/config-finder.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+from collections import defaultdict
+import re
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='Pretty print all configs given a list of scala files')
+  parser.add_argument('FILES', metavar="FILE", type=str, nargs="+", help='File(s) to search within')
+  args = parser.parse_args()
+
+  cmd = ['grep', '-o', r"class \+.* \+extends \+Config"] + args.FILES
+  r = subprocess.run(cmd, check=True, capture_output=True)
+
+  file_path_dict = defaultdict(list)
+  for l in r.stdout.decode("UTF-8").splitlines():
+    match = re.match(r"^(.*):class +([a-zA-Z_$][a-zA-Z\d_$]*).* +extends", l)
+    if match:
+      file_path_dict[match.group(1)].append(match.group(2))
+
+  for k, v in file_path_dict.items():
+    print(f"In file: {k}")
+    for e in v:
+      print(f"  {e}")
+    print("\n")

--- a/scripts/config-finder.py
+++ b/scripts/config-finder.py
@@ -4,23 +4,69 @@ import argparse
 import subprocess
 from collections import defaultdict
 import re
+from copy import deepcopy
+import os
+
+cy_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+# from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
+def deep_merge(a: dict, b: dict) -> dict:
+    """Merge two dicts and return a singular dict"""
+    result = deepcopy(a)
+    for bk, bv in b.items():
+        av = result.get(bk)
+        if isinstance(av, dict) and isinstance(bv, dict):
+            result[bk] = deep_merge(av, bv)
+        else:
+            result[bk] = deepcopy(bv)
+    return result
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Pretty print all configs given a list of scala files')
   parser.add_argument('FILES', metavar="FILE", type=str, nargs="+", help='File(s) to search within')
+  parser.add_argument('-l', '--levels', default=0, type=int, help='Number of levels to recursively look for configs')
   args = parser.parse_args()
 
   cmd = ['grep', '-o', r"class \+.* \+extends \+Config"] + args.FILES
   r = subprocess.run(cmd, check=True, capture_output=True)
 
-  file_path_dict = defaultdict(list)
+  base_file_path_dict = defaultdict(list)
   for l in r.stdout.decode("UTF-8").splitlines():
     match = re.match(r"^(.*):class +([a-zA-Z_$][a-zA-Z\d_$]*).* +extends", l)
     if match:
-      file_path_dict[match.group(1)].append(match.group(2))
+      base_file_path_dict[match.group(1)].append(match.group(2))
 
-  for k, v in file_path_dict.items():
-    print(f"In file: {k}")
+  levels = []
+  for level in range(args.levels):
+    if level == 0:
+      # use the base
+      dict_to_use = base_file_path_dict
+    else:
+      # use the level-1 dict
+      assert len(levels) > 0
+      dict_to_use = levels[-1]
+
+    file_path_dict = defaultdict(list)
+
+    for configs in dict_to_use.values():
+      for config in configs:
+        cmd = ['grep', '-o', r"class \+.* \+extends \+" + f"{config}"] + args.FILES
+        r = subprocess.run(cmd, capture_output=True)
+
+        for l in r.stdout.decode("UTF-8").splitlines():
+          match = re.match(r"^(.*):class +([a-zA-Z_$][a-zA-Z\d_$]*).* +extends", l)
+          if match:
+            file_path_dict[match.group(1)].append(match.group(2))
+
+    levels.append(file_path_dict)
+
+  final_dict = base_file_path_dict
+  for dct in levels:
+    final_dict = deep_merge(final_dict, dct)
+
+  print(f"Finding all one-line config. fragments (up to {args.levels} levels)\n")
+  for k, v in final_dict.items():
+    print(f"{k.replace(cy_path, 'chipyard')}:")
     for e in v:
       print(f"  {e}")
-    print("\n")
+    print("")

--- a/scripts/config-finder.py
+++ b/scripts/config-finder.py
@@ -22,12 +22,16 @@ def deep_merge(a: dict, b: dict) -> dict:
     return result
 
 if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description='Pretty print all configs given a list of scala files')
-  parser.add_argument('FILES', metavar="FILE", type=str, nargs="+", help='File(s) to search within')
+  parser = argparse.ArgumentParser(description='Pretty print all configs given a filelist of scala files')
+  parser.add_argument('FILE', type=str, help='Filelist of scala files to search within')
   parser.add_argument('-l', '--levels', default=0, type=int, help='Number of levels to recursively look for configs')
   args = parser.parse_args()
 
-  cmd = ['grep', '-o', r"class \+.* \+extends \+Config"] + args.FILES
+  files = []
+  with open(args.FILE, 'r') as f:
+    files = f.read().splitlines()
+
+  cmd = ['grep', '-o', r"class \+.* \+extends \+Config"] + files
   r = subprocess.run(cmd, check=True, capture_output=True)
 
   base_file_path_dict = defaultdict(list)
@@ -50,7 +54,7 @@ if __name__ == "__main__":
 
     for configs in dict_to_use.values():
       for config in configs:
-        cmd = ['grep', '-o', r"class \+.* \+extends \+" + f"{config}"] + args.FILES
+        cmd = ['grep', '-o', r"class \+.* \+extends \+" + f"{config}"] + files
         r = subprocess.run(cmd, capture_output=True)
 
         for l in r.stdout.decode("UTF-8").splitlines():


### PR DESCRIPTION
Adds a new target to help users find *some* config fragments (also adds to the docs on how to use it).

Unfortunately, I wanted to do this through Scala reflection, however, that isn't possible since you can only look at the subclasses of `sealed` traits/classes. This is a simple solution that covers large majority of configs (assuming config. fragments are defined on a single line - "class NAME extends CONFIG\n"). This doesn't cover configs that don't inherit directly from `Config`... I don't have time to do that right now (or figure out a better way).

TODO:
- [ ] Right now just finds configs that are on the same line (`class NAME extends Config\n`). Extend this to match on multi-line (is there a scala-parser in Python that we can just read the scala file and see if there is an object that matches this).
- [x] Do successive greps through the code base to find child classes that extend from the main class (stop after a certain depth)

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [x] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [x] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] (If applicable) Did you mark the PR as `Please Backport`?
