### PR TITLE
Update NoC example config to match new PRCI organization

### DIFF
--- a/generators/chipyard/src/main/scala/config/NoCConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/NoCConfigs.scala
@@ -68,9 +68,9 @@ class MultiNoCConfig extends Config(
         "serial-tl" -> 0),
       outNodeMapping = ListMap(
         "error" -> 1, "l2[0]" -> 2, "pbus" -> 3, "plic" -> 4,
-        "clint" -> 5, "dmInner" -> 6, "bootrom" -> 7, "tileClockGater" -> 8, "tileResetSetter" -> 9)),
+        "clint" -> 5, "dmInner" -> 6, "bootrom" -> 7, "clock" -> 8)),
     NoCParams(
-      topology = TerminalRouter(BidirectionalLine(10)),
+      topology = TerminalRouter(BidirectionalLine(9)),
       channelParamGen = (a, b) => UserChannelParams(Seq.fill(5) { UserVirtualChannelParams(4) }),
       routingRelation = NonblockingVirtualSubnetworksRouting(TerminalRouterRouting(BidirectionalLineRouting()), 5, 1))
   )) ++


### PR DESCRIPTION
NoC node mapping needs to be updated to match the new PRCI bus organization.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
