### PR TITLE
Fix VLSI input files list emission to avoid bash "too many arguments" error

### DIFF
--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -122,7 +122,7 @@ $(SYN_CONF): $(VLSI_RTL)
 	echo "synthesis.inputs:" >> $@
 	echo "  top_module: $(VLSI_TOP)" >> $@
 	echo "  input_files:" >> $@
-	for x in $(shell cat $(VLSI_RTL)); do \
+	for x in $$(cat $(VLSI_RTL)); do \
 		echo '    - "'$$x'"' >> $@; \
 	done
 

--- a/vlsi/power.mk
+++ b/vlsi/power.mk
@@ -30,7 +30,7 @@ $(POWER_RTL_CONF): $(VLSI_RTL)
 	echo "power.inputs:" >> $@
 	echo "  level: rtl" >> $@
 	echo "  input_files:" >> $@
-	for x in $(shell cat $(VLSI_RTL)); do \
+	for x in $$(cat $(VLSI_RTL)); do \
 		echo '    - "'$$x'"' >> $@; \
 	done
 

--- a/vlsi/sim.mk
+++ b/vlsi/sim.mk
@@ -10,7 +10,7 @@ $(SIM_CONF): $(sim_common_files)
 	echo "  top_module: $(VLSI_TOP)" >> $@
 	echo "  tb_name: ''" >> $@  # don't specify -top
 	echo "  input_files:" >> $@
-	for x in $(shell cat $(sim_common_files)); do \
+	for x in $$(cat $(sim_common_files)); do \
 		echo '    - "'$$x'"' >> $@; \
 	done
 	echo "  input_files_meta: 'append'" >> $@


### PR DESCRIPTION
This makes the expansion of "cat $(VLSI_RTL)" happen as a child of the shell that runs the for loop.

The existing version will sometimes produce a bash "too many arguments" error because the 

    $(shell cat $(VLSI_RTL)) 

is expanded first and then passed as a giant command to bash.


- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement


**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
