### PR TITLE
Split up RocketConfigs.scala

### DIFF
--- a/docs/Advanced-Concepts/Chip-Communication.rst
+++ b/docs/Advanced-Concepts/Chip-Communication.rst
@@ -98,7 +98,7 @@ As a reminder, to run a software RTL simulation, run:
 If you would like to build and simulate a Chipyard configuration with a DTM configured for DMI communication,
 then you must tie-off the serial-link interface, and instantiate the `SimDTM`.
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
     :language: scala
     :start-after: DOC include start: DmiRocket
     :end-before: DOC include end: DmiRocket

--- a/docs/Customization/DMA-Devices.rst
+++ b/docs/Customization/DMA-Devices.rst
@@ -31,7 +31,7 @@ Once we've created our top-level module including the DMA widget, we can create 
     :start-after: DOC include start: WithInitZero
     :end-before: DOC include end: WithInitZero
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
     :language: scala
     :start-after: DOC include start: InitZeroRocketConfig
     :end-before: DOC include end: InitZeroRocketConfig

--- a/docs/Customization/Dsptools-Blocks.rst
+++ b/docs/Customization/Dsptools-Blocks.rst
@@ -91,14 +91,14 @@ Once again following the path of the previous MMIO example, we now want to mix o
     :start-after: DOC include start: DigitalTop
     :end-before: DOC include end: DigitalTop
 
-Finally, we create the configuration class in ``generators/chipyard/src/main/scala/config/RocketConfigs.scala`` that uses the ``WithFIR`` mixin defined in ``generators/chipyard/src/main/scala/example/dsptools/GenericFIR.scala``.
+Finally, we create the configuration class in ``generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala`` that uses the ``WithFIR`` mixin defined in ``generators/chipyard/src/main/scala/example/dsptools/GenericFIR.scala``.
 
 .. literalinclude:: ../../generators/chipyard/src/main/scala/example/dsptools/GenericFIR.scala
     :language: scala
     :start-after: DOC include start: WithStreamingFIR
     :end-before: DOC include end: WithStreamingFIR
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
     :language: scala
     :start-after: DOC include start: StreamingFIRRocketConfig
     :end-before: DOC include end: StreamingFIRRocketConfig

--- a/docs/Customization/Incorporating-Verilog-Blocks.rst
+++ b/docs/Customization/Incorporating-Verilog-Blocks.rst
@@ -116,7 +116,7 @@ Defining a Chip with a BlackBox
 Since we've parameterized the GCD instantiation to choose between the
 Chisel and the Verilog module, creating a config is easy.
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
     :language: scala
     :start-after: DOC include start: GCDAXI4BlackBoxRocketConfig
     :end-before: DOC include end: GCDAXI4BlackBoxRocketConfig

--- a/docs/Customization/Keys-Traits-Configs.rst
+++ b/docs/Customization/Keys-Traits-Configs.rst
@@ -68,7 +68,7 @@ For example, the ``WithGCD`` config fragment is parameterized by the type of GCD
 
 We can use this config fragment when composing our configs.
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
     :language: scala
     :start-after: DOC include start: GCDTLRocketConfig
     :end-before: DOC include end: GCDTLRocketConfig

--- a/docs/Customization/MMIO-Peripherals.rst
+++ b/docs/Customization/MMIO-Peripherals.rst
@@ -105,14 +105,14 @@ The ``DigitalTopModule`` class is the actual RTL that gets synthesized.
 
 
 
-And finally, we create a configuration class in ``generators/chipyard/src/main/scala/config/RocketConfigs.scala`` that uses the ``WithGCD`` config fragment defined earlier.
+And finally, we create a configuration class in ``generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala`` that uses the ``WithGCD`` config fragment defined earlier.
 
 .. literalinclude:: ../../generators/chipyard/src/main/scala/example/GCD.scala
     :language: scala
     :start-after: DOC include start: GCD config fragment
     :end-before: DOC include end: GCD config fragment
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
     :language: scala
     :start-after: DOC include start: GCDTLRocketConfig
     :end-before: DOC include end: GCDTLRocketConfig

