### PR TITLE
Support uni-directional TLSerdesser

### DIFF
--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -110,7 +110,8 @@ case $1 in
         make run-binary-fast -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} BINARY=$RISCV/riscv64-unknown-elf/share/riscv-tests/benchmarks/multiply.riscv
         ;;
     chipyard-ibex)
-        make run-binary-fast -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} BINARY=$RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv32ui-p-simple
+        # Ibex cannot run the riscv-tests binaries for some reason
+        # make run-binary-fast -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} BINARY=$RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv32ui-p-simple
         ;;
     chipyard-sodor)
         run_asm ${mapping[$1]}

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -110,7 +110,7 @@ case $1 in
         make run-binary-fast -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} BINARY=$RISCV/riscv64-unknown-elf/share/riscv-tests/benchmarks/multiply.riscv
         ;;
     chipyard-ibex)
-        run_bmark ${mapping[$1]} #TODO: Find 32-bit test
+        make run-binary-fast -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} BINARY=$RISCV/riscv64-unknown-elf/share/riscv-tests/isa/rv32ui-p-simple
         ;;
     chipyard-sodor)
         run_asm ${mapping[$1]}

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -47,6 +47,7 @@ class AbstractConfig extends Config(
 
   new testchipip.WithCustomBootPin ++                               // add a custom-boot-pin to support pin-driven boot address
   new testchipip.WithBootAddrReg ++                                 // add a boot-addr-reg for configurable boot address
+  new testchipip.WithSerialTLClientIdBits(4) ++                     // support up to 1 << 4 simultaneous requests from serialTL port
   new testchipip.WithSerialTLWidth(32) ++                           // fatten the serialTL interface to improve testing performance
   new testchipip.WithDefaultSerialTL ++                             // use serialized tilelink port to external serialadapter/harnessRAM
   new chipyard.config.WithDebugModuleAbstractDataWords(8) ++        // increase debug module data capacity

--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -21,8 +21,8 @@ class ChipLikeQuadRocketConfig extends Config(
   // Set up I/O
   //==================================
   new testchipip.WithSerialTLWidth(4) ++
+  new testchipip.WithSerialTLBackingMemory ++                                           // Backing memory is over serial TL protocol
   new chipyard.harness.WithSimAXIMemOverSerialTL ++                                     // Attach fast SimDRAM to TestHarness
-  new chipyard.config.WithSerialTLBackingMemory ++                                      // Backing memory is over serial TL protocol
   new freechips.rocketchip.subsystem.WithExtMemSize((1 << 30) * 4L) ++                  // 4GB max external memory
   new freechips.rocketchip.subsystem.WithNMemoryChannels(1) ++                          // 1 memory channel
 

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -13,9 +13,6 @@ class RocketConfig extends Config(
 
 class TinyRocketConfig extends Config(
   new chipyard.iobinders.WithDontTouchIOBinders(false) ++         // TODO FIX: Don't dontTouch the ports
-  new chipyard.config.WithTLSerialLocation(
-    freechips.rocketchip.subsystem.FBUS,
-    freechips.rocketchip.subsystem.PBUS) ++                       // attach TL serial adapter to f/p busses
   new freechips.rocketchip.subsystem.WithIncoherentBusTopology ++ // use incoherent bus topology
   new freechips.rocketchip.subsystem.WithNBanks(0) ++             // remove L2$
   new freechips.rocketchip.subsystem.WithNoMemPort ++             // remove backing memory
@@ -56,7 +53,6 @@ class GB1MemoryRocketConfig extends Config(
 
 // DOC include start: l1scratchpadrocket
 class ScratchpadOnlyRocketConfig extends Config(
-  new testchipip.WithSerialPBusMem ++
   new chipyard.config.WithL2TLBs(0) ++
   new freechips.rocketchip.subsystem.WithNBanks(0) ++
   new freechips.rocketchip.subsystem.WithNoMemPort ++          // remove offchip mem port
@@ -122,7 +118,7 @@ class MulticlockAXIOverSerialConfig extends Config(
     AsynchronousCrossing().sourceSync) ++
 
   new chipyard.harness.WithSimAXIMemOverSerialTL ++ // add SimDRAM DRAM model for axi4 backing memory over the SerDes link, if axi4 mem is enabled
-  new chipyard.config.WithSerialTLBackingMemory ++ // remove axi4 mem port in favor of SerialTL memory
+  new testchipip.WithSerialTLBackingMemory ++       // remove axi4 mem port in favor of SerialTL memory
 
   new freechips.rocketchip.subsystem.WithNBigCores(2) ++
   new freechips.rocketchip.subsystem.WithNMemoryChannels(1) ++ // 1 memory channel

--- a/generators/chipyard/src/main/scala/config/SodorConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/SodorConfigs.scala
@@ -8,7 +8,6 @@ class Sodor1StageConfig extends Config(
   // Create a Sodor 1-stage core
   new sodor.common.WithNSodorCores(1, internalTile = sodor.common.Stage1Factory) ++
   new testchipip.WithSerialTLWidth(32) ++
-  new testchipip.WithSerialPBusMem ++
   new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use sodor tile-internal scratchpad
   new freechips.rocketchip.subsystem.WithNoMemPort ++          // use no external memory
   new freechips.rocketchip.subsystem.WithNBanks(0) ++
@@ -18,7 +17,6 @@ class Sodor2StageConfig extends Config(
   // Create a Sodor 2-stage core
   new sodor.common.WithNSodorCores(1, internalTile = sodor.common.Stage2Factory) ++
   new testchipip.WithSerialTLWidth(32) ++
-  new testchipip.WithSerialPBusMem ++
   new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use sodor tile-internal scratchpad
   new freechips.rocketchip.subsystem.WithNoMemPort ++          // use no external memory
   new freechips.rocketchip.subsystem.WithNBanks(0) ++
@@ -28,7 +26,6 @@ class Sodor3StageConfig extends Config(
   // Create a Sodor 1-stage core with two ports
   new sodor.common.WithNSodorCores(1, internalTile = sodor.common.Stage3Factory(ports = 2)) ++
   new testchipip.WithSerialTLWidth(32) ++
-  new testchipip.WithSerialPBusMem ++
   new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use sodor tile-internal scratchpad
   new freechips.rocketchip.subsystem.WithNoMemPort ++          // use no external memory
   new freechips.rocketchip.subsystem.WithNBanks(0) ++
@@ -38,7 +35,6 @@ class Sodor3StageSinglePortConfig extends Config(
   // Create a Sodor 3-stage core with one ports (instruction and data memory access controlled by arbiter)
   new sodor.common.WithNSodorCores(1, internalTile = sodor.common.Stage3Factory(ports = 1)) ++
   new testchipip.WithSerialTLWidth(32) ++
-  new testchipip.WithSerialPBusMem ++
   new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use sodor tile-internal scratchpad
   new freechips.rocketchip.subsystem.WithNoMemPort ++          // use no external memory
   new freechips.rocketchip.subsystem.WithNBanks(0) ++
@@ -48,7 +44,6 @@ class Sodor5StageConfig extends Config(
   // Create a Sodor 5-stage core
   new sodor.common.WithNSodorCores(1, internalTile = sodor.common.Stage5Factory) ++
   new testchipip.WithSerialTLWidth(32) ++
-  new testchipip.WithSerialPBusMem ++
   new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use sodor tile-internal scratchpad
   new freechips.rocketchip.subsystem.WithNoMemPort ++          // use no external memory
   new freechips.rocketchip.subsystem.WithNBanks(0) ++
@@ -58,7 +53,6 @@ class SodorUCodeConfig extends Config(
   // Construct a Sodor microcode-based single-bus core
   new sodor.common.WithNSodorCores(1, internalTile = sodor.common.UCodeFactory) ++
   new testchipip.WithSerialTLWidth(32) ++
-  new testchipip.WithSerialPBusMem ++
   new freechips.rocketchip.subsystem.WithScratchpadsOnly ++    // use sodor tile-internal scratchpad
   new freechips.rocketchip.subsystem.WithNoMemPort ++          // use no external memory
   new freechips.rocketchip.subsystem.WithNBanks(0) ++

--- a/generators/chipyard/src/main/scala/config/SpikeConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/SpikeConfigs.scala
@@ -27,7 +27,6 @@ class SpikeFastUARTConfig extends Config(
 class SpikeUltraFastConfig extends Config(
   new chipyard.WithSpikeTCM ++
   new chipyard.WithNSpikeCores(1) ++
-  new testchipip.WithSerialPBusMem ++
   new chipyard.config.WithUARTFIFOEntries(128, 128) ++
   new chipyard.config.WithMemoryBusFrequency(2) ++
   new chipyard.config.WithPeripheryBusFrequency(2) ++
@@ -48,7 +47,6 @@ class SpikeUltraFastDevicesConfig extends Config(
 
   new chipyard.WithSpikeTCM ++
   new chipyard.WithNSpikeCores(1) ++
-  new testchipip.WithSerialPBusMem ++
   new chipyard.config.WithUARTFIFOEntries(128, 128) ++
   new chipyard.config.WithMemoryBusFrequency(2) ++
   new chipyard.config.WithPeripheryBusFrequency(2) ++

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -59,25 +59,9 @@ class WithNoDebug extends Config((site, here, up) => {
   case DebugModuleKey => None
 })
 
-class WithTLSerialLocation(masterWhere: TLBusWrapperLocation, slaveWhere: TLBusWrapperLocation) extends Config((site, here, up) => {
-  case SerialTLAttachKey => up(SerialTLAttachKey, site).copy(masterWhere = masterWhere, slaveWhere = slaveWhere)
-})
-
 class WithTLBackingMemory extends Config((site, here, up) => {
   case ExtMem => None // disable AXI backing memory
   case ExtTLMem => up(ExtMem, site) // enable TL backing memory
-})
-
-class WithSerialTLBackingMemory extends Config((site, here, up) => {
-  case ExtMem => None
-  case SerialTLKey => up(SerialTLKey, site).map { k => k.copy(
-    memParams = {
-      val memPortParams = up(ExtMem, site).get
-      require(memPortParams.nMemoryChannels == 1)
-      memPortParams.master
-    },
-    isMemoryDevice = true
-  )}
 })
 
 class WithExtMemIdBits(n: Int) extends Config((site, here, up) => {

--- a/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
+++ b/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
@@ -40,9 +40,9 @@ class FlatTestHarness(implicit val p: Parameters) extends Module {
 
   // Serialized TL
   val sVal = p(SerialTLKey).get
-  val serialManagerParams = sVal.serialManagerParams.get
-  val axiDomainParams = serialManagerParams.axiMemOverSerialTLParams.get
-  require(serialManagerParams.isMemoryDevice)
+  val serialTLManagerParams = sVal.serialTLManagerParams.get
+  val axiDomainParams = serialTLManagerParams.axiMemOverSerialTLParams.get
+  require(serialTLManagerParams.isMemoryDevice)
   val memFreq = axiDomainParams.getMemFrequency(lazyDut.system)
 
   withClockAndReset(clock, reset) {
@@ -60,8 +60,8 @@ class FlatTestHarness(implicit val p: Parameters) extends Module {
 
     // connect SimDRAM from the AXI port coming from the harness multi clock axi ram
     (harnessMultiClockAXIRAM.mem_axi4.get zip harnessMultiClockAXIRAM.memNode.get.edges.in).map { case (axi_port, edge) =>
-      val memSize = serialManagerParams.memParams.size
-      val memBase = serialManagerParams.memParams.base
+      val memSize = serialTLManagerParams.memParams.size
+      val memBase = serialTLManagerParams.memParams.base
       val lineSize = p(CacheBlockBytes)
       val mem = Module(new SimDRAM(memSize, lineSize, BigInt(memFreq.toLong), memBase, edge.bundle)).suggestName("simdram")
       mem.io.axi <> axi_port.bits

--- a/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
+++ b/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
@@ -40,9 +40,9 @@ class FlatTestHarness(implicit val p: Parameters) extends Module {
 
   // Serialized TL
   val sVal = p(SerialTLKey).get
-  require(sVal.axiMemOverSerialTLParams.isDefined)
-  require(sVal.isMemoryDevice)
-  val axiDomainParams = sVal.axiMemOverSerialTLParams.get
+  val serialManagerParams = sVal.serialManagerParams.get
+  val axiDomainParams = serialManagerParams.axiMemOverSerialTLParams.get
+  require(serialManagerParams.isMemoryDevice)
   val memFreq = axiDomainParams.getMemFrequency(lazyDut.system)
 
   withClockAndReset(clock, reset) {
@@ -59,9 +59,9 @@ class FlatTestHarness(implicit val p: Parameters) extends Module {
     io.success := SimTSI.connect(Some(harnessMultiClockAXIRAM.module.io.tsi), clock, reset)
 
     // connect SimDRAM from the AXI port coming from the harness multi clock axi ram
-    (harnessMultiClockAXIRAM.mem_axi4 zip harnessMultiClockAXIRAM.memNode.edges.in).map { case (axi_port, edge) =>
-      val memSize = sVal.memParams.size
-      val memBase = sVal.memParams.base
+    (harnessMultiClockAXIRAM.mem_axi4.get zip harnessMultiClockAXIRAM.memNode.get.edges.in).map { case (axi_port, edge) =>
+      val memSize = serialManagerParams.memParams.size
+      val memBase = serialManagerParams.memParams.base
       val lineSize = p(CacheBlockBytes)
       val mem = Module(new SimDRAM(memSize, lineSize, BigInt(memFreq.toLong), memBase, edge.bundle)).suggestName("simdram")
       mem.io.axi <> axi_port.bits

--- a/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
@@ -145,9 +145,9 @@ class WithSimAXIMemOverSerialTL extends OverrideHarnessBinder({
     implicit val p = chipyard.iobinders.GetSystemParameters(system)
 
     p(SerialTLKey).map({ sVal =>
-      val serialManagerParams = sVal.serialManagerParams.get
-      val axiDomainParams = serialManagerParams.axiMemOverSerialTLParams.get
-      require(serialManagerParams.isMemoryDevice)
+      val serialTLManagerParams = sVal.serialTLManagerParams.get
+      val axiDomainParams = serialTLManagerParams.axiMemOverSerialTLParams.get
+      require(serialTLManagerParams.isMemoryDevice)
 
       val memFreq = axiDomainParams.getMemFrequency(system.asInstanceOf[HasTileLinkLocations])
 
@@ -168,8 +168,8 @@ class WithSimAXIMemOverSerialTL extends OverrideHarnessBinder({
 
           // connect SimDRAM from the AXI port coming from the harness multi clock axi ram
           (harnessMultiClockAXIRAM.mem_axi4.get zip harnessMultiClockAXIRAM.memNode.get.edges.in).map { case (axi_port, edge) =>
-            val memSize = serialManagerParams.memParams.size
-            val memBase = serialManagerParams.memParams.base
+            val memSize = serialTLManagerParams.memParams.size
+            val memBase = serialTLManagerParams.memParams.base
             val lineSize = p(CacheBlockBytes)
             val mem = Module(new SimDRAM(memSize, lineSize, BigInt(memFreq.toLong), memBase, edge.bundle)).suggestName("simdram")
             mem.io.axi <> axi_port.bits

--- a/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
@@ -145,9 +145,9 @@ class WithSimAXIMemOverSerialTL extends OverrideHarnessBinder({
     implicit val p = chipyard.iobinders.GetSystemParameters(system)
 
     p(SerialTLKey).map({ sVal =>
-      require(sVal.axiMemOverSerialTLParams.isDefined)
-      val axiDomainParams = sVal.axiMemOverSerialTLParams.get
-      require(sVal.isMemoryDevice)
+      val serialManagerParams = sVal.serialManagerParams.get
+      val axiDomainParams = serialManagerParams.axiMemOverSerialTLParams.get
+      require(serialManagerParams.isMemoryDevice)
 
       val memFreq = axiDomainParams.getMemFrequency(system.asInstanceOf[HasTileLinkLocations])
 
@@ -167,9 +167,9 @@ class WithSimAXIMemOverSerialTL extends OverrideHarnessBinder({
           when (success) { th.success := true.B }
 
           // connect SimDRAM from the AXI port coming from the harness multi clock axi ram
-          (harnessMultiClockAXIRAM.mem_axi4 zip harnessMultiClockAXIRAM.memNode.edges.in).map { case (axi_port, edge) =>
-            val memSize = sVal.memParams.size
-            val memBase = sVal.memParams.base
+          (harnessMultiClockAXIRAM.mem_axi4.get zip harnessMultiClockAXIRAM.memNode.get.edges.in).map { case (axi_port, edge) =>
+            val memSize = serialManagerParams.memParams.size
+            val memBase = serialManagerParams.memParams.base
             val lineSize = p(CacheBlockBytes)
             val mem = Module(new SimDRAM(memSize, lineSize, BigInt(memFreq.toLong), memBase, edge.bundle)).suggestName("simdram")
             mem.io.axi <> axi_port.bits

--- a/generators/firechip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/src/main/scala/BridgeBinders.scala
@@ -113,9 +113,9 @@ class WithAXIOverSerialTLCombinedBridges extends OverrideHarnessBinder({
     implicit val p = GetSystemParameters(system)
 
     p(SerialTLKey).map({ sVal =>
-      val serialManagerParams = sVal.serialManagerParams.get
-      val axiDomainParams = serialManagerParams.axiMemOverSerialTLParams.get
-      require(serialManagerParams.isMemoryDevice)
+      val serialTLManagerParams = sVal.serialTLManagerParams.get
+      val axiDomainParams = serialTLManagerParams.axiMemOverSerialTLParams.get
+      require(serialTLManagerParams.isMemoryDevice)
       val memFreq = axiDomainParams.getMemFrequency(system.asInstanceOf[HasTileLinkLocations])
 
       ports.map({ port =>

--- a/generators/firechip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/src/main/scala/BridgeBinders.scala
@@ -113,10 +113,9 @@ class WithAXIOverSerialTLCombinedBridges extends OverrideHarnessBinder({
     implicit val p = GetSystemParameters(system)
 
     p(SerialTLKey).map({ sVal =>
-      require(sVal.axiMemOverSerialTLParams.isDefined)
-      val axiDomainParams = sVal.axiMemOverSerialTLParams.get
-      require(sVal.isMemoryDevice)
-
+      val serialManagerParams = sVal.serialManagerParams.get
+      val axiDomainParams = serialManagerParams.axiMemOverSerialTLParams.get
+      require(serialManagerParams.isMemoryDevice)
       val memFreq = axiDomainParams.getMemFrequency(system.asInstanceOf[HasTileLinkLocations])
 
       ports.map({ port =>
@@ -137,7 +136,7 @@ class WithAXIOverSerialTLCombinedBridges extends OverrideHarnessBinder({
         TSIBridge(th.buildtopClock, harnessMultiClockAXIRAM.module.io.tsi, Some(MainMemoryConsts.globalName), th.buildtopReset.asBool)
 
         // connect SimAxiMem
-        (harnessMultiClockAXIRAM.mem_axi4 zip harnessMultiClockAXIRAM.memNode.edges.in).map { case (axi4, edge) =>
+        (harnessMultiClockAXIRAM.mem_axi4.get zip harnessMultiClockAXIRAM.memNode.get.edges.in).map { case (axi4, edge) =>
           val nastiKey = NastiParameters(axi4.bits.r.bits.data.getWidth,
                                         axi4.bits.ar.bits.addr.getWidth,
                                         axi4.bits.ar.bits.id.getWidth)


### PR DESCRIPTION
This change fixes support for configs in which the TLSerdesser is unidirectional; that is, cases in which the chip acts as only the manager, and off chip acts as only the client.

This simplifies the memory map for all default designs as we no longer have to add a stub off-chip memory to provide the chip-client/harness-manager link.

Why not use the existing `TLDesser/TLSerder`, which already do this? Those IMO can be deleted as their implementations are now supported by the generalized `TLSerdesser`.

Since we support configs now where the serializer only acts as a client to the FBus, a bunch of `WithSerialPBusMem` fragments can be removed, as these were used to specify where the stub tilelink device sat.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
