### PR TITLE
Set default config back to 1-channel

### DIFF
--- a/.github/scripts/defaults.sh
+++ b/.github/scripts/defaults.sh
@@ -38,7 +38,7 @@ grouping["group-fpga"]="arty vcu118 vc707"
 
 # key value store to get the build strings
 declare -A mapping
-mapping["chipyard-rocket"]=""
+mapping["chipyard-rocket"]=" CONFIG=QuadChannelRocketConfig"
 mapping["chipyard-dmirocket"]=" CONFIG=dmiRocketConfig"
 mapping["chipyard-sha3"]=" CONFIG=Sha3RocketConfig"
 mapping["chipyard-mempress"]=" CONFIG=MempressRocketConfig"

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -31,6 +31,9 @@ run_tracegen () {
 case $1 in
     chipyard-rocket)
         run_bmark ${mapping[$1]}
+        make -C $LOCAL_CHIPYARD_DIR/tests
+        make -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} run-binary LOADMEM=1 BINARY=$LOCAL_CHIPYARD_DIR/tests/hello.riscv
+        make -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} run-binary BINARY=$LOCAL_CHIPYARD_DIR/tests/hello.riscv
         ;;
     chipyard-dmirocket)
         $LOCAL_CHIPYARD_DIR/scripts/generate-ckpt.sh -b $RISCV/riscv64-unknown-elf/share/riscv-tests/benchmarks/dhrystone.riscv -i 10000

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -59,7 +59,7 @@ class AbstractConfig extends Config(
   new chipyard.config.WithPeripheryBusFrequencyAsDefault ++         // Unspecified frequencies with match the pbus frequency (which is always set)
   new chipyard.config.WithMemoryBusFrequency(500.0) ++              // Default 500 MHz mbus
   new chipyard.config.WithPeripheryBusFrequency(500.0) ++           // Default 500 MHz pbus
-  new freechips.rocketchip.subsystem.WithNMemoryChannels(2) ++      // Default 2 memory channels
+  new freechips.rocketchip.subsystem.WithNMemoryChannels(1) ++      // Default 1 memory channels
   new freechips.rocketchip.subsystem.WithClockGateModel ++          // add default EICG_wrapper clock gate model
   new freechips.rocketchip.subsystem.WithJtagDTM ++                 // set the debug module to expose a JTAG port
   new freechips.rocketchip.subsystem.WithNoMMIOPort ++              // no top-level MMIO master port (overrides default set in rocketchip)

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -75,3 +75,8 @@ class ManyPeripheralsRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNoMemPort ++        // remove AXI4 backing memory
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
+
+class QuadChannelRocketConfig extends Config(
+  new freechips.rocketchip.subsystem.WithNMemoryChannels(4) ++      // 4 AXI4 channels
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)


### PR DESCRIPTION
Add some tests to CI to provide coverage that was lost when changing default back to single-channel.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
