### PR TITLE
(VCU118 DDR HarnessBinder)Fix data field width mismatch between DDR AXI and TileLink MemoryBus 

### DIFF
--- a/fpga/src/main/scala/vcu118/TestHarness.scala
+++ b/fpga/src/main/scala/vcu118/TestHarness.scala
@@ -84,8 +84,8 @@ class VCU118FPGATestHarness(override implicit val p: Parameters) extends VCU118S
     name = "chip_ddr",
     sourceId = IdRange(0, 1 << dp(ExtTLMem).get.master.idBits)
   )))))
-  ddrNode := ddrClient
-
+  ddrNode := TLWidthWidget(dp(XLen)/8) := ddrClient
+  
   // module implementation
   override lazy val module = new VCU118FPGATestHarnessImp(this)
 }

--- a/fpga/src/main/scala/vcu118/TestHarness.scala
+++ b/fpga/src/main/scala/vcu118/TestHarness.scala
@@ -84,8 +84,8 @@ class VCU118FPGATestHarness(override implicit val p: Parameters) extends VCU118S
     name = "chip_ddr",
     sourceId = IdRange(0, 1 << dp(ExtTLMem).get.master.idBits)
   )))))
-  ddrNode := TLWidthWidget(dp(XLen)/8) := ddrClient
-  
+  ddrNode := TLWidthWidget(dp(ExtTLMem).get.master.beatBytes) := ddrClient
+
   // module implementation
   override lazy val module = new VCU118FPGATestHarnessImp(this)
 }


### PR DESCRIPTION
When evaluating a RV32 design(just add `WithRV32 `in the `RocketVCU118Config`) on vcu118. The beatBytes is 4, and therefore `dataBits `of the MemoryBus will be 32. However the AXI that goes to MIG core is predefined as 64bits wide. Therefore, there is a data field width mismatch here, causing the RV32 design can not access DDR4 of VCU118 successfully. See WithDDRMem HarnessBinder for vcu118 below: 
```
class WithDDRMem extends OverrideHarnessBinder({
  (system: CanHaveMasterTLMemPort, th: BaseModule with HasHarnessSignalReferences, ports: Seq[HeterogeneousBag[TLBundle]]) => {
    th match { case vcu118th: VCU118FPGATestHarnessImp => {
      require(ports.size == 1)
      println(s"the ddr port ${ports}")
      val bundles = vcu118th.vcu118Outer.ddrClient.out.map(_._1)
      println(s"the val bundles = vcu118th.vcu118Outer.ddrClient.out.map(_._1) from mig island is ${bundles.head.params.dataBits}")
      println(s"the val bundles = vcu118th.vcu118Outer.ddrClient.out.map(_._1) from tllink island is ${ports.head.head.params.dataBits}")
      val ddrClientBundle = Wire(new HeterogeneousBag(bundles.map(_.cloneType)))
      bundles.zip(ddrClientBundle).foreach { case (bundle, io) => bundle <> io }
      ddrClientBundle <> ports.head
    } }
  }
})
```
It turns out that this harness binder implementation breaks the diplomatic negotiation. It just conducts a chisel connection between two chisel bundles(`ddrClientBundle <> ports.head`) instead of diplomatic connection.  Even though the width of the data field is normally determined by downward `TLManager `according to `TLImp`. But this harness binder impl breaks that parameter propagation process from manager to client(there are two negotiation ends:  `memTLNode `in `CanHaveMasterTLMemPort `and `val ddrClient = TLClientNode(Seq(inParams.master))` in `VCU118FPGATestHarness`), therefore the data field width mismatch occurs.
This PR adds a `TLWidthWidget  `to hide the width difference, I changed `ddrNode :=  ddrClient`  to the following loc:
`ddrNode := TLWidthWidget(dp(XLen) / 8) := ddrClient`
And the `WithRV32 `configuration runs successfully on vcu118
**Related PRs / Issues**:
https://github.com/ucb-bar/chipyard/issues/1481

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
