### PR TITLE
Add singleclock broadcast clockbinder

### DIFF
--- a/generators/chipyard/src/main/scala/config/ClockingConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ClockingConfigs.scala
@@ -1,0 +1,34 @@
+package chipyard
+
+import org.chipsalliance.cde.config.{Config}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.subsystem.{MBUS, SBUS}
+import testchipip.soc.{OBUS}
+
+//==================================================
+// This file contains examples of the different ways
+// clocks can be generated for chiypard designs
+//==================================================
+
+// The default constructs IOs for all requested clocks in the chiptopClockGroupsNode
+// Note: This is what designs inheriting from AbstractConfig do by default
+class DefaultClockingRocketConfig extends Config(
+  new chipyard.clocking.WithPassthroughClockGenerator ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+// This is a more physically realistic approach, normally we can't punch out a separate
+// pin for each clock domain. The standard "test chip" approach is to punch a few slow clock
+// inputs, integrate a PLL, and generate an array of selectors/dividers to configure the
+// clocks for each domain. See the source for WithPLLSelectorDividerClockGenerator for more info
+class ChipLikeClockingRocketConfig extends Config(
+  new chipyard.clocking.WithPLLSelectorDividerClockGenerator ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+// This merges all the clock domains in chiptopClockGroupsNode into one, then generates a single
+// clock input pin.
+class SingleClockBroadcastRocketConfig extends Config(
+  new chipyard.clocking.WithSingleClockBroadcastClockGenerator ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)


### PR DESCRIPTION
This ClockBinder broadcasts a single clock IO to all clock domains for ultra-simple systems.
Don't merge this until the harness/clock merging is done

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
