### PR TITLE
Ensure conda cleanup regex properly filters out non-numeric chars

### DIFF
--- a/.github/actions/cleanup-conda/action.yml
+++ b/.github/actions/cleanup-conda/action.yml
@@ -15,7 +15,7 @@ runs:
             conda env remove -n $env
           done
         fi
-        IS_NUMBER_REGEX='[0-9]+$'
+        IS_NUMBER_REGEX='^[0-9]+$'
         conda env list | awk '{print $1}' | tail -n +4 | while read envname; do
           ENV_DATE=$(echo $envname | sed "s/cy-[[:digit:]]\+-\(.*\)-\(riscv\|esp\)-tools/\1/")
           if ! [[ $ENV_DATE =~ $IS_NUMBER_REGEX ]]; then


### PR DESCRIPTION
See title. With the addition of new conda environments in our CI that don't match the naming scheme: `cy-<date>-<hash>-<riscv/esp>-tools` the conda cleanup script can fail blocking CI since it greedly matches any numeric character in the conda env. This fixes that issue.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