--- a/docs/Customization/Memory-Hierarchy.rst
+++ b/docs/Customization/Memory-Hierarchy.rst
@@ -42,15 +42,9 @@ The System Bus
 --------------
 
 The system bus is the TileLink network that sits between the tiles and the L2
-agents and MMIO peripherals. Ordinarily, it is a fully-connected crossbar,
-but TestChipIP provides a version that uses a ring network instead. This can
-be useful when taping out larger systems. To use  the ring network system
-bus, simply add the ``WithRingSystemBus`` config fragment to your configuration.
-
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
-    :language: scala
-    :start-after: DOC include start: RingSystemBusRocket
-    :end-before: DOC include end: RingSystemBusRocket
+agents and MMIO peripherals. Ordinarily, it is a fully-connected crossbar, but
+a network-on-chip-based implementation can be generated using Constellation.
+See :ref:`Customization/NoC-SoCs:SoCs with NoC-based Interconnects` for more.
 
 The SiFive L2 Cache
 -------------------

--- a/docs/Customization/NoC-SoCs.rst
+++ b/docs/Customization/NoC-SoCs.rst
@@ -1,3 +1,5 @@
+.. _noc-socs:
+
 SoCs with NoC-based Interconnects
 ==================================
 

--- a/docs/Generators/SiFive-Generators.rst
+++ b/docs/Generators/SiFive-Generators.rst
@@ -31,7 +31,7 @@ This example instantiates a top-level module with include GPIO ports, and then t
 
 Finally, you add the relevant config fragment to the SoC config. For example:
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
     :language: scala
     :start-after: DOC include start: GPIORocketConfig
     :end-before: DOC include end: GPIORocketConfig

--- a/docs/Generators/fft.rst
+++ b/docs/Generators/fft.rst
@@ -7,7 +7,7 @@ Configuration
 --------------------------
 The following configuration creates an 8-point FFT:
 
-.. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala
+.. literalinclude:: ../../generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
    :language: scala
    :start-after: DOC include start: FFTRocketConfig
    :end-before: DOC include end: FFTRocketConfig

--- a/generators/chipyard/src/main/scala/config/BoomConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/BoomConfigs.scala
@@ -34,13 +34,6 @@ class Cloned64MegaBoomConfig extends Config(
   new chipyard.config.WithSystemBusWidth(128) ++
   new chipyard.config.AbstractConfig)
 
