### PR TITLE
Fix Verilog Prerequisites + Ignore `mv` stdout

### DIFF
--- a/generators/chipyard/src/main/resources/csrc/cospike.cc
+++ b/generators/chipyard/src/main/resources/csrc/cospike.cc
@@ -70,7 +70,7 @@ extern "C" void cospike_cosim(long long int cycle,
   if (!sim) {
     printf("Configuring spike cosim\n");
     std::vector<mem_cfg_t> mem_cfg;
-    std::vector<int> hartids;
+    std::vector<size_t> hartids;
     mem_cfg.push_back(mem_cfg_t(info->mem0_base, info->mem0_size));
     for (int i = 0; i < info->nharts; i++)
       hartids.push_back(i);

--- a/generators/chipyard/src/main/resources/csrc/spiketile.cc
+++ b/generators/chipyard/src/main/resources/csrc/spiketile.cc
@@ -75,7 +75,7 @@ public:
   void dcache_d(uint64_t sourceid, uint64_t data[8], unsigned char has_data, unsigned char grantack);
   void drain_stq();
   bool stq_empty() { return st_q.size() == 0; };
-  
+
   ~chipyard_simif_t() { };
   chipyard_simif_t(size_t icache_ways,
                    size_t icache_sets,
@@ -262,7 +262,7 @@ extern "C" void spike_tile(int hartid, char* isa,
                            endianness_little,
                            pmpregions,
                            std::vector<mem_cfg_t>(),
-                           std::vector<int>(),
+                           std::vector<size_t>(),
                            false,
                            0);
     processor_t* p = new processor_t(isa_parser,
@@ -488,7 +488,7 @@ bool chipyard_simif_t::mmio_load(reg_t addr, size_t len, uint8_t* bytes) {
       }
     }
   }
-  
+
   if (!found) {
     return false;
   }
@@ -576,7 +576,7 @@ bool chipyard_simif_t::handle_cache_access(reg_t addr, size_t len,
       }
     }
   }
-  
+
 #define SETIDX(ADDR) ((ADDR >> 6) & (n_sets - 1))
   uint64_t setidx = SETIDX(addr);
   uint64_t offset = addr & (64 - 1);

--- a/scripts/build-toolchain-extra.sh
+++ b/scripts/build-toolchain-extra.sh
@@ -113,6 +113,7 @@ fi
 
 echo '==>  Installing DRAMSim2 Shared Library'
 cd $RDIR
+git submodule update --init tools/DRAMSim2
 cd tools/DRAMSim2
 make libdramsim.so
 cp libdramsim.so $RISCV/lib/


### PR DESCRIPTION
- Fixes issue where if you updated a Verilog file, the `SFC_LEVEL` would be not set breaking the flow. Done by moving the `VLOG_SOURCES` as a prereq of `SFC_LEVEL`.
- Adds new `ibex.mk` so that if a Ibex file is updated it would elaborate the SoC again (which would preprocess the Verilog sources)
- Ignores `mv` `stderr` output (the error code is ignored anyways by using `-`)
- #1386 never passed CI. This fixes 2 errors with the PR, not init'ing the DramSim submodule and changing the `int` to `size_t` in `cospike/spiketile.cc` so that GCC can detect that the `cfg_t` constructor is valid.

**Related PRs / Issues**:
Requires review on https://github.com/ucb-bar/ibex-wrapper/pull/5

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
