### PR TITLE
Bump TestChipIp to improve default serial_tl behavior

### DIFF
--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -39,7 +39,6 @@ class ChipLikeQuadRocketConfig extends Config(
   new chipyard.config.WithCbusToPbusCrossingType(AsynchronousCrossing()) ++  // Add Async crossing between PBUS and CBUS
   new chipyard.config.WithSbusToMbusCrossingType(AsynchronousCrossing()) ++  // Add Async crossings between backside of L2 and MBUS
   new testchipip.WithAsynchronousSerialSlaveCrossing ++                      // Add Async crossing between serial and MBUS. Its master-side is tied to the FBUS
-  new testchipip.WithSerialTLAsyncResetQueue ++                              // Add Async reset queue to block ready while in reset
 
   new chipyard.config.AbstractConfig)
 


### PR DESCRIPTION
Previously, a special config fragment was necessary to prevent the chip from generating serial_tl packets during reset. Additionally, this was done using AsyncQueues, instead of just BlockDuringReset.

This changes all designs to block serial_tl while under reset

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
