### PR TITLE
Integrate barf (prefetchers)

### DIFF
--- a/.github/scripts/check-commit.sh
+++ b/.github/scripts/check-commit.sh
@@ -45,7 +45,7 @@ search () {
     done
 }
 
-submodules=("cva6" "boom" "ibex" "gemmini" "hwacha" "icenet" "nvdla" "rocket-chip" "sha3" "sifive-blocks" "sifive-cache" "testchipip" "riscv-sodor" "mempress")
+submodules=("cva6" "boom" "ibex" "gemmini" "hwacha" "icenet" "nvdla" "rocket-chip" "sha3" "sifive-blocks" "sifive-cache" "testchipip" "riscv-sodor" "mempress" "bar-fetchers")
 dir="generators"
 branches=("master" "main" "dev")
 search

--- a/.github/scripts/defaults.sh
+++ b/.github/scripts/defaults.sh
@@ -28,7 +28,7 @@ REMOTE_COURSIER_CACHE=$REMOTE_WORK_DIR/.coursier-cache
 
 # key value store to get the build groups
 declare -A grouping
-grouping["group-cores"]="chipyard-cva6 chipyard-ibex chipyard-rocket chipyard-hetero chipyard-boom chipyard-sodor chipyard-digitaltop chipyard-multiclock-rocket chipyard-nomem-scratchpad chipyard-spike chipyard-clone"
+grouping["group-cores"]="chipyard-cva6 chipyard-ibex chipyard-rocket chipyard-hetero chipyard-boom chipyard-sodor chipyard-digitaltop chipyard-multiclock-rocket chipyard-nomem-scratchpad chipyard-spike chipyard-clone chipyard-prefetchers"
 grouping["group-peripherals"]="chipyard-dmirocket chipyard-dmiboom chipyard-spiflashwrite chipyard-mmios chipyard-nocores chipyard-manyperipherals chipyard-chiplike"
 grouping["group-accels"]="chipyard-mempress chipyard-sha3 chipyard-hwacha chipyard-gemmini chipyard-manymmioaccels chipyard-nvdla"
 grouping["group-constellation"]="chipyard-constellation"
@@ -42,6 +42,7 @@ mapping["chipyard-rocket"]=" CONFIG=QuadChannelRocketConfig"
 mapping["chipyard-dmirocket"]=" CONFIG=dmiRocketConfig"
 mapping["chipyard-sha3"]=" CONFIG=Sha3RocketConfig"
 mapping["chipyard-mempress"]=" CONFIG=MempressRocketConfig"
+mapping["chipyard-prefetchers"]=" CONFIG=PrefetchingRocketConfig"
 mapping["chipyard-digitaltop"]=" TOP=DigitalTop"
 mapping["chipyard-manymmioaccels"]=" CONFIG=ManyMMIOAcceleratorRocketConfig"
 mapping["chipyard-nvdla"]=" CONFIG=SmallNVDLARocketConfig verilog"

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -56,6 +56,9 @@ case $1 in
     chipyard-hetero)
         run_bmark ${mapping[$1]}
         ;;
+    chipyard-prefetchers)
+        make -C $LOCAL_SIM_DIR $DISABLE_SIM_PREREQ ${mapping[$1]} run-binary BINARY=$RISCV/riscv64-unknown-elf/share/riscv-tests/benchmarks/dhrystone.riscv
+        ;;
     rocketchip)
         run_bmark ${mapping[$1]}
         ;;

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -442,6 +442,29 @@ jobs:
           group-key: "group-cores"
           project-key: "chipyard-rocket"
 
+  chipyard-prefetchers-run-tests:
+    name: chipyard-prefetchers-run-tests
+    needs: prepare-chipyard-cores
+    runs-on: self-hosted
+    steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
+            ls -alh .
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Git workaround
+        uses: ./.github/actions/git-workaround
+      - name: Create conda env
+        uses: ./.github/actions/create-conda-env
+      - name: Run tests
+        uses: ./.github/actions/run-tests
+        with:
+          group-key: "group-cores"
+          project-key: "chipyard-prefetchers"
+
   chipyard-hetero-run-tests:
     name: chipyard-hetero-run-tests
     needs: prepare-chipyard-cores
@@ -1036,6 +1059,7 @@ jobs:
             chipyard-sha3-run-tests,
             chipyard-gemmini-run-tests,
             chipyard-manymmioaccels-run-tests, # chipyard-nvdla-run-tests,
