### PR TITLE
Remove stale conda env's after 2 days

### DIFF
--- a/.github/actions/cleanup-conda/action.yml
+++ b/.github/actions/cleanup-conda/action.yml
@@ -22,7 +22,7 @@ runs:
             echo "Skipping removal of $envname since it cannot be parsed into a date"
           else
             NUM_DIFF=$(( ( $(date +%s) - $(date --date="$ENV_DATE" +%s) )/(60*60*24) ))
-            if (( $NUM_DIFF > 7 )); then
+            if (( $NUM_DIFF > 2 )); then
               echo "Removing $envname since it is $NUM_DIFF days old."
               conda env remove -n $envname
             else


### PR DESCRIPTION
See title. Instead of waiting 7 days to remove conda envs, delete after 2 days. This should add marginal slowdowns if a PR hasn't committed in 2 days (i.e. refetch deps). Functionally this shouldn't change the CI.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
