### PR TITLE
ADD: add documentation for build-setup skip

### DIFF
--- a/docs/Chipyard-Basics/Initial-Repo-Setup.rst
+++ b/docs/Chipyard-Basics/Initial-Repo-Setup.rst
@@ -73,15 +73,15 @@ Run the following script based off which compiler you would like to use.
 .. Warning:: The following script will complete a "full" installation of Chipyard which may take a long time depending on the system.
     Ensure that this script completes fully (no interruptions) before continuing on. User can use the ``--skip`` or ``-s`` flag to skip steps:
     
-    ``-s 1`` skips initializing conda environment
+    ``-s 1`` skips initializing Conda environment
     
-    ``-s 2`` skips initializing chipyard submodules
+    ``-s 2`` skips initializing Chipyard submodules
     
     ``-s 3`` skips initializing toolchain collateral (Spike, PK, tests, libgloss)
     
     ``-s 4`` skips initializing ctags
     
-    ``-s 5`` skips pre-compiling chipyard Scala sources
+    ``-s 5`` skips pre-compiling Chipyard Scala sources
     
     ``-s 6`` skips initializing FireSim
     

--- a/docs/Chipyard-Basics/Initial-Repo-Setup.rst
+++ b/docs/Chipyard-Basics/Initial-Repo-Setup.rst
@@ -71,7 +71,27 @@ Run the following script based off which compiler you would like to use.
 .. Note:: Prior versions of Chipyard recommended ``esp-tools`` for Gemmini development. Gemmini should now be used with the standard ``riscv-tools``.
 
 .. Warning:: The following script will complete a "full" installation of Chipyard which may take a long time depending on the system.
-    Ensure that this script completes fully (no interruptions) before continuing on.
+    Ensure that this script completes fully (no interruptions) before continuing on. User can use the ``-s`` flag to skip steps:
+    
+    ``-s1`` skips initializing conda environment
+    
+    ``-s2`` skips initializing chipyard submodules
+    
+    ``-s3`` skips initializing toolchain collateral (Spike, PK, tests, libgloss)
+    
+    ``-s4`` skips initializing ctags
+    
+    ``-s5`` skips pre-compiling chipyard sources
+    
+    ``-s6`` skips initializing FireSim
+    
+    ``-s7`` skips pre-compiling FireSim sources
+    
+    ``-s8`` skips initializing FireMarshal
+    
+    ``-s9`` skips pre-compiling FireMarshal default buildroot Linux sources
+    
+    ``-s10`` skips running repository clean-up
 
 .. code-block:: shell
 

--- a/docs/Chipyard-Basics/Initial-Repo-Setup.rst
+++ b/docs/Chipyard-Basics/Initial-Repo-Setup.rst
@@ -71,27 +71,27 @@ Run the following script based off which compiler you would like to use.
 .. Note:: Prior versions of Chipyard recommended ``esp-tools`` for Gemmini development. Gemmini should now be used with the standard ``riscv-tools``.
 
 .. Warning:: The following script will complete a "full" installation of Chipyard which may take a long time depending on the system.
-    Ensure that this script completes fully (no interruptions) before continuing on. User can use the ``-s`` flag to skip steps:
+    Ensure that this script completes fully (no interruptions) before continuing on. User can use the ``--skip`` or ``-s`` flag to skip steps:
     
-    ``-s1`` skips initializing conda environment
+    ``-s 1`` skips initializing conda environment
     
-    ``-s2`` skips initializing chipyard submodules
+    ``-s 2`` skips initializing chipyard submodules
     
-    ``-s3`` skips initializing toolchain collateral (Spike, PK, tests, libgloss)
+    ``-s 3`` skips initializing toolchain collateral (Spike, PK, tests, libgloss)
     
-    ``-s4`` skips initializing ctags
+    ``-s 4`` skips initializing ctags
     
-    ``-s5`` skips pre-compiling chipyard sources
+    ``-s 5`` skips pre-compiling chipyard Scala sources
     
-    ``-s6`` skips initializing FireSim
+    ``-s 6`` skips initializing FireSim
     
-    ``-s7`` skips pre-compiling FireSim sources
+    ``-s 7`` skips pre-compiling FireSim sources
     
-    ``-s8`` skips initializing FireMarshal
+    ``-s 8`` skips initializing FireMarshal
     
-    ``-s9`` skips pre-compiling FireMarshal default buildroot Linux sources
+    ``-s 9`` skips pre-compiling FireMarshal default buildroot Linux sources
     
-    ``-s10`` skips running repository clean-up
+    ``-s 10`` skips running repository clean-up
 
 .. code-block:: shell
 


### PR DESCRIPTION
Add a comment on the docs that users may want to skip the firemarshal/firesim components if they are only using chipyard for RTL-dev/VLSI flows

**Related PRs / Issues**:
ERROR: Failed to build workload br-base.json when running `build-setup.sh` on BWRC server.

**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
