### PR TITLE
FIX: fixing docs, WithBackingScratchpad is deprecated, use WithScratchpad instead

### DIFF
--- a/docs/Customization/Memory-Hierarchy.rst
+++ b/docs/Customization/Memory-Hierarchy.rst
@@ -94,7 +94,7 @@ memory channel.
 
 Instead of connecting to off-chip DRAM, you can instead connect a scratchpad
 and remove the off-chip link. This is done by adding a fragment like
-``testchipip.WithBackingScratchpad`` to your configuration and removing the
+``testchipip.WithScratchpad`` to your configuration and removing the
 memory port with ``freechips.rocketchip.subsystem.WithNoMemPort``.
 
 .. literalinclude:: ../../generators/chipyard/src/main/scala/config/RocketConfigs.scala


### PR DESCRIPTION
`WithBackingScratchpad` is removed on [testchipip #3497d53](https://github.com/ucb-bar/testchipip/commit/3497d538f3fae4b0cc4db6ee9c19f289f7fa37aa). Users should use `WithScratchpad(base, size, banks, partitions, busWhere)` instead.


**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