+            chipyard-prefetchers-run-tests,
             chipyard-mempress-run-tests,
             chipyard-constellation-run-tests,
             tracegen-boom-run-tests,

--- a/.gitmodules
+++ b/.gitmodules
@@ -124,3 +124,6 @@
 [submodule "software/embench/embench-iot"]
 	path = software/embench/embench-iot
 	url = https://github.com/embench/embench-iot.git
+[submodule "generators/bar-fetchers"]
+	path = generators/bar-fetchers
+	url = https://github.com/ucb-bar/bar-fetchers.git

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val chipyard = (project in file("generators/chipyard"))
     sha3, // On separate line to allow for cleaner tutorial-setup patches
     dsptools, `rocket-dsp-utils`,
     gemmini, icenet, tracegen, cva6, nvdla, sodor, ibex, fft_generator,
-    constellation, mempress)
+    constellation, mempress, barf)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(
     libraryDependencies ++= Seq(
@@ -166,6 +166,11 @@ lazy val mempress = (project in file("generators/mempress"))
   .dependsOn(rocketchip, midasTargetUtils)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(chiselTestSettings)
+  .settings(commonSettings)
+
+lazy val barf = (project in file("generators/bar-fetchers"))
+  .dependsOn(rocketchip)
+  .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)
 
 lazy val constellation = (project in file("generators/constellation"))

--- a/docs/Generators/Prefetchers.rst
+++ b/docs/Generators/Prefetchers.rst
@@ -1,0 +1,9 @@
+Prefetchers
+====================================
+
+The BAR-fetchers library is a collection of Chisel-implemented prefetchers, designed for compatibility with Chipyard and Rocket-Chip SoCs.
+This package implements a generic prefetcher API, and example implementations of NextLine, Strided, and AMPM prefetchers.
+
+Prefetchers can be instantiated in front of a L1D HellaCache, or as TileLink nodes in front of some TileLink bus.
+
+An example configuration using prefetchers is found in the ``PrefetchingRocketConfig``

--- a/docs/Generators/index.rst
+++ b/docs/Generators/index.rst
@@ -34,3 +34,4 @@ so changes to the generators themselves will automatically be used when building
    NVDLA
    Sodor
    Mempress
+   Prefetchers

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -128,9 +128,9 @@ class CustomIOChipTopRocketConfig extends Config(
   new chipyard.config.AbstractConfig)
 
 class PrefetchingRocketConfig extends Config(
-  new barf.WithHellaCachePrefetcher(Seq(0), barf.SingleStridedPrefetcherParams()) ++   // strided prefetcher into L1D$
-  new barf.WithTLICachePrefetcher(barf.MultiNextLinePrefetcherParams()) ++             // next-line prefetcher into L2 for L1I$ accesses
-  new barf.WithTLDCachePrefetcher(barf.SingleAMPMPrefetcherParams()) ++                // AMPM prefetcher into L2 for L1D$ accesses
+  new barf.WithHellaCachePrefetcher(Seq(0), barf.SingleStridedPrefetcherParams()) ++   // strided prefetcher, sits in front of the L1D$, monitors core requests to prefetching into the L1D$
+  new barf.WithTLICachePrefetcher(barf.MultiNextLinePrefetcherParams()) ++             // next-line prefetcher, sits between L1I$ and L2, monitors L1I$ misses to prefetch into L2
+  new barf.WithTLDCachePrefetcher(barf.SingleAMPMPrefetcherParams()) ++                // AMPM prefetcher, site between L1D$ and L2, monitors L1D$ misses to prefetch into L2
   new chipyard.config.WithTilePrefetchers ++                                           // add TL prefetchers between tiles and the sbus
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++                               // single rocket-core
   new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -126,3 +126,11 @@ class CustomIOChipTopRocketConfig extends Config(
   new chipyard.example.WithCustomIOCells ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++         // single rocket-core
   new chipyard.config.AbstractConfig)
+
+class PrefetchingRocketConfig extends Config(
+  new barf.WithHellaCachePrefetcher(Seq(0), barf.SingleStridedPrefetcherParams()) ++   // strided prefetcher into L1D$
+  new barf.WithTLICachePrefetcher(barf.MultiNextLinePrefetcherParams()) ++             // next-line prefetcher into L2 for L1I$ accesses
+  new barf.WithTLDCachePrefetcher(barf.SingleAMPMPrefetcherParams()) ++                // AMPM prefetcher into L2 for L1D$ accesses
+  new chipyard.config.WithTilePrefetchers ++                                           // add TL prefetchers between tiles and the sbus
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++                               // single rocket-core
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/RocketConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RocketConfigs.scala
@@ -130,7 +130,8 @@ class CustomIOChipTopRocketConfig extends Config(
 class PrefetchingRocketConfig extends Config(
   new barf.WithHellaCachePrefetcher(Seq(0), barf.SingleStridedPrefetcherParams()) ++   // strided prefetcher, sits in front of the L1D$, monitors core requests to prefetching into the L1D$
   new barf.WithTLICachePrefetcher(barf.MultiNextLinePrefetcherParams()) ++             // next-line prefetcher, sits between L1I$ and L2, monitors L1I$ misses to prefetch into L2
-  new barf.WithTLDCachePrefetcher(barf.SingleAMPMPrefetcherParams()) ++                // AMPM prefetcher, site between L1D$ and L2, monitors L1D$ misses to prefetch into L2
+  new barf.WithTLDCachePrefetcher(barf.SingleAMPMPrefetcherParams()) ++                // AMPM prefetcher, sits between L1D$ and L2, monitors L1D$ misses to prefetch into L2
   new chipyard.config.WithTilePrefetchers ++                                           // add TL prefetchers between tiles and the sbus
+  new freechips.rocketchip.subsystem.WithNonblockingL1(2) ++                           // non-blocking L1D$, L1 prefetching only works with non-blocking L1D$
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++                               // single rocket-core
   new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/fragments/TileFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/TileFragments.scala
@@ -9,7 +9,10 @@ import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams
 
 import boom.common.{BoomTileAttachParams}
 import cva6.{CVA6TileAttachParams}
+import sodor.common.{SodorTileAttachParams}
+import ibex.{IbexTileAttachParams}
 import testchipip._
+import barf.{TilePrefetchingMasterPortParams}
 
 class WithL2TLBs(entries: Int) extends Config((site, here, up) => {
   case TilesLocated(InSubsystem) => up(TilesLocated(InSubsystem), site) map {
@@ -79,3 +82,17 @@ class WithRocketDCacheScratchpad extends Config((site, here, up) => {
   }
 })
 
+class WithTilePrefetchers extends Config((site, here, up) => {
+  case TilesLocated(InSubsystem) => up(TilesLocated(InSubsystem), site) map {
+    case tp: RocketTileAttachParams => tp.copy(crossingParams = tp.crossingParams.copy(
+      master = TilePrefetchingMasterPortParams(tp.tileParams.hartId, tp.crossingParams.master)))
+    case tp: BoomTileAttachParams => tp.copy(crossingParams = tp.crossingParams.copy(
+      master = TilePrefetchingMasterPortParams(tp.tileParams.hartId, tp.crossingParams.master)))
+    case tp: SodorTileAttachParams => tp.copy(crossingParams = tp.crossingParams.copy(
+      master = TilePrefetchingMasterPortParams(tp.tileParams.hartId, tp.crossingParams.master)))
+    case tp: IbexTileAttachParams => tp.copy(crossingParams = tp.crossingParams.copy(
+      master = TilePrefetchingMasterPortParams(tp.tileParams.hartId, tp.crossingParams.master)))
+    case tp: CVA6TileAttachParams => tp.copy(crossingParams = tp.crossingParams.copy(
+      master = TilePrefetchingMasterPortParams(tp.tileParams.hartId, tp.crossingParams.master)))
+  }
+})

--- a/scripts/tutorial-patches/build.sbt.patch
+++ b/scripts/tutorial-patches/build.sbt.patch
@@ -10,7 +10,7 @@ index ec36a85f..c0c2849a 100644
 +//    sha3, // On separate line to allow for cleaner tutorial-setup patches
      dsptools, `rocket-dsp-utils`,
      gemmini, icenet, tracegen, cva6, nvdla, sodor, ibex, fft_generator,
-     constellation, mempress)
+     constellation, mempress, barf)
 @@ -204,11 +204,11 @@ lazy val sodor = (project in file("generators/riscv-sodor"))
    .settings(libraryDependencies ++= rocketLibDeps.value)
    .settings(commonSettings)


### PR DESCRIPTION
BARF (BAR-fetchers) is a generic API for describing simple prefetchers, that can be instantiated in front of L1 HellaCaches, or in TileLink bus widgets.

Currently, a handful of example algorithms are implemented.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
