### PR TITLE
Support banked/partitioned scratchpads

### DIFF
--- a/generators/chipyard/src/main/scala/DigitalTop.scala
+++ b/generators/chipyard/src/main/scala/DigitalTop.scala
@@ -16,7 +16,7 @@ class DigitalTop(implicit p: Parameters) extends ChipyardSystem
   with testchipip.CanHavePeripheryCustomBootPin // Enables optional custom boot pin
   with testchipip.CanHavePeripheryBootAddrReg // Use programmable boot address register
   with testchipip.CanHaveTraceIO // Enables optionally adding trace IO
-  with testchipip.CanHaveBackingScratchpad // Enables optionally adding a backing scratchpad
+  with testchipip.CanHaveBankedScratchpad // Enables optionally adding a banked scratchpad
   with testchipip.CanHavePeripheryBlockDevice // Enables optionally adding the block device
   with testchipip.CanHavePeripheryTLSerial // Enables optionally adding the backing memory and serial adapter
   with sifive.blocks.devices.i2c.HasPeripheryI2C // Enables optionally adding the sifive I2C

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -74,12 +74,18 @@ class L1ScratchpadRocketConfig extends Config(
   new chipyard.config.AbstractConfig)
 
 // DOC include start: mbusscratchpadrocket
-class MbusScratchpadRocketConfig extends Config(
-  new testchipip.WithBackingScratchpad ++                   // add mbus backing scratchpad
-  new freechips.rocketchip.subsystem.WithNoMemPort ++       // remove offchip mem port
+class MbusScratchpadOnlyRocketConfig extends Config(
+  new testchipip.WithMbusScratchpad(stripes=2, partitions=2) ++ // add 4 banks mbus backing scratchpad
+  new freechips.rocketchip.subsystem.WithNoMemPort ++         // remove offchip mem port
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 // DOC include end: mbusscratchpadrocket
+
+class SbusScratchpadRocketConfig extends Config(
+  new testchipip.WithSbusScratchpad(base=0x70000000L, stripes=2, partitions=2) ++ // add 4 lanes sbus backing scratchpad
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
 
 class MulticlockRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithAsynchronousRocketTiles(3, 3) ++ // Add async crossings between RocketTile and uncore

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -75,14 +75,14 @@ class L1ScratchpadRocketConfig extends Config(
 
 // DOC include start: mbusscratchpadrocket
 class MbusScratchpadOnlyRocketConfig extends Config(
-  new testchipip.WithMbusScratchpad(stripes=2, partitions=2) ++ // add 4 banks mbus backing scratchpad
+  new testchipip.WithMbusScratchpad(banks=2, partitions=2) ++               // add 2 partitions of 2 banks mbus backing scratchpad
   new freechips.rocketchip.subsystem.WithNoMemPort ++         // remove offchip mem port
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 // DOC include end: mbusscratchpadrocket
 
 class SbusScratchpadRocketConfig extends Config(
-  new testchipip.WithSbusScratchpad(base=0x70000000L, stripes=2, partitions=2) ++ // add 4 lanes sbus backing scratchpad
+  new testchipip.WithSbusScratchpad(base=0x70000000L, banks=4) ++ // add 4 banks sbus backing scratchpad
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
 

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -138,7 +138,7 @@ class WithFireSimConfigTweaks extends Config(
 class WithMinimalFireSimHighPerfConfigTweaks extends Config(
   new WithFireSimHighPerfClocking ++
   new freechips.rocketchip.subsystem.WithNoMemPort ++
-  new testchipip.WithBackingScratchpad ++
+  new testchipip.WithMbusScratchpad ++
   new WithMinimalFireSimDesignTweaks
 )
 
@@ -148,7 +148,7 @@ class WithMinimalFireSimHighPerfConfigTweaks extends Config(
 class WithMinimalAndBlockDeviceFireSimHighPerfConfigTweaks extends Config(
   new WithFireSimHighPerfClocking ++
   new freechips.rocketchip.subsystem.WithNoMemPort ++ // removes mem port for FASEDBridge to match against
-  new testchipip.WithBackingScratchpad ++ // adds backing scratchpad for memory to replace FASED model
+  new testchipip.WithMbusScratchpad ++ // adds backing scratchpad for memory to replace FASED model
   new testchipip.WithBlockDevice(true) ++ // add in block device
   new WithMinimalFireSimDesignTweaks
 )
@@ -329,7 +329,7 @@ class FireSim16LargeBoomConfig extends Config(
 class FireSimNoMemPortConfig extends Config(
   new WithDefaultFireSimBridges ++
   new freechips.rocketchip.subsystem.WithNoMemPort ++
-  new testchipip.WithBackingScratchpad ++
+  new testchipip.WithMbusScratchpad ++
   new WithFireSimConfigTweaks ++
   new chipyard.RocketConfig)
 


### PR DESCRIPTION
This generalized the backing-scratchpad feature in testchipip to support - 
 - Placing the spad at arbitrary buses
 - Banking the scratchpad by cacheline
 - Placing multiple scratchpads on the bus, this allows for construction of scratchpad "partitions"

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
