### PR TITLE
Improve peripheral fragments to include more peripheral devices and support instantiating multiple instances of same device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ project/project/
 .ivy2
 .sbt
 .classpath_cache/
+.vscode/

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -6,7 +6,8 @@ import chisel3.util.{log2Up}
 
 import org.chipsalliance.cde.config.{Config}
 import freechips.rocketchip.devices.tilelink.{BootROMLocated, PLICKey}
-import freechips.rocketchip.devices.debug.{Debug, ExportDebug, DebugModuleKey, DMI}
+import freechips.rocketchip.devices.debug.{Debug, ExportDebug, DebugModuleKey, DMI, JtagDTMKey, JtagDTMConfig}
+import freechips.rocketchip.diplomacy.{AsynchronousCrossing}
 import freechips.rocketchip.stage.phases.TargetDirKey
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tile.{XLen}
@@ -14,6 +15,7 @@ import freechips.rocketchip.tile.{XLen}
 import sifive.blocks.devices.gpio._
 import sifive.blocks.devices.uart._
 import sifive.blocks.devices.spi._
+import sifive.blocks.devices.i2c._
 
 import testchipip._
 
@@ -22,41 +24,65 @@ import chipyard.{ExtTLMem}
 // Set the bootrom to the Chipyard bootrom
 class WithBootROM extends Config((site, here, up) => {
   case BootROMLocated(x) => up(BootROMLocated(x), site)
-      .map(_.copy(contentFileName = s"${site(TargetDirKey)}/bootrom.rv${site(XLen)}.img"))
+      .map(_.copy(
+        address = 0x10000,
+        size = 0x10000,
+        hang = 0x10040,
+        contentFileName = s"${site(TargetDirKey)}/bootrom.rv${site(XLen)}.img"
+      ))
 })
 
 // DOC include start: gpio config fragment
-class WithGPIO extends Config((site, here, up) => {
-  case PeripheryGPIOKey => Seq(
-    GPIOParams(address = 0x10012000, width = 4, includeIOF = false))
+class WithGPIO(address: BigInt = 0x10010000, width: Int = 4) extends Config ((site, here, up) => {
+  case PeripheryGPIOKey => up(PeripheryGPIOKey) ++ Seq(
+    GPIOParams(address = address, width = width, includeIOF = false))
 })
 // DOC include end: gpio config fragment
 
-class WithUART(baudrate: BigInt = 115200) extends Config((site, here, up) => {
-  case PeripheryUARTKey => Seq(
-    UARTParams(address = 0x54000000L, nTxEntries = 256, nRxEntries = 256, initBaudRate = baudrate))
-})
-
 class WithNoUART extends Config((site, here, up) => {
   case PeripheryUARTKey => Nil
+})
+
+class WithUART(address: BigInt = 0x10020000, baudrate: BigInt = 115200) extends Config ((site, here, up) => {
+  case PeripheryUARTKey => up(PeripheryUARTKey) ++ Seq(
+    UARTParams(address = address, nTxEntries = 256, nRxEntries = 256, initBaudRate = baudrate))
 })
 
 class WithUARTFIFOEntries(txEntries: Int, rxEntries: Int) extends Config((site, here, up) => {
   case PeripheryUARTKey => up(PeripheryUARTKey).map(_.copy(nTxEntries = txEntries, nRxEntries = rxEntries))
 })
 
-class WithSPIFlash(size: BigInt = 0x10000000) extends Config((site, here, up) => {
+class WithSPIFlash(address: BigInt = 0x10030000, fAddress: BigInt = 0x20000000, size: BigInt = 0x10000000) extends Config((site, here, up) => {
   // Note: the default size matches freedom with the addresses below
-  case PeripherySPIFlashKey => Seq(
-    SPIFlashParams(rAddress = 0x10040000, fAddress = 0x20000000, fSize = size))
+  case PeripherySPIFlashKey => up(PeripherySPIFlashKey) ++ Seq(
+    SPIFlashParams(rAddress = address, fAddress = fAddress, fSize = size))
+})
+
+class WithSPI(address: BigInt = 0x10031000) extends Config((site, here, up) => {
+  case PeripherySPIKey => up(PeripherySPIKey) ++ Seq(
+    SPIParams(rAddress = address))
+})
+
+class WithI2C(address: BigInt = 0x10040000) extends Config((site, here, up) => {
+  case PeripheryI2CKey => up(PeripheryI2CKey) ++ Seq(
+    I2CParams(address = address, controlXType = AsynchronousCrossing(), intXType = AsynchronousCrossing())
+  )
+})
+
+class WithNoDebug extends Config((site, here, up) => {
+  case DebugModuleKey => None
 })
 
 class WithDMIDTM extends Config((site, here, up) => {
   case ExportDebug => up(ExportDebug, site).copy(protocols = Set(DMI))
 })
 
-class WithNoDebug extends Config((site, here, up) => {
-  case DebugModuleKey => None
+class WithJTAGDTMKey(idcodeVersion: Int = 2, partNum: Int = 0x000, manufId: Int = 0x489, debugIdleCycles: Int = 5) extends Config((site, here, up) => {
+  case JtagDTMKey => new JtagDTMConfig (
+    idcodeVersion = idcodeVersion,
+    idcodePartNum = partNum,
+    idcodeManufId = manufId,
+    debugIdleCycles = debugIdleCycles)
 })
 
 class WithTLBackingMemory extends Config((site, here, up) => {


### PR DESCRIPTION
Improve peripheral fragments to include more peripheral devices and support instantiating multiple instances of same device

This is a new PR regarding the discussion in #1397:
- Removed `WithUARTOverride` per requested. User can generate ChipConfig from scratch if the default UART address need to be changed.
- Added several other helpful peripheral config fragments, which are used in the tapeout class chip.
- Minor addition on ignoring the .vscode/ folder.


**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated thexconda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
