### PR TITLE
Improve peripheral config binders (Reapply #1511)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ project/project/
 .ivy2
 .sbt
 .classpath_cache/
+.vscode/

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -85,7 +85,7 @@ class WithUARTInitBaudRate(baudrate: BigInt = 115200) extends Config ((site, her
   * @param fAddress the address of the Execute-in-Place (XIP) region of the SPI flash memory
   * @param size the size of the Execute-in-Place (XIP) region of the SPI flash memory
   */
-class WithSPIFlash(size: BigInt = 0x10000000, address: BigInt = 0x10030000, fAddress: BigInt = 0x20000000) extends Config((site, here, up) => {
+class WithSPIFlash(size: BigInt = 0x10000000, address: BigInt = 0x10040000, fAddress: BigInt = 0x20000000) extends Config((site, here, up) => {
   // Note: the default size matches freedom with the addresses below
   case PeripherySPIFlashKey => up(PeripherySPIFlashKey) ++ Seq(
     SPIFlashParams(rAddress = address, fAddress = fAddress, fSize = size))

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -63,7 +63,7 @@ class WithNoUART extends Config((site, here, up) => {
   * @param address the address of the UART device
   * @param baudrate the baudrate of the UART device
   */
-class WithUART(address: BigInt = 0x10020000, baudrate: BigInt = 115200) extends Config ((site, here, up) => {
+class WithUART(baudrate: BigInt = 115200, address: BigInt = 0x10020000) extends Config ((site, here, up) => {
   case PeripheryUARTKey => up(PeripheryUARTKey) ++ Seq(
     UARTParams(address = address, nTxEntries = 256, nRxEntries = 256, initBaudRate = baudrate))
 })
@@ -79,7 +79,7 @@ class WithUARTFIFOEntries(txEntries: Int, rxEntries: Int) extends Config((site, 
   * @param fAddress the address of the Execute-in-Place (XIP) region of the SPI flash memory
   * @param size the size of the Execute-in-Place (XIP) region of the SPI flash memory
   */
-class WithSPIFlash(address: BigInt = 0x10030000, fAddress: BigInt = 0x20000000, size: BigInt = 0x10000000) extends Config((site, here, up) => {
+class WithSPIFlash(size: BigInt = 0x10000000, address: BigInt = 0x10030000, fAddress: BigInt = 0x20000000) extends Config((site, here, up) => {
   // Note: the default size matches freedom with the addresses below
   case PeripherySPIFlashKey => up(PeripherySPIFlashKey) ++ Seq(
     SPIFlashParams(rAddress = address, fAddress = fAddress, fSize = size))

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -85,7 +85,7 @@ class WithUARTInitBaudRate(baudrate: BigInt = 115200) extends Config ((site, her
   * @param fAddress the address of the Execute-in-Place (XIP) region of the SPI flash memory
   * @param size the size of the Execute-in-Place (XIP) region of the SPI flash memory
   */
-class WithSPIFlash(size: BigInt = 0x10000000, address: BigInt = 0x10040000, fAddress: BigInt = 0x20000000) extends Config((site, here, up) => {
+class WithSPIFlash(size: BigInt = 0x10000000, address: BigInt = 0x10030000, fAddress: BigInt = 0x20000000) extends Config((site, here, up) => {
   // Note: the default size matches freedom with the addresses below
   case PeripherySPIFlashKey => up(PeripherySPIFlashKey) ++ Seq(
     SPIFlashParams(rAddress = address, fAddress = fAddress, fSize = size))

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -72,6 +72,10 @@ class WithUARTFIFOEntries(txEntries: Int, rxEntries: Int) extends Config((site, 
   case PeripheryUARTKey => up(PeripheryUARTKey).map(_.copy(nTxEntries = txEntries, nRxEntries = rxEntries))
 })
 
+class WithUARTInitBaudRate(baudrate: BigInt = 115200) extends Config ((site, here, up) => {
+  case PeripheryUARTKey => up(PeripheryUARTKey).map(_.copy(initBaudRate=baudrate))
+})
+
 /**
   * Config fragment for adding a SPI peripheral device with Execute-in-Place capability to the SoC
   *

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -39,6 +39,7 @@ class WithBootROM(address: BigInt = 0x10000, size: Int = 0x10000, hang: BigInt =
       ))
 })
 
+// DOC include start: gpio config fragment
 /**
  * Config fragment for adding a GPIO peripheral device to the SoC
  * 
@@ -49,6 +50,7 @@ class WithGPIO(address: BigInt = 0x10010000, width: Int = 4) extends Config ((si
   case PeripheryGPIOKey => up(PeripheryGPIOKey) ++ Seq(
     GPIOParams(address = address, width = width, includeIOF = false))
 })
+// DOC include end: gpio config fragment
 
 /**
  * Config fragment for removing all UART peripheral devices from the SoC

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -92,7 +92,7 @@ class WithFireSimDesignTweaks extends Config(
   // Optional: reduce the width of the Serial TL interface
   new testchipip.WithSerialTLWidth(4) ++
   // Required*: Scale default baud rate with periphery bus frequency
-  new chipyard.config.WithUART(BigInt(3686400L)) ++
+  new chipyard.config.WithUARTInitBaudRate(BigInt(3686400L)) ++
   // Optional: Adds IO to attach tracerV bridges
   new chipyard.config.WithTraceIO ++
   // Optional: Request 16 GiB of target-DRAM by default (can safely request up to 32 GiB on F1)
@@ -241,7 +241,7 @@ class FireSimSmallSystemConfig extends Config(
   new freechips.rocketchip.subsystem.WithExtMemSize(1 << 28) ++
   new testchipip.WithDefaultSerialTL ++
   new testchipip.WithBlockDevice ++
-  new chipyard.config.WithUART ++
+  new chipyard.config.WithUARTInitBaudRate(BigInt(3686400L)) ++
   new freechips.rocketchip.subsystem.WithInclusiveCache(nWays = 2, capacityKB = 64) ++
   new chipyard.RocketConfig)
 

--- a/tests/spiflash.h
+++ b/tests/spiflash.h
@@ -5,7 +5,7 @@
 #define SPIFLASH_BASE_MEM 0x20000000
 #define SPIFLASH_BASE_MEM_SIZE 0x10000000
 
-#define SPIFLASH_BASE_CTRL 0x10040000
+#define SPIFLASH_BASE_CTRL 0x10030000
 // Only defining the registers we use; there are more
 // Software control
 #define SPIFLASH_OFFS_CSMODE 0x18


### PR DESCRIPTION
This reapplies #1511, while also keeping the default parameter order for `WithUART`/`WithSPIFlash`, so legacy configs which use those fragments will maintain the same behavior.

Do not merge until after 1.10.0

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
