### PR TITLE
Improvements to chipyard clocking

### DIFF
--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -80,7 +80,7 @@ jobs:
           eval "$(conda shell.bash hook)"
           mkdir ${{ env.JAVA_TMP_DIR }}
           export MAKEFLAGS="-j32"
-          ./build-setup.sh -f
+          ./build-setup.sh -f -v
 
   run-cfg-finder:
     name: run-cfg-finder

--- a/generators/chipyard/src/main/scala/clocking/ClockBinders.scala
+++ b/generators/chipyard/src/main/scala/clocking/ClockBinders.scala
@@ -38,9 +38,9 @@ class WithPLLSelectorDividerClockGenerator extends OverrideLazyIOBinder({
     val clockSelector = system.prci_ctrl_domain { LazyModule(new TLClockSelector(baseAddress + 0x30000, tlbus.beatBytes)) }
     val pllCtrl       = system.prci_ctrl_domain { LazyModule(new FakePLLCtrl    (baseAddress + 0x40000, tlbus.beatBytes)) }
 
-    tlbus.coupleTo("clock-div-ctrl") { clockDivider.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := TLBuffer() := _ }
-    tlbus.coupleTo("clock-sel-ctrl") { clockSelector.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := TLBuffer() := _ }
-    tlbus.coupleTo("pll-ctrl") { pllCtrl.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := TLBuffer() := _ }
+    clockDivider.tlNode  := system.prci_ctrl_bus
+    clockSelector.tlNode := system.prci_ctrl_bus
+    pllCtrl.tlNode       := system.prci_ctrl_bus
 
     system.allClockGroupsNode := clockDivider.clockNode := clockSelector.clockNode
 

--- a/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
+++ b/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
@@ -36,6 +36,14 @@ trait HasChipyardPRCI { this: BaseSubsystem with InstantiatesTiles =>
   val prci_ctrl_domain = LazyModule(new ClockSinkDomain(name=Some("chipyard-prci-control")))
   prci_ctrl_domain.clockNode := tlbus.fixedClockNode
 
+  val prci_ctrl_bus = prci_ctrl_domain { TLXbar() }
+  tlbus.coupleTo("prci_ctrl") { (prci_ctrl_bus
+    := TLFIFOFixer(TLFIFOFixer.all)
+    := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes)
+    := TLBuffer()
+    := _)
+  }
+
   // Aggregate all the clock groups into a single node
   val aggregator = LazyModule(new ClockGroupAggregator("allClocks")).node
   val allClockGroupsNode = ClockGroupEphemeralNode()
@@ -72,18 +80,23 @@ trait HasChipyardPRCI { this: BaseSubsystem with InstantiatesTiles =>
   val frequencySpecifier = ClockGroupFrequencySpecifier(p(ClockFrequencyAssignersKey))
   val clockGroupCombiner = ClockGroupCombiner()
   val resetSynchronizer  = prci_ctrl_domain { ClockGroupResetSynchronizer() }
-  val tileClockGater     = if (prciParams.enableTileClockGating) { prci_ctrl_domain {
-    TileClockGater(prciParams.baseAddress + 0x00000, tlbus)
-  } } else { ClockGroupEphemeralNode() }
-  val tileResetSetter    = if (prciParams.enableTileResetSetting) { prci_ctrl_domain {
-    TileResetSetter(prciParams.baseAddress + 0x10000, tlbus, tile_prci_domains.map(_.tile_reset_domain.clockNode.portParams(0).name.get), Nil)
-  } } else { ClockGroupEphemeralNode() }
+  val tileClockGater     = Option.when(prciParams.enableTileClockGating) { prci_ctrl_domain {
+    val clock_gater = LazyModule(new TileClockGater(prciParams.baseAddress + 0x00000, tlbus.beatBytes))
+    clock_gater.tlNode := prci_ctrl_bus
+    clock_gater
+  } }
+  val tileResetSetter    = Option.when(prciParams.enableTileResetSetting) { prci_ctrl_domain {
+    val reset_setter = LazyModule(new TileResetSetter(prciParams.baseAddress + 0x10000, tlbus.beatBytes,
+      tile_prci_domains.map(_.tile_reset_domain.clockNode.portParams(0).name.get), Nil))
+    reset_setter.tlNode := prci_ctrl_bus
+    reset_setter
+  } }
 
   (aggregator
     := frequencySpecifier
     := clockGroupCombiner
     := resetSynchronizer
-    := tileClockGater
-    := tileResetSetter
+    := tileClockGater.map(_.clockNode).getOrElse(ClockGroupEphemeralNode()(ValName("temp")))
+    := tileResetSetter.map(_.clockNode).getOrElse(ClockGroupEphemeralNode()(ValName("temp")))
     := allClockGroupsNode)
 }

--- a/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
+++ b/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
@@ -71,7 +71,7 @@ trait HasChipyardPRCI { this: BaseSubsystem with InstantiatesTiles =>
   // diplomatic IOBinder should drive
   val frequencySpecifier = ClockGroupFrequencySpecifier(p(ClockFrequencyAssignersKey))
   val clockGroupCombiner = ClockGroupCombiner()
-  val resetSynchronizer  = ClockGroupResetSynchronizer()
+  val resetSynchronizer  = prci_ctrl_domain { ClockGroupResetSynchronizer() }
   val tileClockGater     = if (prciParams.enableTileClockGating) { prci_ctrl_domain {
     TileClockGater(prciParams.baseAddress + 0x00000, tlbus)
   } } else { ClockGroupEphemeralNode() }

--- a/generators/chipyard/src/main/scala/clocking/TileClockGater.scala
+++ b/generators/chipyard/src/main/scala/clocking/TileClockGater.scala
@@ -46,10 +46,3 @@ class TileClockGater(address: BigInt, beatBytes: Int)(implicit p: Parameters, va
   }
 }
 
-object TileClockGater {
-  def apply(address: BigInt, tlbus: TLBusWrapper)(implicit p: Parameters, v: ValName) = {
-    val gater = LazyModule(new TileClockGater(address, tlbus.beatBytes))
-    tlbus.coupleTo("clock-gater") { gater.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := TLBuffer() := _ }
-    gater.clockNode
-  }
-}

--- a/generators/chipyard/src/main/scala/clocking/TileResetSetter.scala
+++ b/generators/chipyard/src/main/scala/clocking/TileResetSetter.scala
@@ -62,12 +62,3 @@ class TileResetSetter(address: BigInt, beatBytes: Int, tileNames: Seq[String], i
     }
   }
 }
