### PR TITLE
Use new CI machines

### DIFF
--- a/.github/scripts/remote-run-firesim-scala-tests.sh
+++ b/.github/scripts/remote-run-firesim-scala-tests.sh
@@ -14,8 +14,9 @@ cd $REMOTE_CHIPYARD_DIR
 ./scripts/init-submodules-no-riscv-tools.sh --force
 
 # Run Firesim Scala Tests
-export FIRESIM_ENV_SOURCED=1;
+export FIRESIM_ENV_SOURCED=1
 export COURSIER_CACHE=$REMOTE_COURSIER_CACHE
 export JVM_MEMORY=10G
 export JAVA_TMP_DIR=$REMOTE_JAVA_TMP_DIR
+export TEST_DISABLE_VIVADO=1
 make -C $REMOTE_FIRESIM_DIR TARGET_SBT_PROJECT="{file:$REMOTE_CHIPYARD_DIR}firechip" testOnly ${mapping[$1]}

--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -65,7 +65,7 @@ jobs:
     name: setup-repo
     needs: [change-filters, cancel-prior-workflows]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: ferry
+    runs-on: jktqos
     steps:
       - name: Delete old checkout
         run: |
@@ -88,7 +88,7 @@ jobs:
   run-cfg-finder:
     name: run-cfg-finder
     needs: [setup-repo]
-    runs-on: ferry
+    runs-on: jktqos
     steps:
       - name: Run config finder
         run: |
@@ -101,7 +101,7 @@ jobs:
   run-tutorial:
     name: run-tutorial
     needs: [setup-repo]
-    runs-on: ferry
+    runs-on: jktqos
     steps:
       - name: Run smoke test
         run: |
@@ -168,7 +168,7 @@ jobs:
   cleanup:
     name: cleanup
     needs: [run-tutorial]
-    runs-on: ferry
+    runs-on: jktqos
     if: ${{ always() }}
     steps:
       - name: Delete repo copy and conda env

--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -174,3 +174,4 @@ jobs:
       - name: Delete repo copy and conda env
         run: |
            rm -rf ${{ env.REMOTE_WORK_DIR }}
+           rm -rf ${{ env.JAVA_TMP_DIR }}

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -178,11 +178,11 @@ jobs:
             conda activate ${{ env.conda-env-name-no-time }}-$(date --date "${{ env.workflow-timestamp }}" +%Y%m%d)-riscv-tools
             .github/scripts/build-extra-tests.sh
 
-  create-conda-env-knight:
-    name: create-conda-env-knight
+  create-conda-env-jktgz:
+    name: create-conda-env-jktgz
     needs: [change-filters, cancel-prior-workflows]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: knight
+    runs-on: jktgz
     steps:
       - name: Delete old checkout
         run: |
@@ -199,11 +199,11 @@ jobs:
       - name: Create conda env
         uses: ./.github/actions/create-conda-env
 
-  create-conda-env-ferry:
-    name: create-conda-env-ferry
+  create-conda-env-jktqos:
+    name: create-conda-env-jktqos
     needs: [change-filters, cancel-prior-workflows]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: ferry
+    runs-on: jktqos
     steps:
       - name: Delete old checkout
         run: |
@@ -225,7 +225,7 @@ jobs:
   # When adding new prep jobs, please add them to `needs` below
   setup-complete:
     name: setup-complete
-    needs: [create-conda-env-knight, create-conda-env-ferry, build-extra-tests]
+    needs: [create-conda-env-jktgz, create-conda-env-jktqos, build-extra-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Set up complete
@@ -393,7 +393,7 @@ jobs:
   chipyard-spike-gemmini-run-tests:
     name: chipyard-spike-gemmini-run-tests
     needs: prepare-chipyard-accels # technically doesn't depend on RTL but should be after the build.sh for Gemmini
-    runs-on: ferry
+    runs-on: jktqos
     steps:
       - name: Delete old checkout
         run: |

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Generate keys
         id: genkey
         run: |
-          echo "::set-output name=extra-tests-cache-key::extra-tests-${{ github.sha }}"
+          echo "extra-tests-cache-key=extra-tests-${{ github.sha }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: build-extra-tools-cache
         with:


### PR DESCRIPTION
Use new CI machines. Explicitly disable Vivado FireSim tests since the CI machine also has Vivado installed on it (same functionality as before). Also ensure that `JAVA_TMP_DIR` is deleted on cleanup.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [x] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] (If applicable) Did you mark the PR as `Please Backport`?
