### PR TITLE
Update assert message if configs can't be split by `:`

### DIFF
--- a/generators/chipyard/src/main/scala/stage/ChipyardAnnotations.scala
+++ b/generators/chipyard/src/main/scala/stage/ChipyardAnnotations.scala
@@ -13,7 +13,7 @@ private[stage] object UnderscoreDelimitedConfigsAnnotation extends HasShellOptio
       longOption = "legacy-configs",
       toAnnotationSeq = a => {
         val split = a.split(':')
-        assert(split.length == 2)
+        assert(split.length == 2, s"'${a}' split by ':' doesn't yield two things")
         val packageName = split.head
         val configs     = split.last.split("_")
         Seq(new ConfigsAnnotation(configs map { config => if (config contains ".") s"${config}" else s"${packageName}.${config}" } ))


### PR DESCRIPTION
Taken from #872. Updates the assertion message if multiple configs concatenated cannot be split.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