-
-
-object TileResetSetter {
-  def apply(address: BigInt, tlbus: TLBusWrapper, tileNames: Seq[String], initResetHarts: Seq[Int])(implicit p: Parameters, v: ValName) = {
-    val setter = LazyModule(new TileResetSetter(address, tlbus.beatBytes, tileNames, initResetHarts))
-    tlbus.coupleTo("tile-reset-setter") { setter.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := TLBuffer() := _ }
-    setter.clockNode
-  }
-}


### PR DESCRIPTION
**Localizes all the clock devices to prci_ctrl_domain, and adds a xbar for all the clock control devices.**
This should improve physical design of clock/reset devices, since it all is under a single module hierarchically with fewer IO

**Fixes TLClockDivider behavior.**
Previously, if the divisor register somehow misses the reset pulse, it would set the DividerOrPass to a bad state that could initialize the system to a very slow clock. This would never happen in a physical implementation. 

However, in RTL simulations where the power-reset sequence is not totally simulated, only a `negedge reset` might be evaluated with no `posedge reset`. Since the AsyncResetRegs are sensitive to `posedge reset or posedge clock`, and the `asyncReset` may deassert before a clock arrives at the TLBus, that register might never be reset in simulation.

This fix overall makes the system more robust, it forces the DivideOrPass to output the undivided clock until the TL bus clock is alive, and the TL bus reset is deasserted, regardless of the value of the divisor register. The divisor register is now reset by the TL bus reset as well, which guarantees that it would be reset properly under any RTL simulation, as the TL bus reset should be deasserted after the TL bus clock is alive.

**Fixes divisor synchronization**
The divisor register is clocked to the TL bus clock, but it needs to be synchronized to the clock it is dividing (which may not be the same). The testchipip bump fixes this.

**Explicitly use RawModules**
Blocks which produce clocks/reset/sync-issues should not use implicit clock/reset, it is too confusing. The ClockDivideOrPass is now a RawModule.


**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
