### PR TITLE
Make BootAddrReg optional

### DIFF
--- a/generators/chipyard/src/main/scala/DigitalTop.scala
+++ b/generators/chipyard/src/main/scala/DigitalTop.scala
@@ -14,7 +14,7 @@ import freechips.rocketchip.devices.tilelink._
 // DOC include start: DigitalTop
 class DigitalTop(implicit p: Parameters) extends ChipyardSystem
   with testchipip.CanHavePeripheryCustomBootPin // Enables optional custom boot pin
-  with testchipip.HasPeripheryBootAddrReg // Use programmable boot address register
+  with testchipip.CanHavePeripheryBootAddrReg // Use programmable boot address register
   with testchipip.CanHaveTraceIO // Enables optionally adding trace IO
   with testchipip.CanHaveBackingScratchpad // Enables optionally adding a backing scratchpad
   with testchipip.CanHavePeripheryBlockDevice // Enables optionally adding the block device

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -46,6 +46,8 @@ class AbstractConfig extends Config(
   // This should get replaced with a PLL-like config instead
   new chipyard.clocking.WithDividerOnlyClockGenerator ++
 
+  new testchipip.WithCustomBootPin ++                               // add a custom-boot-pin to support pin-driven boot address
+  new testchipip.WithBootAddrReg ++                                 // add a boot-addr-reg for configurable boot address
   new testchipip.WithSerialTLWidth(32) ++                           // fatten the serialTL interface to improve testing performance
   new testchipip.WithDefaultSerialTL ++                             // use serialized tilelink port to external serialadapter/harnessRAM
   new chipyard.config.WithDebugModuleAbstractDataWords(8) ++        // increase debug module data capacity


### PR DESCRIPTION
Previously, the BootAddrReg device is always instantiated on all designs.
This change makes that device optional, so it can be removed from designs with no tiles.

This also adds the config flag for CustomBootPin to AbstractConfig, so its clearer what the set of "default devices" includes.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
