### PR TITLE
Remove chisel-testers submodule

### DIFF
--- a/.github/scripts/check-commit.sh
+++ b/.github/scripts/check-commit.sh
@@ -88,7 +88,7 @@ dir="software"
 branches=("master" "dev")
 search
 
-submodules=("DRAMSim2" "axe" "barstools" "chisel-testers" "dsptools" "rocket-dsp-utils" "torture")
+submodules=("DRAMSim2" "axe" "barstools" "dsptools" "rocket-dsp-utils" "torture")
 dir="tools"
 branches=("master" "dev")
 search

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,9 +31,6 @@
 [submodule "tools/dsptools"]
 	path = tools/dsptools
 	url = https://github.com/ucb-bar/dsptools.git
-[submodule "tools/chisel-testers"]
-	path = tools/chisel-testers
-	url = https://github.com/freechipsproject/chisel-testers.git
 [submodule "generators/sha3"]
 	path = generators/sha3
 	url = https://github.com/ucb-bar/sha3.git

--- a/docs/Tools/Chisel-Testers.rst
+++ b/docs/Tools/Chisel-Testers.rst
@@ -1,7 +1,0 @@
-Chisel Testers
-==============================
-
-`Chisel Testers <https://github.com/freechipsproject/chisel-testers>`__ is a library for writing tests for Chisel designs.
-It provides a Scala API for interacting with a DUT.
-It can use multiple backends, including things such as Treadle and Verilator.
-See :ref:`Tools/Treadle:Treadle and FIRRTL Interpreter` and :ref:`sw-rtl-sim-intro` for more information on these simulation methods.

--- a/docs/Tools/index.rst
+++ b/docs/Tools/index.rst
@@ -11,7 +11,6 @@ The following pages will introduce them, and how we can use them in order to gen
    Chisel
    FIRRTL
    Treadle
-   Chisel-Testers
    Dsptools
    Barstools
    Dromajo


### PR DESCRIPTION
Since this is managed by SBT/maven now, we shouldn't need this submodule.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [x] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [x] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] (If applicable) Did you mark the PR as `Please Backport`?
