### PR TITLE
Docs add that ASAP7 tutorial should be executed in vlsi directory

### DIFF
--- a/docs/VLSI/ASAP7-Tutorial.rst
+++ b/docs/VLSI/ASAP7-Tutorial.rst
@@ -66,6 +66,12 @@ In the Chipyard root, ensure that you have the Chipyard conda environment activa
 
 to pull and install the plugin submodules. Note that for technologies other than ``sky130`` or ``asap7``, the tech submodule must be added in the ``vlsi`` folder first.
 
+Now navigate to the ``vlsi`` directory. The remainder of the tutorial will assume you are in this directory.
+
+.. code-block:: shell
+
+    cd ~chipyard/vlsi
+
 Building the Design
 --------------------
 To elaborate the ``TinyRocketConfig`` and set up all prerequisites for the build system to push the design and SRAM macros through the flow:


### PR DESCRIPTION
Add an explicit statement that the ASAP7 Tutorial flow should be executed in the `vlsi` directory.

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
