### PR TITLE
Flip serial_tl_clock to be generated off-chip

### DIFF
--- a/docs/Advanced-Concepts/Chip-Communication.rst
+++ b/docs/Advanced-Concepts/Chip-Communication.rst
@@ -211,7 +211,7 @@ Softcore-driven Bringup Setup of the Example Test Chip after Tapeout
 
 .. warning::
    Bringing up test chips with a FPGA softcore  as described here is discouraged.
-   An alternative approach using the FPGA to "bridge" between a x86 host and the test chip is the preferred approach.
+   An alternative approach using the FPGA to "bridge" between a host computer and the test chip is the preferred approach.
 
 Assuming this example test chip is taped out and now ready to be tested, we can communicate with the chip using this serial-link.
 For example, a common test setup used at Berkeley to evaluate Chipyard-based test-chips includes an FPGA running a RISC-V soft-core that is able to speak to the DUT (over an FMC).

--- a/docs/Advanced-Concepts/Chip-Communication.rst
+++ b/docs/Advanced-Concepts/Chip-Communication.rst
@@ -206,8 +206,12 @@ This type of simulation setup is done in the following multi-clock configuration
     :start-after: DOC include start: MulticlockAXIOverSerialConfig
     :end-before: DOC include end: MulticlockAXIOverSerialConfig
 
-Bringup Setup of the Example Test Chip after Tapeout
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Softcore-driven Bringup Setup of the Example Test Chip after Tapeout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+   Bringing up test chips with a FPGA softcore  as described here is discouraged.
+   An alternative approach using the FPGA to "bridge" between a x86 host and the test chip is the preferred approach.
 
 Assuming this example test chip is taped out and now ready to be tested, we can communicate with the chip using this serial-link.
 For example, a common test setup used at Berkeley to evaluate Chipyard-based test-chips includes an FPGA running a RISC-V soft-core that is able to speak to the DUT (over an FMC).
@@ -222,4 +226,4 @@ The following image shows this flow:
 .. image:: ../_static/images/chip-bringup.png
 
 In fact, this exact type of bringup setup is what the following section discusses:
-:ref:`Prototyping/VCU118:Introduction to the Bringup Design`.
+:ref:_legacy-vcu118-bringup.

--- a/docs/Prototyping/VCU118.rst
+++ b/docs/Prototyping/VCU118.rst
@@ -47,8 +47,14 @@ After the harness is created, the ``BundleBridgeSource``'s must be connected to 
 This is done with harness binders and io binders (see ``fpga/src/main/scala/vcu118/HarnessBinders.scala`` and ``fpga/src/main/scala/vcu118/IOBinders.scala``).
 For more information on harness binders and io binders, refer to :ref:`Customization/IOBinders:IOBinders and HarnessBinders`.
 
-Introduction to the Bringup Design
-----------------------------------
+(Legacy) Introduction to the Legacy Bringup Design
+--------------------------------------------------
+
+.. warning::
+   The bringup VCU118 design described here is designed for old versions of Chipyard SoCs, pre-1.9.1.
+   The key difference is that these designs rely on a clock generated on-chip to synchronize the slow serialized-TileLink interface.
+   After Chipyard 1.9.1, the FPGA host is expected to pass the clock to the chip, instead of the other way around.
+   A new bringup solution will be developed for post-1.9.1 Chipyard designs.
 
 An example of a more complicated design used for Chipyard test chips can be viewed in ``fpga/src/main/scala/vcu118/bringup/``.
 This example extends the default test harness and creates new ``Overlays`` to connect to a DUT (connected to the FMC port).

