### PR TITLE
Small build system improvements

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -17,7 +17,7 @@ HELP_COMPILATION_VARIABLES += \
 "   EXTRA_SIM_SOURCES         = additional simulation sources needed for simulator" \
 "   EXTRA_SIM_REQS            = additional make requirements to build the simulator" \
 "   ENABLE_SBT_THIN_CLIENT    = if set, use sbt's experimental thin client (works best when overridding SBT_BIN with the mainline sbt script)" \
-"   ENABLE_CUSTOM_FIRRTL_PASS = if set, enable custom firrtl passes (SFC lowers to LowFIRRTL & MFC converts to Verilog) \
+"   ENABLE_CUSTOM_FIRRTL_PASS = if set, enable custom firrtl passes (SFC lowers to LowFIRRTL & MFC converts to Verilog)" \
 "   EXTRA_CHISEL_OPTIONS      = additional options to pass to the Chisel compiler" \
 "   EXTRA_FIRRTL_OPTIONS      = additional options to pass to the FIRRTL compiler"
 

--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -90,9 +90,6 @@ fpga_common_script_dir := $(fpga_dir)/common/tcl
 #########################################################################################
 # setup misc. sim files
 #########################################################################################
-SIM_FILE_REQS += \
-	$(ROCKETCHIP_RSRCS_DIR)/vsrc/EICG_wrapper.v
-
 # copy files but ignore *.h files in *.f (match vcs)
 $(sim_files): $(SIM_FILE_REQS) | $(OUT_DIR)
 	cp -f $^ $(OUT_DIR)

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -51,6 +51,7 @@ class AbstractConfig extends Config(
   new chipyard.config.WithPeripheryBusFrequencyAsDefault ++         // Unspecified frequencies with match the pbus frequency (which is always set)
   new chipyard.config.WithMemoryBusFrequency(100.0) ++              // Default 100 MHz mbus
   new chipyard.config.WithPeripheryBusFrequency(100.0) ++           // Default 100 MHz pbus
+  new freechips.rocketchip.subsystem.WithClockGateModel ++        // add default EICG_wrapper clock gate model
   new freechips.rocketchip.subsystem.WithJtagDTM ++                 // set the debug module to expose a JTAG port
   new freechips.rocketchip.subsystem.WithNoMMIOPort ++              // no top-level MMIO master port (overrides default set in rocketchip)
   new freechips.rocketchip.subsystem.WithNoSlavePort ++             // no top-level MMIO slave port (overrides default set in rocketchip)

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -51,7 +51,7 @@ class AbstractConfig extends Config(
   new chipyard.config.WithPeripheryBusFrequencyAsDefault ++         // Unspecified frequencies with match the pbus frequency (which is always set)
   new chipyard.config.WithMemoryBusFrequency(100.0) ++              // Default 100 MHz mbus
   new chipyard.config.WithPeripheryBusFrequency(100.0) ++           // Default 100 MHz pbus
-  new freechips.rocketchip.subsystem.WithClockGateModel ++        // add default EICG_wrapper clock gate model
+  new freechips.rocketchip.subsystem.WithClockGateModel ++          // add default EICG_wrapper clock gate model
   new freechips.rocketchip.subsystem.WithJtagDTM ++                 // set the debug module to expose a JTAG port
   new freechips.rocketchip.subsystem.WithNoMMIOPort ++              // no top-level MMIO master port (overrides default set in rocketchip)
   new freechips.rocketchip.subsystem.WithNoSlavePort ++             // no top-level MMIO slave port (overrides default set in rocketchip)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.8.2

--- a/sims/common-sim-flags.mk
+++ b/sims/common-sim-flags.mk
@@ -33,6 +33,3 @@ SIM_LDFLAGS = \
 	-lfesvr \
 	-ldramsim \
 	$(EXTRA_SIM_LDFLAGS)
-
-SIM_FILE_REQS += \
-	$(ROCKETCHIP_RSRCS_DIR)/vsrc/EICG_wrapper.v

--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -54,7 +54,7 @@ endif
 #########################################################################################
 # general rules
 #########################################################################################
-.PHONY: default
+.PHONY: default all
 default: all
 
 all: drc lvs
@@ -82,7 +82,6 @@ ifneq ($(CUSTOM_VLOG), )
 else
 	cat $(TOP_MODS_FILELIST) $(TOP_BB_MODS_FILELIST) | sort -u > $(VLSI_RTL)
 	echo $(TOP_SMEMS_FILE) >> $(VLSI_RTL)
-	echo $(build_dir)/EICG_wrapper.v >> $(VLSI_RTL)
 endif
 
 #########################################################################################


### PR DESCRIPTION
- Bump to SBT 1.8.2 (doesn't break anything but adds deprecation warnings)
- Have the `EICG_wrapper.v` be added by the FIRRTL `addResource/Path` call instead of manually copied. This requires adding a new config. fragment.
- Add a missing `"` to fix the `make help` formatting be correct
- Added in the VLSI `Makefile` a `.PHONY: all` to satisfy the `pre-commit` `Makefile` syntax check

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