-class HwachaLargeBoomConfig extends Config(
-  new chipyard.config.WithHwachaTest ++
-  new hwacha.DefaultHwachaConfig ++                              // use Hwacha vector accelerator
-  new boom.common.WithNLargeBooms(1) ++
-  new chipyard.config.WithSystemBusWidth(128) ++
-  new chipyard.config.AbstractConfig)
-
 class LoopbackNICLargeBoomConfig extends Config(
   new chipyard.harness.WithLoopbackNIC ++                        // drive NIC IOs with loopback
   new icenet.WithIceNIC ++                                       // build a NIC

--- a/generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/MMIOAcceleratorConfigs.scala
@@ -1,0 +1,58 @@
+package chipyard
+
+import freechips.rocketchip.config.{Config}
+import freechips.rocketchip.diplomacy.{AsynchronousCrossing}
+
+// ------------------------------
+// Configs with MMIO accelerators
+// ------------------------------
+
+// DOC include start: FFTRocketConfig
+class FFTRocketConfig extends Config(
+  new fftgenerator.WithFFTGenerator(numPoints=8, width=16, decPt=8) ++ // add 8-point mmio fft at the default addr (0x2400) with 16bit fixed-point numbers.
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: FFTRocketConfig
+
+// DOC include start: GCDTLRocketConfig
+class GCDTLRocketConfig extends Config(
+  new chipyard.example.WithGCD(useAXI4=false, useBlackBox=false) ++          // Use GCD Chisel, connect Tilelink
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: GCDTLRocketConfig
+
+// DOC include start: GCDAXI4BlackBoxRocketConfig
+class GCDAXI4BlackBoxRocketConfig extends Config(
+  new chipyard.example.WithGCD(useAXI4=true, useBlackBox=true) ++            // Use GCD blackboxed verilog, connect by AXI4->Tilelink
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: GCDAXI4BlackBoxRocketConfig
+
+// DOC include start: InitZeroRocketConfig
+class InitZeroRocketConfig extends Config(
+  new chipyard.example.WithInitZero(0x88000000L, 0x1000L) ++   // add InitZero
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: InitZeroRocketConfig
+
+class StreamingPassthroughRocketConfig extends Config(
+  new chipyard.example.WithStreamingPassthrough ++          // use top with tilelink-controlled streaming passthrough
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+// DOC include start: StreamingFIRRocketConfig
+class StreamingFIRRocketConfig extends Config (
+  new chipyard.example.WithStreamingFIR ++                  // use top with tilelink-controlled streaming FIR
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: StreamingFIRRocketConfig
+
+class SmallNVDLARocketConfig extends Config(
+  new nvidia.blocks.dla.WithNVDLA("small") ++               // add a small NVDLA
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class LargeNVDLARocketConfig extends Config(
+  new nvidia.blocks.dla.WithNVDLA("large", true) ++         // add a large NVDLA with synth. rams
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -1,0 +1,65 @@
+package chipyard
+
+import freechips.rocketchip.config.{Config}
+import freechips.rocketchip.diplomacy.{AsynchronousCrossing}
+
+// ---------------------------------------------------------
+// Configs which add non-default peripheral devices or ports
+// ---------------------------------------------------------
+
+class LargeSPIFlashROMRocketConfig extends Config(
+  new chipyard.harness.WithSimSPIFlashModel(true) ++        // add the SPI flash model in the harness (read-only)
+  new chipyard.config.WithSPIFlash ++                       // add the SPI flash controller
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class SmallSPIFlashRocketConfig extends Config(
+  new chipyard.harness.WithSimSPIFlashModel(false) ++       // add the SPI flash model in the harness (writeable)
+  new chipyard.config.WithSPIFlash(0x100000) ++             // add the SPI flash controller (1 MiB)
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class SimBlockDeviceRocketConfig extends Config(
+  new chipyard.harness.WithSimBlockDevice ++                // drive block-device IOs with SimBlockDevice
+  new testchipip.WithBlockDevice ++                         // add block-device module to peripherybus
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class BlockDeviceModelRocketConfig extends Config(
+  new chipyard.harness.WithBlockDeviceModel ++              // drive block-device IOs with a BlockDeviceModel
+  new testchipip.WithBlockDevice ++                         // add block-device module to periphery bus
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+// DOC include start: GPIORocketConfig
+class GPIORocketConfig extends Config(
+  new chipyard.config.WithGPIO ++                           // add GPIOs to the peripherybus
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: GPIORocketConfig
+
+class LoopbackNICRocketConfig extends Config(
+  new chipyard.harness.WithLoopbackNIC ++                      // drive NIC IOs with loopback
+  new icenet.WithIceNIC ++                                     // add an IceNIC
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class MMIORocketConfig extends Config(
+  new freechips.rocketchip.subsystem.WithDefaultMMIOPort ++  // add default external master port
+  new freechips.rocketchip.subsystem.WithDefaultSlavePort ++ // add default external slave port
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class LBWIFRocketConfig extends Config(
+  new testchipip.WithSerialTLMem(isMainMemory=true) ++      // set lbwif memory base to DRAM_BASE, use as main memory
+  new freechips.rocketchip.subsystem.WithNoMemPort ++       // remove AXI4 backing memory
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+// DOC include start: DmiRocket
+class dmiRocketConfig extends Config(
+  new chipyard.harness.WithSerialAdapterTiedOff ++               // don't attach an external SimSerial
+  new chipyard.config.WithDMIDTM ++                              // have debug module expose a clocked DMI port
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: DmiRocket

--- a/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
@@ -1,0 +1,46 @@
+package chipyard
+
+import freechips.rocketchip.config.{Config}
+import freechips.rocketchip.diplomacy.{AsynchronousCrossing}
+
+// ------------------------------
+// Configs with RoCC Accelerators
+// ------------------------------
+
+// DOC include start: GemminiRocketConfig
+class GemminiRocketConfig extends Config(
+  new gemmini.DefaultGemminiConfig ++                            // use Gemmini systolic array GEMM accelerator
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new chipyard.config.AbstractConfig)
+// DOC include end: GemminiRocketConfig
+
+class FPGemminiRocketConfig extends Config(
+  new gemmini.GemminiFP32DefaultConfig ++                         // use FP32Gemmini systolic array GEMM accelerator
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new chipyard.config.AbstractConfig)
+
+class HwachaRocketConfig extends Config(
+  new chipyard.config.WithHwachaTest ++
+  new hwacha.DefaultHwachaConfig ++                              // use Hwacha vector accelerator
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new chipyard.config.AbstractConfig)
+
+class MempressRocketConfig extends Config(
+  new mempress.WithMemPress ++                                    // use Mempress (memory traffic generation) accelerator
+  new chipyard.config.WithExtMemIdBits(7) ++                      // use 7 bits for tl like request id
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new freechips.rocketchip.subsystem.WithNBanks(8) ++
+  new freechips.rocketchip.subsystem.WithInclusiveCache(nWays=16, capacityKB=2048) ++
+  new freechips.rocketchip.subsystem.WithNMemoryChannels(4) ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class HwachaLargeBoomConfig extends Config(
+  new chipyard.config.WithHwachaTest ++
+  new hwacha.DefaultHwachaConfig ++                              // use Hwacha vector accelerator
+  new boom.common.WithNLargeBooms(1) ++
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -21,50 +21,10 @@ class TinyRocketConfig extends Config(
   new freechips.rocketchip.subsystem.With1TinyCore ++             // single tiny rocket-core
   new chipyard.config.AbstractConfig)
 
-// DOC include start: DmiRocket
-class dmiRocketConfig extends Config(
-  new chipyard.harness.WithSerialAdapterTiedOff ++               // don't attach an external SimSerial
-  new chipyard.config.WithDMIDTM ++                              // have debug module expose a clocked DMI port
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: DmiRocket
-
-
-class LargeSPIFlashROMRocketConfig extends Config(
-  new chipyard.harness.WithSimSPIFlashModel(true) ++        // add the SPI flash model in the harness (read-only)
-  new chipyard.config.WithSPIFlash ++                       // add the SPI flash controller
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
-class SmallSPIFlashRocketConfig extends Config(
-  new chipyard.harness.WithSimSPIFlashModel(false) ++       // add the SPI flash model in the harness (writeable)
-  new chipyard.config.WithSPIFlash(0x100000) ++             // add the SPI flash controller (1 MiB)
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
 class SimAXIRocketConfig extends Config(
   new chipyard.harness.WithSimAXIMem ++                     // drive the master AXI4 memory with a SimAXIMem, a 1-cycle magic memory, instead of default SimDRAM
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
-
-class SimBlockDeviceRocketConfig extends Config(
-  new chipyard.harness.WithSimBlockDevice ++                // drive block-device IOs with SimBlockDevice
-  new testchipip.WithBlockDevice ++                         // add block-device module to peripherybus
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
-class BlockDeviceModelRocketConfig extends Config(
-  new chipyard.harness.WithBlockDeviceModel ++              // drive block-device IOs with a BlockDeviceModel
-  new testchipip.WithBlockDevice ++                         // add block-device module to periphery bus
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
-// DOC include start: GPIORocketConfig
-class GPIORocketConfig extends Config(
-  new chipyard.config.WithGPIO ++                           // add GPIOs to the peripherybus
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: GPIORocketConfig
 
 class QuadRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(4) ++    // quad-core (4 RocketTiles)
@@ -82,12 +42,6 @@ class RV32RocketConfig extends Config(
 
 class GB1MemoryRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithExtMemSize((1<<30) * 1L) ++ // use 1GB simulated external memory
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
-class LoopbackNICRocketConfig extends Config(
-  new chipyard.harness.WithLoopbackNIC ++                      // drive NIC IOs with loopback
-  new icenet.WithIceNIC ++                                     // add an IceNIC
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 
@@ -122,12 +76,6 @@ class MbusScratchpadRocketConfig extends Config(
   new chipyard.config.AbstractConfig)
 // DOC include end: mbusscratchpadrocket
 
-class MMIORocketConfig extends Config(
-  new freechips.rocketchip.subsystem.WithDefaultMMIOPort ++  // add default external master port
-  new freechips.rocketchip.subsystem.WithDefaultSlavePort ++ // add default external slave port
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
 class MulticlockRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   // Frequency specifications
@@ -146,12 +94,6 @@ class MulticlockRocketConfig extends Config(
 class TestChipMulticlockRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.WithTestChipBusFreqs ++
-  new chipyard.config.AbstractConfig)
-
-class LBWIFRocketConfig extends Config(
-  new testchipip.WithSerialTLMem(isMainMemory=true) ++      // set lbwif memory base to DRAM_BASE, use as main memory
-  new freechips.rocketchip.subsystem.WithNoMemPort ++       // remove AXI4 backing memory
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 
 // DOC include start: MulticlockAXIOverSerialConfig

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -122,13 +122,6 @@ class MbusScratchpadRocketConfig extends Config(
   new chipyard.config.AbstractConfig)
 // DOC include end: mbusscratchpadrocket
 
-// DOC include start: RingSystemBusRocket
-class RingSystemBusRocketConfig extends Config(
-  new testchipip.WithRingSystemBus ++                       // Ring-topology system bus
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: RingSystemBusRocket
-
 class MMIORocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithDefaultMMIOPort ++  // add default external master port
   new freechips.rocketchip.subsystem.WithDefaultSlavePort ++ // add default external slave port

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -21,45 +21,6 @@ class TinyRocketConfig extends Config(
   new freechips.rocketchip.subsystem.With1TinyCore ++             // single tiny rocket-core
   new chipyard.config.AbstractConfig)
 
-class MempressRocketConfig extends Config(
-  new mempress.WithMemPress ++                                    // use Mempress (memory traffic generation) accelerator
-  new freechips.rocketchip.subsystem.WithNBanks(8) ++
-  new freechips.rocketchip.subsystem.WithInclusiveCache(nWays=16, capacityKB=2048) ++
-  new chipyard.config.WithExtMemIdBits(7) ++                      // use 7 bits for tl like request id
-  new freechips.rocketchip.subsystem.WithNMemoryChannels(4) ++
-  new chipyard.config.WithSystemBusWidth(128) ++
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
-// DOC include start: FFTRocketConfig
-class FFTRocketConfig extends Config(
-  new fftgenerator.WithFFTGenerator(numPoints=8, width=16, decPt=8) ++ // add 8-point mmio fft at the default addr (0x2400) with 16bit fixed-point numbers.
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: FFTRocketConfig
-
-class HwachaRocketConfig extends Config(
-  new chipyard.config.WithHwachaTest ++
-  new hwacha.DefaultHwachaConfig ++                              // use Hwacha vector accelerator
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.WithSystemBusWidth(128) ++
-  new chipyard.config.AbstractConfig)
-
-// DOC include start: GemminiRocketConfig
-class GemminiRocketConfig extends Config(
-  new gemmini.DefaultGemminiConfig ++                            // use Gemmini systolic array GEMM accelerator
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.WithSystemBusWidth(128) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: GemminiRocketConfig
-
-class FPGemminiRocketConfig extends Config(
-  new gemmini.GemminiFP32DefaultConfig ++                         // use FP32Gemmini systolic array GEMM accelerator
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.WithSystemBusWidth(128) ++
-  new chipyard.config.AbstractConfig)
-
-
 // DOC include start: DmiRocket
 class dmiRocketConfig extends Config(
   new chipyard.harness.WithSerialAdapterTiedOff ++               // don't attach an external SimSerial
@@ -68,19 +29,6 @@ class dmiRocketConfig extends Config(
   new chipyard.config.AbstractConfig)
 // DOC include end: DmiRocket
 
-// DOC include start: GCDTLRocketConfig
-class GCDTLRocketConfig extends Config(
-  new chipyard.example.WithGCD(useAXI4=false, useBlackBox=false) ++          // Use GCD Chisel, connect Tilelink
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: GCDTLRocketConfig
-
-// DOC include start: GCDAXI4BlackBoxRocketConfig
-class GCDAXI4BlackBoxRocketConfig extends Config(
-  new chipyard.example.WithGCD(useAXI4=true, useBlackBox=true) ++            // Use GCD blackboxed verilog, connect by AXI4->Tilelink
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: GCDAXI4BlackBoxRocketConfig
 
 class LargeSPIFlashROMRocketConfig extends Config(
   new chipyard.harness.WithSimSPIFlashModel(true) ++        // add the SPI flash model in the harness (read-only)
@@ -137,13 +85,6 @@ class GB1MemoryRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 
-// DOC include start: InitZeroRocketConfig
-class InitZeroRocketConfig extends Config(
-  new chipyard.example.WithInitZero(0x88000000L, 0x1000L) ++   // add InitZero
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: InitZeroRocketConfig
-
 class LoopbackNICRocketConfig extends Config(
   new chipyard.harness.WithLoopbackNIC ++                      // drive NIC IOs with loopback
   new icenet.WithIceNIC ++                                     // add an IceNIC
@@ -187,28 +128,6 @@ class RingSystemBusRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 // DOC include end: RingSystemBusRocket
-
-class StreamingPassthroughRocketConfig extends Config(
-  new chipyard.example.WithStreamingPassthrough ++          // use top with tilelink-controlled streaming passthrough
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
-// DOC include start: StreamingFIRRocketConfig
-class StreamingFIRRocketConfig extends Config (
-  new chipyard.example.WithStreamingFIR ++                  // use top with tilelink-controlled streaming FIR
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-// DOC include end: StreamingFIRRocketConfig
-
-class SmallNVDLARocketConfig extends Config(
-  new nvidia.blocks.dla.WithNVDLA("small") ++               // add a small NVDLA
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
-
-class LargeNVDLARocketConfig extends Config(
-  new nvidia.blocks.dla.WithNVDLA("large", true) ++         // add a large NVDLA with synth. rams
-  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.AbstractConfig)
 
 class MMIORocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithDefaultMMIOPort ++  // add default external master port

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -19,7 +19,6 @@ import scala.math.{min, max}
 
 import chipyard.clocking.{ChipyardPRCIControlKey}
 import icenet._
-import testchipip.WithRingSystemBus
 
 import firesim.bridges._
 import firesim.configs._
@@ -235,15 +234,6 @@ class FireSimGemminiRocketConfig extends Config(
   new WithDefaultMemModel ++
   new WithFireSimConfigTweaks ++
   new chipyard.GemminiRocketConfig)
-
-//******************************************************************
-// Configuration with Ring topology SystemBus
-//******************************************************************
-class FireSimRingSystemBusRocketConfig extends Config(
-  new WithDefaultFireSimBridges ++
-  new WithDefaultMemModel ++
-  new WithFireSimConfigTweaks ++
-  new chipyard.RingSystemBusRocketConfig)
 
 //**********************************************************************************
 // Supernode Configurations, base off chipyard's RocketConfig


### PR DESCRIPTION
Sample configs have been getting dumped into RocketConfigs. This PR splits up that file into RoCCAccelConfigs/MMIOAccelConfigs/PeripheralDeviceConfigs, to improve discoverability of features.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