--- a/fpga/src/main/scala/arty100t/HarnessBinders.scala
+++ b/fpga/src/main/scala/arty100t/HarnessBinders.scala
@@ -25,7 +25,8 @@ class WithArty100TUARTTSI(uartBaudRate: BigInt = 115200) extends OverrideHarness
     ports.map({ port =>
       val ath = th.asInstanceOf[Arty100THarness]
       val freq = p(PeripheryBusKey).dtsFrequency.get
-      val bits = SerialAdapter.asyncQueue(port, th.buildtopClock, th.buildtopReset)
+      val bits = port.bits
+      port.clock := th.buildtopClock
       withClockAndReset(th.buildtopClock, th.buildtopReset) {
         val ram = SerialAdapter.connectHarnessRAM(system.serdesser.get, bits, th.buildtopReset)
         val uart_to_serial = Module(new UARTToSerial(

--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -34,11 +34,5 @@ class ChipLikeQuadRocketConfig extends Config(
   // Create the uncore clock group
   new chipyard.clocking.WithClockGroupsCombinedByName("uncore", "implicit", "sbus", "mbus", "cbus", "system_bus", "fbus", "pbus") ++
 
-  // Set up the crossings
-  new chipyard.config.WithFbusToSbusCrossingType(AsynchronousCrossing()) ++  // Add Async crossing between SBUS and FBUS
-  new chipyard.config.WithCbusToPbusCrossingType(AsynchronousCrossing()) ++  // Add Async crossing between PBUS and CBUS
-  new chipyard.config.WithSbusToMbusCrossingType(AsynchronousCrossing()) ++  // Add Async crossings between backside of L2 and MBUS
-  new testchipip.WithAsynchronousSerialSlaveCrossing ++                      // Add Async crossing between serial and MBUS. Its master-side is tied to the FBUS
-
   new chipyard.config.AbstractConfig)
 

--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -31,9 +31,8 @@ class ChipLikeQuadRocketConfig extends Config(
   //==================================
   new chipyard.clocking.WithPLLSelectorDividerClockGenerator ++   // Use a PLL-based clock selector/divider generator structure
 
-  // Create two clock groups, uncore and fbus, in addition to the tile clock groups
-  new chipyard.clocking.WithClockGroupsCombinedByName("uncore", "implicit", "sbus", "mbus", "cbus", "system_bus") ++
-  new chipyard.clocking.WithClockGroupsCombinedByName("fbus", "fbus", "pbus") ++
+  // Create the uncore clock group
+  new chipyard.clocking.WithClockGroupsCombinedByName("uncore", "implicit", "sbus", "mbus", "cbus", "system_bus", "fbus", "pbus") ++
 
   // Set up the crossings
   new chipyard.config.WithFbusToSbusCrossingType(AsynchronousCrossing()) ++  // Add Async crossing between SBUS and FBUS

--- a/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
+++ b/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
@@ -49,7 +49,8 @@ class FlatTestHarness(implicit val p: Parameters) extends Module {
     val memOverSerialTLClockBundle = Wire(new ClockBundle(ClockBundleParameters()))
     memOverSerialTLClockBundle.clock := clock
     memOverSerialTLClockBundle.reset := reset
-    val serial_bits = SerialAdapter.asyncQueue(dut.serial_tl_pad, clock, reset)
+    val serial_bits = dut.serial_tl_pad.bits
+    dut.serial_tl_pad.clock := clock
     val harnessMultiClockAXIRAM = SerialAdapter.connectHarnessMultiClockAXIRAM(
       lazyDut.system.serdesser.get,
       serial_bits,

--- a/generators/firechip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/src/main/scala/BridgeBinders.scala
@@ -72,7 +72,8 @@ class WithSerialBridge extends OverrideHarnessBinder({
   (system: CanHavePeripheryTLSerial, th: FireSim, ports: Seq[ClockedIO[SerialIO]]) => {
     ports.map { port =>
       implicit val p = GetSystemParameters(system)
-      val bits = SerialAdapter.asyncQueue(port, th.buildtopClock, th.buildtopReset)
+      val bits = port.bits
+      port.clock := th.buildtopClock
       val ram = withClockAndReset(th.buildtopClock, th.buildtopReset) {
         SerialAdapter.connectHarnessRAM(system.serdesser.get, bits, th.buildtopReset)
       }
@@ -125,8 +126,8 @@ class WithAXIOverSerialTLCombinedBridges extends OverrideHarnessBinder({
         axiClockBundle.clock := axiClock
         axiClockBundle.reset := ResetCatchAndSync(axiClock, th.buildtopReset.asBool)
 
-        val serial_bits = SerialAdapter.asyncQueue(port, th.buildtopClock, th.buildtopReset)
-
+        val serial_bits = port.bits
+        port.clock := th.buildtopClock
         val harnessMultiClockAXIRAM = withClockAndReset(th.buildtopClock, th.buildtopReset) {
           SerialAdapter.connectHarnessMultiClockAXIRAM(
             system.serdesser.get,


### PR DESCRIPTION
Previously, the serial_tl_clock is generated on-chip, and passed to the host bringup FPGA. This flips that, so the FPGA must generate the clock.

Follows up on #1435 to improve the serial_tl robustness and ease-of-use.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
