### PR TITLE
VLSI Fixes

### DIFF
--- a/vlsi/example-asap7.yml
+++ b/vlsi/example-asap7.yml
@@ -17,7 +17,7 @@ vlsi.inputs.power_spec_type: "cpf"
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_clock", period: "1ns", uncertainty: "0.1ns"}
+  {name: "clock_uncore_clock", period: "1ns", uncertainty: "0.1ns"}
 ]
 
 # Generate Make include to aid in flow

--- a/vlsi/example-design.yml
+++ b/vlsi/example-design.yml
@@ -10,7 +10,7 @@ vlsi.inputs.power_spec_type: "cpf"
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_clock", period: "2ns", uncertainty: "0.1ns"}
+  {name: "clock_uncore_clock", period: "2ns", uncertainty: "0.1ns"}
 ]
 
 # Specify pin properties

--- a/vlsi/example-designs/sky130-commercial.yml
+++ b/vlsi/example-designs/sky130-commercial.yml
@@ -2,7 +2,7 @@
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_clock", period: "30ns", uncertainty: "2ns"}
+  {name: "clock_uncore_clock", period: "30ns", uncertainty: "2ns"}
 ]
 
 # Placement Constraints

--- a/vlsi/example-designs/sky130-openroad-rockettile.yml
+++ b/vlsi/example-designs/sky130-openroad-rockettile.yml
@@ -1,7 +1,7 @@
 # Override configurations in ../example-sky130.yml and example-designs
 
 # Specify clock signals
-# Rocket/RocketTile names clock signal "clock" instead of "clock_clock"
+# Rocket/RocketTile names clock signal "clock" instead of "clock_uncore_clock"
 vlsi.inputs.clocks: [
   {name: "clock", period: "30ns", uncertainty: "3ns"}
 ]

--- a/vlsi/example-designs/sky130-openroad.yml
+++ b/vlsi/example-designs/sky130-openroad.yml
@@ -3,7 +3,7 @@
 # Specify clock signals
 # Relax the clock period for OpenROAD to meet timing
 vlsi.inputs.clocks: [
-  {name: "clock_clock", period: "50ns", uncertainty: "2ns"}
+  {name: "clock_uncore_clock", period: "50ns", uncertainty: "2ns"}
 ]
 
 # Flow parameters that yield a routable design with reasonable timing

--- a/vlsi/example-designs/sky130-rocket.yml
+++ b/vlsi/example-designs/sky130-rocket.yml
@@ -1,7 +1,7 @@
 # Override configurations in ../example-sky130.yml and example-designs
 
 # Specify clock signals
-# Rocket/RocketTile names clock signal "clock" instead of "clock_clock"
+# Rocket/RocketTile names clock signal "clock" instead of "clock_uncore_clock"
 vlsi.inputs.clocks: [
   {name: "clock", period: "5ns", uncertainty: "1ns"}
 ]

--- a/vlsi/example-sky130.yml
+++ b/vlsi/example-sky130.yml
@@ -20,7 +20,7 @@ vlsi.inputs.power_spec_type: "cpf"
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_clock", period: "20ns", uncertainty: "1ns"}
+  {name: "clock_uncore_clock", period: "20ns", uncertainty: "1ns"}
 ]
 
 # Generate Make include to aid in flow

--- a/vlsi/sim.mk
+++ b/vlsi/sim.mk
@@ -21,7 +21,7 @@ $(SIM_CONF): $(sim_common_files) check-binary
 	done
 	echo "  options_meta: 'append'" >> $@
 	echo "  defines:" >> $@
-	for x in $(subst +define+,,$(PREPROC_DEFINES)); do \
+	for x in $(subst +define+,,$(SIM_PREPROC_DEFINES)); do \
 		echo '    - "'$$x'"' >> $@; \
 	done
 	echo "  defines_meta: 'append'" >> $@
@@ -75,7 +75,7 @@ $(SIM_TIMING_CONF): $(sim_common_files)
 	echo "sim.inputs:" > $@
 	echo "  defines: ['NTC']" >> $@
 	echo "  defines_meta: 'append'" >> $@
-	echo "  timing_annotated: 'true'" >> $@
+	echo "  timing_annotated: true" >> $@
 
 # Update hammer top-level sim targets to include our generated sim configs
 redo-sim-rtl: $(SIM_CONF)


### PR DESCRIPTION
The clock name for TinyRocketConfig has changed from `clock_clock` to `clock_uncore_clock`.
Also the Make variable `PREPROC_DEFINES` was renamed to `SIM_PREPROC_DEFINES`, so Hammer was breaking because the sim.defines YAML key was being set to nothing.

Pulling these changes from #1514 so it's easier to merge for the release.
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
