### PR TITLE
Fixed typos in CDE docs page, and added info on how config fragments in the chain can be overridden

### DIFF
--- a/docs/Advanced-Concepts/CDEs.rst
+++ b/docs/Advanced-Concepts/CDEs.rst
@@ -39,6 +39,19 @@ When forming a query based on a ``Parameters`` object, like ``p(SomeKeyX)``, the
 
 In this example, the evaluation of ``params(SomeKeyX)`` will terminate in the partial function defined in ``WithX(true)``, while the evaluation of ``params(SomeKeyY)`` will terminate in the partial function defined in ``WithY(true)``. Note that when no partial functions match, the evaluation will return the default value for that parameter.
 
+Config fragments take precedence from left to right, meaning that a fragment at the start of the chain can override the value of a fragment to the right. It helps to read the fragment chain from right to left.
+
+.. code:: scala
+
+    case object SomeKeyX extends Field[Int](0)
+
+    class WithX(n: Int) extends Config((site, here, up) => {
+      case SomeKeyX => n
+    })
+
+    val params = new Config(new WithX(10) ++ new WithX(5))
+    println(params(SomeKeyX)) // evaluates to 10
+
 The real power of CDEs arises from the ``(site, here, up)`` parameters to the partial functions, which provide useful "views" into the global parameterization that the partial functions may access to determine a parameterization.
 
 .. note::

--- a/docs/Advanced-Concepts/CDEs.rst
+++ b/docs/Advanced-Concepts/CDEs.rst
@@ -21,18 +21,18 @@ Consider the following example using CDEs.
 
     class WithX(b: Boolean) extends Config((site, here, up) => {
       case SomeKeyX => b
-    }
+    })
 
     class WithY(b: Boolean) extends Config((site, here, up) => {
       case SomeKeyY => b
-    }
+    })
 
 
 When forming a query based on a ``Parameters`` object, like ``p(SomeKeyX)``, the configuration system traverses the "chain" of config fragments until it finds a partial function which is defined at the key, and then returns that value.
 
 .. code:: scala
 
-    val params = Config(new WithX(true) ++ new WithY(true)) // "chain" together config fragments
+    val params = new Config(new WithX(true) ++ new WithY(true)) // "chain" together config fragments
     params(SomeKeyX) // evaluates to true
     params(SomeKeyY) // evaluates to true
     params(SomeKeyZ) // evaluates to false
@@ -54,10 +54,10 @@ Site
 
     class WithXEqualsYSite extends Config((site, here, up) => {
       case SomeKeyX => site(SomeKeyY) // expands to site(SomeKeyY, site)
-    }
+    })
 
-    val params_1 = Config(new WithXEqualsYSite ++ new WithY(true))
-    val params_2 = Config(new WithY(true) ++ new WithXEqualsYSite)
+    val params_1 = new Config(new WithXEqualsYSite ++ new WithY(true))
+    val params_2 = new Config(new WithY(true) ++ new WithXEqualsYSite)
     params_1(SomeKeyX) // evaluates to true
     params_2(SomeKeyX) // evaluates to true
 
@@ -75,10 +75,10 @@ Here
     class WithXEqualsYHere extends Config((site, here, up) => {
       case SomeKeyY => false
       case SomeKeyX => here(SomeKeyY, site)
-    }
+    })
 
-    val params_1 = Config(new WithXEqualsYHere ++ new WithY(true))
-    val params_2 = Config(new WithY(true) ++ new WithXEqualsYHere)
+    val params_1 = new Config(new WithXEqualsYHere ++ new WithY(true))
+    val params_2 = new Config(new WithY(true) ++ new WithXEqualsYHere)
 
     params_1(SomeKeyX) // evaluates to false
     params_2(SomeKeyX) // evaluates to false
@@ -95,10 +95,10 @@ Up
 
     class WithXEqualsYUp extends Config((site, here, up) => {
       case SomeKeyX => up(SomeKeyY, site)
-    }
+    })
 
-    val params_1 = Config(new WithXEqualsYUp ++ new WithY(true))
-    val params_2 = Config(new WithY(true) ++ new WithXEqualsYUp)
+    val params_1 = new Config(new WithXEqualsYUp ++ new WithY(true))
+    val params_2 = new Config(new WithY(true) ++ new WithXEqualsYUp)
 
     params_1(SomeKeyX) // evaluates to true
     params_2(SomeKeyX) // evaluates to false


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
N/A
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [ ]  **(N/A)** Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?

The code snippets, as written, don't work when you paste them into a Scala file and run it, due to missing `)` and that there is no singleton `Config` object. I also think it's worth including on this page the way that config fragments toward the bottom/right get overridden by fragments on the left/top.