### PR TITLE
Bump lockfiles | Force user-installed conda during conda-lock

### DIFF
--- a/.github/actions/create-conda-env/action.yml
+++ b/.github/actions/create-conda-env/action.yml
@@ -10,8 +10,8 @@ runs:
         else
           echo "Creating a conda environment for each toolchain with the toolchain installed"
           conda activate base
-          conda-lock install -n ${{ env.conda-env-name-no-time }}-$(date --date "${{ env.workflow-timestamp }}" +%Y%m%d)-riscv-tools ./conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
-          conda-lock install -n ${{ env.conda-env-name-no-time }}-$(date --date "${{ env.workflow-timestamp }}" +%Y%m%d)-esp-tools ./conda-reqs/conda-lock-reqs/conda-requirements-esp-tools-linux-64.conda-lock.yml
+          conda-lock install --conda $(which conda) -n ${{ env.conda-env-name-no-time }}-$(date --date "${{ env.workflow-timestamp }}" +%Y%m%d)-riscv-tools ./conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
+          conda-lock install --conda $(which conda) -n ${{ env.conda-env-name-no-time }}-$(date --date "${{ env.workflow-timestamp }}" +%Y%m%d)-esp-tools ./conda-reqs/conda-lock-reqs/conda-requirements-esp-tools-linux-64.conda-lock.yml
           conda deactivate
 
           echo "Add extra toolchain collateral to RISC-V install area"

--- a/.github/scripts/install-conda.sh
+++ b/.github/scripts/install-conda.sh
@@ -145,15 +145,16 @@ else
     $SUDO bash ./install_conda.sh -b -p "$CONDA_INSTALL_PREFIX" $conda_install_extra
     rm ./install_conda.sh
 
+    # get most up-to-date conda version
+    "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" update $DRY_RUN_OPTION -y -n base -c conda-forge conda
+
     # see https://conda-forge.org/docs/user/tipsandtricks.html#multiple-channels
     # for more information on flexible channel_priority
     "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" config --system --set channel_priority flexible
     # By default, don't mess with people's PS1, I personally find it annoying
     "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" config --system --set changeps1 false
-    # don't automatically activate the 'base' environment when intializing shells
+    # don't automatically activate the 'base' environment when initializing shells
     "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" config --system --set auto_activate_base false
-    # don't automatically update conda to avoid https://github.com/conda-forge/conda-libmamba-solver-feedstock/issues/2
-    "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" config --system --set auto_update_conda false
     # automatically use the ucb-bar channel for specific packages https://anaconda.org/ucb-bar/repo
     "${DRY_RUN_ECHO[@]}" $SUDO "$CONDA_EXE" config --system --add channels ucb-bar
 

--- a/conda-reqs/chipyard.yaml
+++ b/conda-reqs/chipyard.yaml
@@ -23,8 +23,8 @@ dependencies:
     # bundle FireSim driver with deps into installer shell-script
     - constructor
 
-    - gcc
-    - gxx
+    - gcc<13
+    - gxx<13
     - sysroot_linux-64=2.17 # needed to match pre-built CI XRT glibc version
     - conda-gcc-specs
     - binutils

--- a/conda-reqs/conda-lock-reqs/conda-requirements-esp-tools-linux-64.conda-lock.yml
+++ b/conda-reqs/conda-lock-reqs/conda-requirements-esp-tools-linux-64.conda-lock.yml
@@ -21,7 +21,7 @@ metadata:
   - url: nodefaults
     used_env_vars: []
   content_hash:
-    linux-64: c82daab41979122418c73ddbeb064bef42659c857750ef19fe713af8e06f305d
+    linux-64: 967545a3d2b81a4de0339614d0f20b58c49406462f629da7d0dcc2451fb276aa
   platforms:
   - linux-64
   sources:
@@ -145,14 +145,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: 5ec50dcd74ba7461709c4ac9c4cc4190
-    sha256: 749dabbfe7b571affa19ef3ddb23e22e2eed12d5a699a9830a0f7fba2f296e02
+    md5: b9ae31bc2e565684ebaf82d4bd954d55
+    sha256: 257495088b78d4344c7ea21145581ed6da1c5bf8320f49b659ce2ed2d6265f76
   manager: conda
   name: libgcc-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-13.1.0-he3cc6c4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_0.conda
+  version: 12.3.0
 - category: main
   dependencies: {}
   hash:
@@ -167,14 +167,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: e703914ad2288ab24cf5ac94d812fc11
-    sha256: 21b95f21a80462c832caa348ece5413e10ba69d922dca01826706fe7b6f3a764
+    md5: 7c80158949230e6d837186b20b2fcf13
+    sha256: b311dad92ffafd29668fca6330dc707f4d7f154a4fa4c3859832897416de39ec
   manager: conda
   name: libstdcxx-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-13.1.0-he3cc6c4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_0.conda
+  version: 12.3.0
 - category: main
   dependencies: {}
   hash:
@@ -189,14 +189,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: 374b3bf084169a90f41675d19b0ad35a
-    sha256: f8d37016976d69b9b983a9299783884fd746258666f7e47a0dd1f5b3b0259568
+    md5: 0fde972b336190cd618fe158e7b8f295
+    sha256: b72044c8657645a8a8f7a7e1b8f37b552080cd67df06ef1054e34831677ca66d
   manager: conda
   name: open_pdks.sky130a
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.422_0_gd9f6d38-20230709_210322.tar.bz2
-  version: 1.0.422_0_gd9f6d38
+  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.423_0_g1604945-20230709_210322.tar.bz2
+  version: 1.0.423_0_g1604945
 - category: main
   dependencies: {}
   hash:
@@ -693,16 +693,16 @@ package:
   version: 0.3.23
 - category: main
   dependencies:
-    libgcc-ng: '>=13.1.0'
+    libgcc-ng: '>=12.3.0'
   hash:
-    md5: 7594fd17fb4d1b8b0e47a6b306fe01ae
-    sha256: 49214f61c270400e4da89f00b6b24565dc59d1d8b869fa003a22aeacaeca3851
+    md5: bbc8fef17925480272a671b1d83431fa
+    sha256: 2fa38e53f7d58789283af351f014748a485ec8f4e7db3f150ed6274f50983663
   manager: conda
   name: libsanitizer
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.1.0-hfd8a6a1_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1209,21 +1209,21 @@ package:
 - category: main
   dependencies:
     binutils_impl_linux-64: '>=2.39'
-    libgcc-devel_linux-64: 13.1.0 he3cc6c4_0
-    libgcc-ng: '>=13.1.0'
-    libgomp: '>=13.1.0'
-    libsanitizer: 13.1.0 hfd8a6a1_0
-    libstdcxx-ng: '>=13.1.0'
+    libgcc-devel_linux-64: 12.3.0 h8bca6fd_0
+    libgcc-ng: '>=12.3.0'
+    libgomp: '>=12.3.0'
+    libsanitizer: 12.3.0 h0f45ef3_0
+    libstdcxx-ng: '>=12.3.0'
     sysroot_linux-64: ''
   hash:
-    md5: 99d1a8a8ee1665ee9435f8d160df69fe
-    sha256: d728da49acc79f2a46f9abe1f603fd4ccc9fc96f533b1647e3c836985caa5924
+    md5: 1e41f51d89695fd3f810e2245517460b
+    sha256: ccbbb82de1ca95b02477e4340c5791e49424b379c6caa27e89bae3c40b7ad296
   manager: conda
   name: gcc_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.1.0-hc4be1a9_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1661,16 +1661,16 @@ package:
   version: 1.0.9
 - category: main
   dependencies:
-    gcc_impl_linux-64: '>=13.1.0,<13.1.1.0a0'
+    gcc_impl_linux-64: '>=12.3.0,<12.3.1.0a0'
   hash:
-    md5: bf50acee3dbe6198ad304538eedd9413
-    sha256: a89b1750b88e5b2d3f3326a1755267dcd20ee1998cef9e961dde1d67890c584c
+    md5: 203fbb799caffdf242ccef5f9879d3a1
+    sha256: b9db23cd4fd2df43c06734b3cdb7491e03472679282a058bca7148455704b6a4
   manager: conda
   name: conda-gcc-specs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.1.0-h0612280_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-12.3.0-h83fac38_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1714,16 +1714,16 @@ package:
   version: 2.12.1
 - category: main
   dependencies:
-    gcc_impl_linux-64: 13.1.0.*
+    gcc_impl_linux-64: 12.3.0.*
   hash:
-    md5: 847c6849a2a4ca12e907c17872694d23
-    sha256: b6ee942b1d9b30c2d6eda2a2c36ba05f26a4a8a625d8aa27d5fbaa13045399ab
+    md5: 8da41232e71a99e3ff1cc43350d0f0fb
+    sha256: 1cd58fecd56680f8e8eda18fa3d557231b7016cd3de50c73a0ce8b79303d37b9
   manager: conda
   name: gcc
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.1.0-h8e92de4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1743,18 +1743,18 @@ package:
   version: 3.7.8
 - category: main
   dependencies:
-    gcc_impl_linux-64: 13.1.0 hc4be1a9_0
-    libstdcxx-devel_linux-64: 13.1.0 he3cc6c4_0
+    gcc_impl_linux-64: 12.3.0 he2b93b0_0
+    libstdcxx-devel_linux-64: 12.3.0 h8bca6fd_0
     sysroot_linux-64: ''
   hash:
-    md5: e6591b3c81fc5fb83e342b20a2506e80
-    sha256: a2e154839f057a4fc540c038de13db3c562bccf361a06ed5072e1c74691c4062
+    md5: 3f00aa0a8f8d3924890fecae937cc6bd
+    sha256: 87c7ec85f76aa065c2c991acd7bbf86d25b4724bc283f793400c14f5d5e39aa0
   manager: conda
   name: gxx_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.1.0-hc4be1a9_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     keyutils: '>=1.6.1,<2.0a0'
@@ -2364,17 +2364,17 @@ package:
   version: 0.7.6
 - category: main
   dependencies:
-    gcc: 13.1.0.*
-    gxx_impl_linux-64: 13.1.0.*
+    gcc: 12.3.0.*
+    gxx_impl_linux-64: 12.3.0.*
   hash:
-    md5: 5592c3280d50f5dc8dc548ba98c6e9ba
-    sha256: 3c99a6df3f0cac1b8730fea9cc32fab07475b1b8a9b1e7a10d3951bdf29a415f
+    md5: c6f5830abf6e0849e32eeaa8feb6af2e
+    sha256: e6734338ae19b90956532cbab5792e57ec0885fd1e36ab95fe0d1f6e5b5959e4
   manager: conda
   name: gxx
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.1.0-h8e92de4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -3710,14 +3710,14 @@ package:
     more-itertools: ''
     python: '>=3.7'
   hash:
-    md5: 31e4a1506968d017229bdb64695013a1
-    sha256: 6a81b67a1de8f761f66a4540bbd07cc27f9fbf2c7d67aa3732ebef379cf62874
+    md5: e9f79248d30e942f7c358ff21a1790f5
+    sha256: 14f5240c3834e1b784dd41a5a14392d9150dff62a74ae851f73e65d2e2bbd891
   manager: conda
   name: jaraco.classes
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.2.3-pyhd8ed1ab_0.tar.bz2
-  version: 3.2.3
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.0-pyhd8ed1ab_0.conda
+  version: 3.3.0
 - category: main
   dependencies:
     markupsafe: '>=2.0'
@@ -4924,14 +4924,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
   hash:
-    md5: 0edc7c1cfd7921df59c922f2b734ff1c
-    sha256: 232a3ad207515d492274b004bf59bacc7254893086ac0d72fe0108cea2834dbf
+    md5: 191ea267121cccd3531e98ea5b869b87
+    sha256: 3172c3714a3c6abc729af5335dfbf2ac02acc01ec64ad1d30413bd49f1bd0497
   manager: conda
   name: botocore
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.1-pyhd8ed1ab_0.conda
-  version: 1.31.1
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.2-pyhd8ed1ab_0.conda
+  version: 1.31.2
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4999,14 +4999,14 @@ package:
     six: '>=1.11.0'
     typing-extensions: '>=4.0.1'
   hash:
-    md5: 5576496c2743cafa05111ac76267db29
-    sha256: 51951b49a43b7de818ad055d113348f7e438e225fc7a5f8f4c635998239c4c89
+    md5: 3f61696f5c09ca1e7001d042c9968c1d
+    sha256: da22c5d95a9ed937509b696568cd51580f3becec90febf0e5b1aca1096bf4c24
   manager: conda
   name: azure-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.27.1-pyhd8ed1ab_0.conda
-  version: 1.27.1
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.28.0-pyhd8ed1ab_0.conda
+  version: 1.28.0
 - category: main
   dependencies:
     msgpack-python: '>=0.5.2'
@@ -5166,7 +5166,7 @@ package:
   version: 5.1.1
 - category: main
   dependencies:
-    botocore: 1.31.1
+    botocore: 1.31.2
     colorama: '>=0.2.5,<0.4.5'
     docutils: '>=0.10,<0.17'
     python: '>=3.9,<3.10.0a0'
@@ -5175,29 +5175,29 @@ package:
     rsa: '>=3.1.2,<4.8'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: fc7abf3233e1843ceccccdb17c4f2b99
-    sha256: d44ceac9af03e60b4f626b7c9263084ae92ecc2266116c37c438209b5058bc62
+    md5: 7d905f150353c988f96214e8938f6f97
+    sha256: b5d6ee42625204b702eaa07d612d9b19aad1f5f9f90caac7f6bac1f1a401953e
   manager: conda
   name: awscli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.29.1-py39hf3d152e_0.conda
-  version: 1.29.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.29.2-py39hf3d152e_0.conda
+  version: 1.29.2
 - category: main
   dependencies:
-    botocore: '>=1.31.1,<1.32.0'
+    botocore: '>=1.31.2,<1.32.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.7'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 3a0123e890ea210f6468121bdfa6cfc0
-    sha256: 4fea48dc33349ea59efe4f8ddb6c4ec2fbec24c49a7482263893498bc6e506ca
+    md5: 1ebffec127102119aff7a572243464da
+    sha256: 454975a1def5ec1043925403547f9cf938c91a534c62cba509eb108b253bbf89
   manager: conda
   name: boto3
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.28.1-pyhd8ed1ab_0.conda
-  version: 1.28.1
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.28.2-pyhd8ed1ab_0.conda
+  version: 1.28.2
 - category: main
   dependencies:
     cachecontrol: 0.13.0 pyhd8ed1ab_0
@@ -5323,14 +5323,14 @@ package:
     python: ''
     typing_extensions: ''
   hash:
-    md5: e07be93e70ff9affb934ff017a86c722
-    sha256: c3a63fce78c2b080803b2a40cc3f5fe9e5ade617efe278cf09b6b89c8f0ea232
+    md5: 31349469d53ac0877f3a90842023571d
+    sha256: feb48351ca5a328d200a7307d041b05f5d1e476151929951e1a11a1ecede8d4e
   manager: conda
   name: boto3-stubs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.28.1-pyhd8ed1ab_0.conda
-  version: 1.28.1
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.28.2-pyhd8ed1ab_0.conda
+  version: 1.28.2
 - category: main
   dependencies:
     cachecontrol-with-filecache: '>=0.12.9'

--- a/conda-reqs/conda-lock-reqs/conda-requirements-esp-tools-linux-64.conda-lock.yml
+++ b/conda-reqs/conda-lock-reqs/conda-requirements-esp-tools-linux-64.conda-lock.yml
@@ -9,7 +9,7 @@
 # To update a single package to the latest version compatible with the version constraints in the source:
 #     conda-lock lock --lockfile conda-requirements-esp-tools-linux-64.conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
-#     conda-lock -f /scratch/abejgonza/cy/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy/conda-reqs/esp-tools.yaml -f /scratch/abejgonza/cy-check/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy-check/conda-reqs/esp-tools.yaml --lockfile conda-requirements-esp-tools-linux-64.conda-lock.yml
+#     conda-lock -f /scratch/abejgonza/cy/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy/conda-reqs/esp-tools.yaml -f /scratch/abejgonza/cy-check/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy-check/conda-reqs/esp-tools.yaml -f /scratch/abejgonza/new-cy/conda-reqs/chipyard.yaml -f /scratch/abejgonza/new-cy/conda-reqs/esp-tools.yaml --lockfile conda-requirements-esp-tools-linux-64.conda-lock.yml
 metadata:
   channels:
   - url: ucb-bar
@@ -29,6 +29,8 @@ metadata:
   - /scratch/abejgonza/cy/conda-reqs/esp-tools.yaml
   - /scratch/abejgonza/cy-check/conda-reqs/chipyard.yaml
   - /scratch/abejgonza/cy-check/conda-reqs/esp-tools.yaml
+  - /scratch/abejgonza/new-cy/conda-reqs/chipyard.yaml
+  - /scratch/abejgonza/new-cy/conda-reqs/esp-tools.yaml
 package:
 - category: main
   dependencies: {}
@@ -143,58 +145,58 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: 199a7292b1d3535376ecf7670c231d1f
-    sha256: d6df7758b85d4f82baaa526bff1b9f0a9ae2b73b0df7fcb27cafdaf5e24fdefb
+    md5: 5ec50dcd74ba7461709c4ac9c4cc4190
+    sha256: 749dabbfe7b571affa19ef3ddb23e22e2eed12d5a699a9830a0f7fba2f296e02
   manager: conda
   name: libgcc-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.2.0-h3b97bd3_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-13.1.0-he3cc6c4_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 164b4b1acaedc47ee7e658ae6b308ca3
-    sha256: 03ea784edd12037dc3a7a0078ff3f9c3383feabb34d5ba910bb2fd7a21a2d961
+    md5: afb656a334c409dd9805508af1c89c7a
+    sha256: a06235f4c4b85b463d9b8a73c9e10c1b5b4105f8a0ea8ac1f2f5f64edac3dfe7
   manager: conda
   name: libgfortran5
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-12.2.0-h337968e_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.1.0-h15d22d2_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 277d373b57791ee71cafc3c5bfcf0641
-    sha256: 152a54b52b0bc0cda89b4394e43f010ce2a16f4012a3e706709d53a68407df46
+    md5: e703914ad2288ab24cf5ac94d812fc11
+    sha256: 21b95f21a80462c832caa348ece5413e10ba69d922dca01826706fe7b6f3a764
   manager: conda
   name: libstdcxx-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.2.0-h3b97bd3_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-13.1.0-he3cc6c4_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 1030b1f38c129f2634eae026f704fe60
-    sha256: 0289e6a7b9a5249161a3967909e12dcfb4ab4475cdede984635d3fb65c606f08
+    md5: 067bcc23164642f4c226da631f2a2e1d
+    sha256: 6f9eb2d7a96687938c0001166a3b308460a8eb02b10e9d0dd9e251f0219ea05c
   manager: conda
   name: libstdcxx-ng
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-12.2.0-h46fd767_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 0299e410bfb4300540bdc0012a7985ef
-    sha256: 8572efb7092c72fe7b73d2a0f1e5e27159a8edea0371e1bef533bcb7d85b19c6
+    md5: 374b3bf084169a90f41675d19b0ad35a
+    sha256: f8d37016976d69b9b983a9299783884fd746258666f7e47a0dd1f5b3b0259568
   manager: conda
   name: open_pdks.sky130a
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.406_0_g0c37b7c-20230412_103222.tar.bz2
-  version: 1.0.406_0_g0c37b7c
+  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.422_0_gd9f6d38-20230709_210322.tar.bz2
+  version: 1.0.422_0_gd9f6d38
 - category: main
   dependencies: {}
   hash:
@@ -246,28 +248,28 @@ package:
   version: 3.10.0
 - category: main
   dependencies:
-    libgfortran5: 12.2.0 h337968e_19
+    libgfortran5: 13.1.0 h15d22d2_0
   hash:
-    md5: cd7a806282c16e1f2d39a7e80d3a3e0d
-    sha256: c7d061f323e80fbc09564179073d8af303bf69b953b0caddcf79b47e352c746f
+    md5: 506dc07710dd5b0ba63cbf134897fc10
+    sha256: 429e1d8a3e70b632df5b876e3fc322a56f769756693daa07114c46fa5098684e
   manager: conda
   name: libgfortran-ng
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-12.2.0-h69a702a_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.1.0-h69a702a_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     _libgcc_mutex: 0.1 conda_forge
   hash:
-    md5: cedcee7c064c01c403f962c9e8d3c373
-    sha256: 81a76d20cfdee9fe0728b93ef057ba93494fd1450d42bc3717af4e468235661e
+    md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
+    sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
   manager: conda
   name: libgomp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-12.2.0-h65d4601_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     _libgcc_mutex: 0.1 conda_forge
@@ -324,14 +326,14 @@ package:
     _libgcc_mutex: 0.1 conda_forge
     _openmp_mutex: '>=4.5'
   hash:
-    md5: e4c94f80aef025c17ab0828cd85ef535
-    sha256: f3899c26824cee023f1e360bd0859b0e149e2b3e8b1668bc6dd04bfc70dcd659
+    md5: cd93f779ff018dd85c7544c015c9db3c
+    sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
   manager: conda
   name: libgcc-ng
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-12.2.0-h65d4601_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -559,25 +561,25 @@ package:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
   hash:
-    md5: f67106643beadfc737b94ca0bfd6d8e3
-    sha256: 1778dc86603df24aaf6865f7f3e1ffc5c793a0f1fc4570add2a6ccb4c0a62785
+    md5: d1db1b8be7c3a8983dcbbbfe4f0765de
+    sha256: 3c6fab31ed4dc8428605588454596b307b1bd59d33b0c7073c407ab51408b011
   manager: conda
   name: libabseil
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230125.2-cxx17_h59595ed_2.conda
-  version: '20230125.2'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230125.3-cxx17_h59595ed_0.conda
+  version: '20230125.3'
 - category: main
   dependencies:
     libgcc-ng: '>=12'
   hash:
-    md5: 9194c9bf9428035a05352d031462eae4
-    sha256: ddc961a36d498aaafd5b71078836ad5dd247cc6ba7924157f3801a2f09b77b14
+    md5: 61641e239f96eae2b8492dc7e755828c
+    sha256: fc57c0876695c5b4ab7173438580c1d7eaa7dccaf14cb6467ca9e0e97abe0cf0
   manager: conda
   name: libbrotlicommon
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
@@ -679,28 +681,28 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libgfortran-ng: ''
-    libgfortran5: '>=10.4.0'
+    libgfortran5: '>=11.3.0'
   hash:
-    md5: 8c5963a49b6035c40646a763293fbb35
-    sha256: 018372af663987265cb3ca8f37ac8c22b5f39219f65a0c162b056a30af11bba0
+    md5: 9c5ea51ccb8ffae7d06c645869d24ce6
+    sha256: 00aee12d04979d024c7f9cabccff5f5db2852c934397ec863a4abde3e09d5a79
   manager: conda
   name: libopenblas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.21-pthreads_h78a6416_3.tar.bz2
-  version: 0.3.21
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.23-pthreads_h80387f5_0.conda
+  version: 0.3.23
 - category: main
   dependencies:
-    libgcc-ng: '>=12.2.0'
+    libgcc-ng: '>=13.1.0'
   hash:
-    md5: 80d0e00150401e9c06a055f36e8e73f2
-    sha256: 6cf904606c091e1cab5cf3b1f1bb0d6756474e6e37b1a97a502fc1255d71641b
+    md5: 7594fd17fb4d1b8b0e47a6b306fe01ae
+    sha256: 49214f61c270400e4da89f00b6b24565dc59d1d8b869fa003a22aeacaeca3851
   manager: conda
   name: libsanitizer
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.2.0-h46fd767_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.1.0-hfd8a6a1_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -777,25 +779,25 @@ package:
   dependencies:
     libgcc-ng: '>=12'
   hash:
-    md5: 0d4a7508d8c6c65314f2b9c1f56ad408
-    sha256: ac3e073ea77803da71eb77e7fcef07defb345bda95eee3327c73ddf85b5714da
+    md5: 82bf6f63eb15ef719b556b63feec3a77
+    sha256: 66658d5cdcf89169e284488d280b6ce693c98c0319d7eabebcedac0929140a73
   manager: conda
   name: libwebp-base
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.0-h0b41bf4_0.conda
-  version: 1.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.1-hd590300_0.conda
+  version: 1.3.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
   hash:
-    md5: f3f9de449d32ca9b9c66a22863c96f41
-    sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
+    md5: f36c115f1ee199da648e0597ec2047ad
+    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
   manager: conda
   name: libzlib
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
   version: 1.2.13
 - category: main
   dependencies:
@@ -848,16 +850,16 @@ package:
   version: '4.3'
 - category: main
   dependencies:
-    libgcc-ng: '>=10.3.0'
+    libgcc-ng: '>=12'
   hash:
-    md5: 4acfc691e64342b9dae57cf2adc63238
-    sha256: b801e8cf4b2c9a30bce5616746c6c2a4e36427f045b46d9fc08a4ed40a9f7065
+    md5: 681105bccc2a3f7f1a837d47d39c9179
+    sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
   manager: conda
   name: ncurses
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2
-  version: '6.3'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+  version: '6.4'
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1207,21 +1209,21 @@ package:
 - category: main
   dependencies:
     binutils_impl_linux-64: '>=2.39'
-    libgcc-devel_linux-64: 12.2.0 h3b97bd3_19
-    libgcc-ng: '>=12.2.0'
-    libgomp: '>=12.2.0'
-    libsanitizer: 12.2.0 h46fd767_19
-    libstdcxx-ng: '>=12.2.0'
+    libgcc-devel_linux-64: 13.1.0 he3cc6c4_0
+    libgcc-ng: '>=13.1.0'
+    libgomp: '>=13.1.0'
+    libsanitizer: 13.1.0 hfd8a6a1_0
+    libstdcxx-ng: '>=13.1.0'
     sysroot_linux-64: ''
   hash:
-    md5: bb48ea333c8e6dcc159a1575f04d869e
-    sha256: 1e67063ca887c0569c647d7e8e3da9d09234585ed0fce7f728d6709d7314d0f5
+    md5: 99d1a8a8ee1665ee9435f8d160df69fe
+    sha256: d728da49acc79f2a46f9abe1f603fd4ccc9fc96f533b1647e3c836985caa5924
   manager: conda
   name: gcc_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.2.0-hcc96c02_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.1.0-hc4be1a9_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1237,41 +1239,41 @@ package:
   version: '1.6'
 - category: main
   dependencies:
-    libopenblas: '>=0.3.21,<1.0a0'
+    libopenblas: '>=0.3.23,<1.0a0'
   hash:
-    md5: d9b7a8639171f6c6fa0a983edabcfe2b
-    sha256: 4e4c60d3fe0b95ffb25911dace509e3532979f5deef4364141c533c5ca82dd39
+    md5: 57fb44770b1bc832fb2dbefa1bd502de
+    sha256: 5a9dfeb9ede4b7ac136ac8c0b589309f8aba5ce79d14ca64ad8bffb3876eb04b
   manager: conda
   name: libblas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-16_linux64_openblas.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-17_linux64_openblas.conda
   version: 3.9.0
 - category: main
   dependencies:
-    libbrotlicommon: 1.0.9 h166bdaf_8
+    libbrotlicommon: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: 4ae4d7795d33e02bd20f6b23d91caf82
-    sha256: d88ba07c3be27c89cb4975cc7edf63ee7b1c62d01f70d5c3f7efeb987c82b052
+    md5: 081aa22f4581c08e4372b0b6c2f8478e
+    sha256: 564f301430c3c61bc5e149e74157ec181ed2a758befc89f7c38466d515a0f614
   manager: conda
   name: libbrotlidec
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
-    libbrotlicommon: 1.0.9 h166bdaf_8
+    libbrotlicommon: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: 04bac51ba35ea023dc48af73c1c88c25
-    sha256: a0468858b2f647f51509a32040e93512818a8f9980f20b3554cccac747bcc4be
+    md5: 1f0a03af852a9659ed2bf08f2f1704fd
+    sha256: d27bc2562ea3f3b2bfd777f074f1cac6bfa4a737233dad288cd87c4634a9bb3a
   manager: conda
   name: libbrotlienc
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
@@ -1350,14 +1352,14 @@ package:
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
   hash:
-    md5: 498393f87a3979b097e4c14d9c53438a
-    sha256: ea98b575ac097670bc3179389322967c9da3e67adc30ffa2cff8d4a70f9a19a2
+    md5: c8da7f04073ed0fabcb60885a4c1a722
+    sha256: b0255d3c46c71e184d0513566a770356abf2cede5e795c4944521c4f7b6a26d4
   manager: conda
   name: libprotobuf
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.2-hd1fb520_2.conda
-  version: 4.23.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.3-hd1fb520_0.conda
+  version: 4.23.3
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1374,17 +1376,17 @@ package:
 - category: main
   dependencies:
     libgcc-ng: '>=12'
-    libzlib: '>=1.2.12,<1.3.0a0'
-    openssl: '>=3.0.5,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.1,<4.0a0'
   hash:
-    md5: d85acad4b47dff4e3def14a769a97906
-    sha256: 9a9a01f35d2d50326eb8ca7c0a92d0c45b2d0f77d9ea117680c70094ff480c0c
+    md5: 1f5a58e686b13bcfde88b93f547d23fe
+    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
   manager: conda
   name: libssh2
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.10.0-hf14f497_3.tar.bz2
-  version: 1.10.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  version: 1.11.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1472,16 +1474,16 @@ package:
   version: '10.40'
 - category: main
   dependencies:
-    libgcc-ng: '>=9.4.0'
+    libgcc-ng: '>=12'
     libnsl: '>=2.0.0,<2.1.0a0'
   hash:
-    md5: 09ba115862623f00962e9809ea248f1a
-    sha256: a116c1d3c64a072280b441c43d893d341a1d37d16ec18afc76eee40299deabfa
+    md5: 53dc30c420516340641b00ec1571dd53
+    sha256: 7e282c6b4106ccb00b3e5be9fc7f863b003d732ba51f76696ab23544a047a4fb
   manager: conda
   name: perl
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-2_h7f98852_perl5.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-3_hd590300_perl5.conda
   version: 5.32.1
 - category: main
   dependencies:
@@ -1578,15 +1580,15 @@ package:
 - category: main
   dependencies:
     libgcc-ng: '>=12'
-    libzlib: 1.2.13 h166bdaf_4
+    libzlib: 1.2.13 hd590300_5
   hash:
-    md5: 4b11e365c0275b808be78b30f904e295
-    sha256: 282ce274ebe6da1fbd52efbb61bd5a93dec0365b14d64566e6819d1691b75300
+    md5: 68c34ec6149623be41a1933ab996a209
+    sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
   manager: conda
   name: zlib
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h166bdaf_4.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
   version: 1.2.13
 - category: main
   dependencies:
@@ -1594,13 +1596,13 @@ package:
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
   hash:
-    md5: 6b63daed8feeca47be78f323e793d555
-    sha256: fbe49a8c8df83c2eccb37c5863ad98baeb29796ec96f2c503783d7b89bf80c98
+    md5: 32ae18eb2a687912fc9e92a501c0a11b
+    sha256: a7f7e765dfb7af5265a38080e46f18cb07cfeecf81fe28fad23c4538e7d521c3
   manager: conda
   name: zstd
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-h3eb15da_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-hfc55251_7.conda
   version: 1.5.2
 - category: main
   dependencies:
@@ -1645,30 +1647,30 @@ package:
   version: 3.8.2
 - category: main
   dependencies:
-    libbrotlidec: 1.0.9 h166bdaf_8
-    libbrotlienc: 1.0.9 h166bdaf_8
+    libbrotlidec: 1.0.9 h166bdaf_9
+    libbrotlienc: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: e5613f2bc717e9945840ff474419b8e4
-    sha256: ab1994e03bdd88e4b27f9f802ac18e45ed29b92cce25e1fd86da43b89734950f
+    md5: d47dee1856d9cb955b8076eeff304a5b
+    sha256: 1c128f136a59ee2fa47d7fbd9b6fc8afa8460d340e4ae0e6f5419ebbd7539a10
   manager: conda
   name: brotli-bin
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
-    gcc_impl_linux-64: '>=12.2.0,<12.2.1.0a0'
+    gcc_impl_linux-64: '>=13.1.0,<13.1.1.0a0'
   hash:
-    md5: 8b6a817ae6f518315cd82a8e826077e8
-    sha256: d5230896809664dec267b3f06b50586de5d7cda22a914b82dc5ab136251d94fd
+    md5: bf50acee3dbe6198ad304538eedd9413
+    sha256: a89b1750b88e5b2d3f3326a1755267dcd20ee1998cef9e961dde1d67890c584c
   manager: conda
   name: conda-gcc-specs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-12.2.0-he6d4335_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.1.0-h0612280_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1712,16 +1714,16 @@ package:
   version: 2.12.1
 - category: main
   dependencies:
-    gcc_impl_linux-64: 12.2.0.*
+    gcc_impl_linux-64: 13.1.0.*
   hash:
-    md5: ec93d13e0fe8514f65842120dbae1b16
-    sha256: 5478f5b7672b6c2d5b644aaa9fe18fbb1468ca6ea9cea1b0f0a2254459438e24
+    md5: 847c6849a2a4ca12e907c17872694d23
+    sha256: b6ee942b1d9b30c2d6eda2a2c36ba05f26a4a8a625d8aa27d5fbaa13045399ab
   manager: conda
   name: gcc
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.2.0-h26027b1_13.conda
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.1.0-h8e92de4_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1741,18 +1743,18 @@ package:
   version: 3.7.8
 - category: main
   dependencies:
-    gcc_impl_linux-64: 12.2.0 hcc96c02_19
-    libstdcxx-devel_linux-64: 12.2.0 h3b97bd3_19
+    gcc_impl_linux-64: 13.1.0 hc4be1a9_0
+    libstdcxx-devel_linux-64: 13.1.0 he3cc6c4_0
     sysroot_linux-64: ''
   hash:
-    md5: 698aae34e4f5e0ea8eac0d529c8f20b6
-    sha256: eaca73bdeabe7d862f41e88be18788d00bd2135bc6003bbe7423e96c4275b944
+    md5: e6591b3c81fc5fb83e342b20a2506e80
+    sha256: a2e154839f057a4fc540c038de13db3c562bccf361a06ed5072e1c74691c4062
   manager: conda
   name: gxx_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.2.0-hcc96c02_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.1.0-hc4be1a9_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     keyutils: '>=1.6.1,<2.0a0'
@@ -1791,15 +1793,15 @@ package:
   version: 3.5.2
 - category: main
   dependencies:
-    libblas: 3.9.0 16_linux64_openblas
+    libblas: 3.9.0 17_linux64_openblas
   hash:
-    md5: 20bae26d0a1db73f758fc3754cab4719
-    sha256: e4ceab90a49cb3ac1af20177016dc92066aa278eded19646bb928d261b98367f
+    md5: 7ef0969b00fe3d6eef56a8151d3afb29
+    sha256: 535bc0a6bc7641090b1bdd00a001bb6c4ac43bce2a11f238bc6676252f53eb3f
   manager: conda
   name: libcblas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-16_linux64_openblas.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-17_linux64_openblas.conda
   version: 3.9.0
 - category: main
   dependencies:
@@ -1811,25 +1813,25 @@ package:
     libzlib: '>=1.2.13,<1.3.0a0'
     pcre2: '>=10.40,<10.41.0a0'
   hash:
-    md5: a64f11b244b2c112cd3fa1cbe9493999
-    sha256: 6a34c6b123f06fcee7e28e981ec0daad09bce35616ad8e9e61ef84be7fad4d92
+    md5: c6f951789c888f7bbd2dd6858eab69de
+    sha256: e909b5e648d1ace172aac2ddf9d755f72429b134155a9b07156acb58a77ceee1
   manager: conda
   name: libglib
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.76.3-hebfc3b9_0.conda
-  version: 2.76.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.76.4-hebfc3b9_0.conda
+  version: 2.76.4
 - category: main
   dependencies:
-    libblas: 3.9.0 16_linux64_openblas
+    libblas: 3.9.0 17_linux64_openblas
   hash:
-    md5: 955d993f41f9354bf753d29864ea20ad
-    sha256: f5f30b8049dfa368599e5a08a4f35cb1966af0abc539d1fd1f50d93db76a74e6
+    md5: a2103882c46492e26500fcb56c03de8b
+    sha256: 45128394d2f4d4caf949c1b02bff1cace3ef2e33762dbe8f0edec7701a16aaa9
   manager: conda
   name: liblapack
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_openblas.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-17_linux64_openblas.conda
   version: 3.9.0
 - category: main
   dependencies:
@@ -1859,31 +1861,31 @@ package:
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.2,<1.6.0a0'
   hash:
-    md5: 4e5ee4b062c21519efbee7e2ae608748
-    sha256: caacb23e1b95fbdd8115be69228f9c82068ed87bf57f055027e31d093ae6a1a2
+    md5: 8ad377fb60abab446a9f02c62b3c2190
+    sha256: 920943ad46869938bd070ccd4c0117594e07538bc6b27b75462594c67b6f215d
   manager: conda
   name: libtiff
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-ha587672_6.conda
-  version: 4.5.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.1-h8b53f26_0.conda
+  version: 4.5.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
-    libprotobuf: '>=4.23.2,<4.23.3.0a0'
+    libprotobuf: '>=4.23.3,<4.23.4.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.3,<7.0a0'
-    openssl: '>=3.1.0,<4.0a0'
+    ncurses: '>=6.4,<7.0a0'
+    openssl: '>=3.1.1,<4.0a0'
     perl: '>=5.32.1,<5.33.0a0 *_perl5'
   hash:
-    md5: 2cf0c4f7a0a46c75e27735d16fab1501
-    sha256: 412157ab852270658e1b96e6f66e00f8ca7039ea8d4ae24090b1d3f726fadfac
+    md5: 434a2df8dbd192cb511290763a4f93d8
+    sha256: b0424b21c5d1790c04e96a7d62e10326fa3c8b0c263ad8cb4eda707b94317f98
   manager: conda
   name: mosh
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mosh-1.4.0-pl5321h4605741_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/mosh-1.4.0-pl5321hc529e37_2.conda
   version: 1.4.0
 - category: main
   dependencies:
@@ -1983,14 +1985,14 @@ package:
     xorg-xextproto: '>=7.3.0,<8.0a0'
     xorg-xproto: ''
   hash:
-    md5: 52d09ea80a42c0466214609ef0a2d62d
-    sha256: 26e5c72def9f1b191afea84aa2d09622d34b2f547a446eac201ecf894521e5ee
+    md5: 7590b76c3d11d21caa44f3fc38ac584a
+    sha256: 3360f81f7687179959a6bf1c762938240172e8bb3aef957e0a14fb12a0b7c105
   manager: conda
   name: xorg-libx11
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h8ee46fc_1.conda
-  version: 1.8.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.6-h8ee46fc_0.conda
+  version: 1.8.6
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2017,16 +2019,16 @@ package:
   version: 1.4.4
 - category: main
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
   hash:
-    md5: 0b3460f5bf4ae27dfd72fdcccc9667a9
-    sha256: 18aad01518cb08e4eff18e507e14ebf6c522d89ef53ca267c48080933c4435f7
+    md5: 964bace0c38ce4733851a2a29679e3f9
+    sha256: 1fe9b55d3daeb26ac404ec51f106ce8792d7d6548810ca87600cd9b9e9cfbd6e
   manager: conda
   name: argcomplete
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.0.8-pyhd8ed1ab_0.conda
-  version: 3.0.8
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.1-pyhd8ed1ab_0.conda
+  version: 3.1.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -2067,18 +2069,18 @@ package:
   version: 1.6.2
 - category: main
   dependencies:
-    brotli-bin: 1.0.9 h166bdaf_8
-    libbrotlidec: 1.0.9 h166bdaf_8
-    libbrotlienc: 1.0.9 h166bdaf_8
+    brotli-bin: 1.0.9 h166bdaf_9
+    libbrotlidec: 1.0.9 h166bdaf_9
+    libbrotlienc: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: 2ff08978892a3e8b954397c461f18418
-    sha256: 74c0fa22ea7c62d2c8f7a7aea03a3bd4919f7f3940ef5b027ce0dfb5feb38c06
+    md5: 4601544b4982ba1861fa9b9c607b2c06
+    sha256: 2357d205931912def55df0dc53573361156b27856f9bf359d464da162812ec1f
   manager: conda
   name: brotli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
@@ -2118,29 +2120,29 @@ package:
   version: 3.3.1
 - category: main
   dependencies:
-    python: '>=3.6'
+    python: '>=3.7'
   hash:
-    md5: c1d5b294fbf9a795dec349a6f4d8be8e
-    sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
+    md5: 313516e9a4b08b12dfb1e1cd390a96e3
+    sha256: 0666a95fbbd2299008162e2126c009191e5953d1cad1878bf9f4d8d634af1dd4
   manager: conda
   name: charset-normalizer
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2
-  version: 2.1.1
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.2.0-pyhd8ed1ab_0.conda
+  version: 3.2.0
 - category: main
   dependencies:
-    python: '>=3.9,<3.10.0a0'
-    python_abi: 3.9.* *_cp39
+    __unix: ''
+    python: '>=3.8'
   hash:
-    md5: 3613ff4128b3e565d048106196206929
-    sha256: 21c425ecc4e6f4ec97aab1285b22ad629c75d2efb62f89cd6d9618ab6a2e606c
+    md5: fcae73fbdce7981fd500c626bb1ba6ab
+    sha256: 63f2b103488ba80b274f25bade66394fdd02344024fce45ab44e45861931c61d
   manager: conda
   name: click
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/click-8.1.3-py39hf3d152e_1.tar.bz2
-  version: 8.1.3
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.4-unix_pyh707e725_0.conda
+  version: 8.1.4
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2250,26 +2252,26 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 7312299d7a0ea4993159229b7d2dceb2
-    sha256: f073c3ba993912f1c0027bc34a54975642885f0a4cd5f9dc42a17ca945df2c18
+    md5: de4cb3384374e1411f0454edcf546cdb
+    sha256: 7b23ea0169fa6e7c3a0867d96d9eacd312759f83e5d83ad0fcc93e85379c16ae
   manager: conda
   name: exceptiongroup
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.1-pyhd8ed1ab_0.conda
-  version: 1.1.1
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.2-pyhd8ed1ab_0.conda
+  version: 1.1.2
 - category: main
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 650f18a56f366dbf419c15b543592c2d
-    sha256: 68db3a6280d6786be76f2c7c6cf41dd878c5d1a24f5de10f7f0af82c6fcfade6
+    md5: 53522ec72e6adae42bd373ef58357230
+    sha256: 1cbae9f05860f2e566e2977f14dfcd5494beb22c028b0a853ade4ec381d9de71
   manager: conda
   name: filelock
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.12.0-pyhd8ed1ab_0.conda
-  version: 3.12.0
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.12.2-pyhd8ed1ab_0.conda
+  version: 3.12.2
 - category: main
   dependencies:
     expat: '>=2.5.0,<3.0a0'
@@ -2304,14 +2306,14 @@ package:
   dependencies:
     python: '>=3.8'
   hash:
-    md5: 20edd290b319aa0eff3e9055375756dc
-    sha256: cbb5c77c0217cda9bf4f4240158de11822a099a6eaa05ba626e822819a54f46d
+    md5: 50ea2067ec92dfcc38b4f07992d7e235
+    sha256: 0015e12d85b454ca8e09085e9e788a6156f4f1da1b270019cab2658381d60258
   manager: conda
   name: fsspec
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.5.0-pyh1a96a4e_0.conda
-  version: 2023.5.0
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.6.0-pyh1a96a4e_0.conda
+  version: 2023.6.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -2348,31 +2350,31 @@ package:
   version: 2.1.2
 - category: main
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    libglib: '>=2.66.4,<3.0a0'
-    libstdcxx-ng: '>=9.3.0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.76.3,<3.0a0'
+    libstdcxx-ng: '>=12'
   hash:
-    md5: 112eb9b5b93f0c02e59aea4fd1967363
-    sha256: ed9ae774aa867ad41bb0aa3f4a088f326dec32ab3468040322dbbd6c5bf33b0a
+    md5: 4d8df0b0db060d33c9a702ada998a8fe
+    sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
   manager: conda
   name: gts
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h64030ff_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
   version: 0.7.6
 - category: main
   dependencies:
-    gcc: 12.2.0.*
-    gxx_impl_linux-64: 12.2.0.*
+    gcc: 13.1.0.*
+    gxx_impl_linux-64: 13.1.0.*
   hash:
-    md5: de605ff437f3fdc010f1b529642339f1
-    sha256: 58bc0a7ff843c4ac2fd53b1370d266d635b59cf8d1d6f165cc26cf1f5324c9f8
+    md5: 5592c3280d50f5dc8dc548ba98c6e9ba
+    sha256: 3c99a6df3f0cac1b8730fea9cc32fab07475b1b8a9b1e7a10d3951bdf29a415f
   manager: conda
   name: gxx
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.2.0-h26027b1_13.conda
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.1.0-h8e92de4_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -2577,14 +2579,14 @@ package:
     gnutls: '>=3.7.8,<3.8.0a0'
     libgcc-ng: '>=12'
   hash:
-    md5: a946cb6b36807a772748b55f59089a08
-    sha256: 33ddfa3d91816ee44df405424ee2fedf5df5c02a1ffa1819aa4c956eedae4533
+    md5: 20e3667699ceaae97d6ba110a098e8f8
+    sha256: 8530794bb59332eefea6af1e7e3e7289a5fe40d2c4d265357af72b67ff6ee38e
   manager: conda
   name: libmicrohttpd
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.76-h87ba234_0.conda
-  version: 0.9.76
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.77-h97afed2_0.conda
+  version: 0.9.77
 - category: main
   dependencies:
     python: '>=3.4'
@@ -2603,17 +2605,17 @@ package:
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=2.1.5.1,<3.0a0'
     libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
-    libwebp-base: '>=1.3.0,<2.0a0'
+    libtiff: '>=4.5.1,<4.6.0a0'
+    libwebp-base: '>=1.3.1,<2.0a0'
   hash:
-    md5: 9cfd7ad6e1539ca1ad172083586b3301
-    sha256: 461fe2c0279309c21f206f114f3bd6592e906ef6f8cc181b2e28482941b8b925
+    md5: 4963f3f12db45a576f2b8fbe9a0b8569
+    sha256: b0428f43bb3bc4544b997fcd9dfeb5593ee10701e8895cef22212105a8d8aa8d
   manager: conda
   name: libwebp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.3.0-hb47c5f0_0.conda
-  version: 1.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.3.1-hbf2b3c1_0.conda
+  version: 1.3.1
 - category: main
   dependencies:
     python: ''
@@ -2632,14 +2634,14 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.* *_cp39
   hash:
-    md5: 35514f5320206df9f4661c138c02e1c1
-    sha256: da31fe95611393bb7dd3dee309a89328448570fd8a3205c2c55c03eb73688b61
+    md5: 9c858d105816f454c6b64f3e19184b60
+    sha256: de3be21c64141b6ca1fc404977145ec06291f8efe67077412ac84868ffe7feb0
   manager: conda
   name: markupsafe
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.2-py39h72bdee0_0.conda
-  version: 2.1.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py39hd1e30aa_0.conda
+  version: 2.1.3
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2727,14 +2729,14 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.* *_cp39
   hash:
-    md5: 8626d6d5169950ce4b99b082667773f7
-    sha256: c8fac78b5292c279449e4ccba03661dd75f9d39b0f5d40b8bf55c3fcd89f64ce
+    md5: d3e2ec4b400a6ad93057a29b7e3cb701
+    sha256: 282da8ac8a70cf6fbc7a28fd5dcd12a09957bcb14ab3b9956ee67c7ed011d583
   manager: conda
   name: numpy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.3-py39h6183b62_0.conda
-  version: 1.24.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.25.1-py39h6183b62_0.conda
+  version: 1.25.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -2789,17 +2791,16 @@ package:
   version: 1.9.6
 - category: main
   dependencies:
-    python: '>=3.9,<3.10.0a0'
-    python_abi: 3.9.* *_cp39
+    python: '>=3.8'
   hash:
-    md5: d86903c57fe229d9dd8878a6dd9d149f
-    sha256: abf2d34464c6255d35703e3c9477475e3e6e353ca8675990596d2477cdbc5b52
+    md5: 7263924c642d22e311d9e59b839f1b33
+    sha256: ff1f70e0bd50693be7e2bad0efb2539f5dcc5ec4d638e787e703f28098e72de4
   manager: conda
   name: pluggy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pluggy-1.0.0-py39hf3d152e_4.tar.bz2
-  version: 1.0.0
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.2.0-pyhd8ed1ab_0.conda
+  version: 1.2.0
 - category: main
   dependencies:
     python: '>=3.9,<3.10.0a0'
@@ -2905,14 +2906,14 @@ package:
   dependencies:
     python: '>=3.6'
   hash:
-    md5: e8fbc1b54b25f4b08281467bc13b70cc
-    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    md5: d3ed087d1f7f8f5590e8e87b57a8ce64
+    sha256: 18e3bd52c64f23bbc7c200fd2fc4152dd29423936dc43e8f129cb43f1af0136c
   manager: conda
   name: pyparsing
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
-  version: 3.0.9
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.0-pyhd8ed1ab_0.conda
+  version: 3.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3025,14 +3026,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 3b68bc43ec6baa48f7354a446267eefe
-    sha256: 3ac44771fce01f19218bcdf3992e24984748048db69889a9df65abcc6a10e29b
+    md5: 5a7739d0f57ee64133c9d32e6507c46d
+    sha256: 083a0913f5b56644051f31ac40b4eeea762a88c00aa12437817191b85a753cec
   manager: conda
   name: setuptools
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-67.7.2-pyhd8ed1ab_0.conda
-  version: 67.7.2
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.0.0-pyhd8ed1ab_0.conda
+  version: 68.0.0
 - category: main
   dependencies:
     python: ''
@@ -3243,14 +3244,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 5a4a270e5a3f93846d6bade2f71fa440
-    sha256: 8af96d7b665daabe3e60fa9c7457986237db1ad54469b01af3f4736bc18be284
+    md5: c39d6a09fe819de4951c2642629d9115
+    sha256: 6edd6d5be690be492712cb747b6d62707f0d0c34ef56eefc796d91e5a03187d1
   manager: conda
   name: typing_extensions
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.6.2-pyha770c72_0.conda
-  version: 4.6.2
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.7.1-pyha770c72_0.conda
+  version: 4.7.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3300,14 +3301,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: bfe7e7cd1476092f51efbcde15dfb110
-    sha256: 85310b382c4220d7846fa8f046216fd722b88db07991f07bd7decdf2e5dc3446
+    md5: c34d9325a609381a0b0e8a5b4f325147
+    sha256: c71cb65ac49692adb33735f3114b99a96c0c5140db1d56cf4ccef4fe92ea9a4c
   manager: conda
   name: websocket-client
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
-  version: 1.5.2
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.1-pyhd8ed1ab_0.conda
+  version: 1.6.1
 - category: main
   dependencies:
     python: '>=3.7'
@@ -3376,18 +3377,18 @@ package:
   version: 5.0.3
 - category: main
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-libx11: '>=1.7.0,<2.0a0'
+    libgcc-ng: '>=12'
+    xorg-libx11: '>=1.8.6,<2.0a0'
     xorg-renderproto: ''
   hash:
-    md5: f59c1242cc1dd93e72c2ee2b360979eb
-    sha256: 7d907ed9e2ec5af5d7498fb3ab744accc298914ae31497ab6dcc6ef8bd134d00
+    md5: ed67c36f215b310412b2af935bf3e530
+    sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
   manager: conda
   name: xorg-libxrender
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2
-  version: 0.9.10
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+  version: 0.9.11
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3407,16 +3408,16 @@ package:
   version: 1.3.0
 - category: main
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
   hash:
-    md5: 13018819ca8f5b7cc675a8faf1f5fedf
-    sha256: 241de30545299be9bcea3addf8a2c22a3b3d4ba6730890e150ab690ac937a3d2
+    md5: 0ea0b5003b96e53769a5f70175ff5264
+    sha256: 14b78fc742efdf46e3ecff0a4b89cbdf780b8cf22c822024cc642e4284339ea4
   manager: conda
   name: zipp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
-  version: 3.15.0
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.0-pyhd8ed1ab_1.conda
+  version: 3.16.0
 - category: main
   dependencies:
     frozenlist: '>=1.1.0'
@@ -3560,14 +3561,14 @@ package:
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.* *_cp39
   hash:
-    md5: c5387f3fb1f5b8b71e1c865fc55f4951
-    sha256: 74a767b73686caf0bb1d1186cd62a54f01e03ad5432eaaf0a7babad7634c4067
+    md5: 54e6f32e448fdc273606011f0940d076
+    sha256: 61a3d4a322dc310fa53ec3d8f58d6f9ef75f1fcacfcda88b1e4fabd7506b36c2
   manager: conda
   name: contourpy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.0.7-py39h4b4f3f3_0.conda
-  version: 1.0.7
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.0-py39h7633fee_0.conda
+  version: 1.1.0
 - category: main
   dependencies:
     krb5: '>=1.20.1,<1.21.0a0'
@@ -3630,14 +3631,14 @@ package:
     python_abi: 3.9.* *_cp39
     unicodedata2: '>=14.0.0'
   hash:
-    md5: 80605b792f58cf5c78a5b7e20cef1e35
-    sha256: a7e7256d309fa6561e28aedaaabafceb7b3c04a6261fa3fc9cd7aac4e89df823
+    md5: 5f7c468bf9d9551a80187db7e809ef1f
+    sha256: 9d4a61bf76070a197ec565943a1811b53260ec3a468a14671bbf8b9c36a1232f
   manager: conda
   name: fonttools
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.39.4-py39hd1e30aa_0.conda
-  version: 4.39.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.40.0-py39hd1e30aa_0.conda
+  version: 4.40.0
 - category: main
   dependencies:
     python: '>=3.4'
@@ -3683,27 +3684,27 @@ package:
     python: '>=3.8'
     zipp: '>=0.5'
   hash:
-    md5: f91a5d5175fb7ff2a91952ec7da59cb9
-    sha256: 33d49065756a73fbb92277c756fa00a41891408528eb90ae05ff3367a401ae6e
+    md5: 4e9f59a060c3be52bc4ddc46ee9b6946
+    sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
   manager: conda
   name: importlib-metadata
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.6.0-pyha770c72_0.conda
-  version: 6.6.0
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+  version: 6.8.0
 - category: main
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
     zipp: '>=3.1.0'
   hash:
-    md5: e5fd2260a231ee63b6969f4801082f2b
-    sha256: 091cca3e010f7a7353152f0abda2d68cfd83ddde80a15e974d9e18b2047e7be2
+    md5: a08b6be5bf18b9d2a927d3457750f82e
+    sha256: 94c1b2831c0f908ae56212d9aeb9c9173051d307682b4fedfd88fef774b0b8f7
   manager: conda
   name: importlib_resources
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-5.12.0-pyhd8ed1ab_0.conda
-  version: 5.12.0
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.0.0-pyhd8ed1ab_1.conda
+  version: 6.0.0
 - category: main
   dependencies:
     more-itertools: ''
@@ -3805,14 +3806,14 @@ package:
     tomli: '>=1.1.0'
     typing_extensions: '>=3.10'
   hash:
-    md5: 752593aa8094de1c8606411d13d003fb
-    sha256: 973ade2e49e9bc73b2364322506c5cc39320037ac416f45b133801bc2706446a
+    md5: 51533b4b6e7faadfffe35dd60bb47767
+    sha256: 6139824c025225888eed5cf7032081c87bd720c32ae8e9e80680179a1bd5a74c
   manager: conda
   name: mypy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.3.0-py39hd1e30aa_0.conda
-  version: 1.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.4.1-py39hd1e30aa_0.conda
+  version: 1.4.1
 - category: main
   dependencies:
     python: 2.7|>=3.7
@@ -3832,8 +3833,8 @@ package:
     lcms2: '>=2.15,<3.0a0'
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
-    libwebp-base: '>=1.3.0,<2.0a0'
+    libtiff: '>=4.5.1,<4.6.0a0'
+    libwebp-base: '>=1.3.1,<2.0a0'
     libxcb: '>=1.15,<1.16.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openjpeg: '>=2.5.0,<3.0a0'
@@ -3841,14 +3842,14 @@ package:
     python_abi: 3.9.* *_cp39
     tk: '>=8.6.12,<8.7.0a0'
   hash:
-    md5: d7aa9b99ed6ade75fbab1e4cedcb3ce2
-    sha256: 3cb87b24c89cd4fdb0c448982e6d37d6974332160f7576c1a99d0eb59f537444
+    md5: f97a95fab7c69678ebf6b57396b1323e
+    sha256: 8182e1782baaef35efdbb80468db7df160af7bd4ec46127d5c284768eca2980b
   manager: conda
   name: pillow
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.5.0-py39haaeba84_1.conda
-  version: 9.5.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.0-py39haaeba84_0.conda
+  version: 10.0.0
 - category: main
   dependencies:
     python: '>=3.7'
@@ -3863,6 +3864,24 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/noarch/pip-23.1.2-pyhd8ed1ab_0.conda
   version: 23.1.2
+- category: main
+  dependencies:
+    colorama: ''
+    exceptiongroup: '>=1.0.0rc8'
+    iniconfig: ''
+    packaging: ''
+    pluggy: '>=0.12,<2.0'
+    python: '>=3.7'
+    tomli: '>=1.0.0'
+  hash:
+    md5: 3cfe9b9e958e7238a386933c75d190db
+    sha256: 52b2eb4e8d0380d92d45643d0c9706725e691ce8404dab4c2db4aaf58e48a23c
+  manager: conda
+  name: pytest
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.0-pyhd8ed1ab_0.conda
+  version: 7.4.0
 - category: main
   dependencies:
     python: '>=3.6'
@@ -3916,14 +3935,14 @@ package:
     ruamel.yaml.clib: '>=0.1.2'
     setuptools: ''
   hash:
-    md5: bb9509b491be59807c5c935516b223f2
-    sha256: bc9f26d477c5f3748a7f3060096ffe3fefda330dc7d249843130fd3c17431073
+    md5: 9195e245f63b036613cca28dd499efdf
+    sha256: 3bf4ce9639e4acc647ad878a331714c0982df00702440c0f4993fbd6ce2bde99
   manager: conda
   name: ruamel.yaml
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.31-py39hd1e30aa_0.conda
-  version: 0.17.31
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.32-py39hd1e30aa_0.conda
+  version: 0.17.32
 - category: main
   dependencies:
     colorama: ''
@@ -3952,16 +3971,16 @@ package:
   version: 2.31.0.1
 - category: main
   dependencies:
-    typing_extensions: 4.6.2 pyha770c72_0
+    typing_extensions: 4.7.1 pyha770c72_0
   hash:
-    md5: f676553904bb8f7c1dfe71c9db0d9ba7
-    sha256: 5c6dcf5ff0d6be8a15d6bf5297867d9cb0154b6b946e8c87f69becf8a356e71b
+    md5: f96688577f1faa58096d06a45136afa2
+    sha256: d5d19b8f5b275240c19616a46d67ec57250b3720ba88200da8c732c3fcbfc21d
   manager: conda
   name: typing-extensions
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.6.2-hd8ed1ab_0.conda
-  version: 4.6.2
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.7.1-hd8ed1ab_0.conda
+  version: 4.7.1
 - category: main
   dependencies:
     gettext: '>=0.21.1,<1.0a0'
@@ -3987,14 +4006,14 @@ package:
     markupsafe: '>=2.1.1'
     python: '>=3.8'
   hash:
-    md5: 23ddbe41ab0115bc0bfb75dcbf5de7cf
-    sha256: 2df1970270839b36e13a4ba7e4b393cfa95aa1d7438909aa8c3db14170ea207c
+    md5: 55fbbb3e67185820ee2007395bfe0073
+    sha256: 28515f7ddb8a20f1436b9ac3a6ba2aa9be337995e4ee63c72d0f5d0efd6a2062
   manager: conda
   name: werkzeug
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.4-pyhd8ed1ab_0.conda
-  version: 2.3.4
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.6-pyhd8ed1ab_0.conda
+  version: 2.3.6
 - category: main
   dependencies:
     libgcc-ng: '>=9.3.0'
@@ -4027,6 +4046,19 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.2-py39hd1e30aa_0.conda
   version: 1.9.2
+- category: main
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.0.0'
+  hash:
+    md5: 578ae086f225bc2380c79f3b551ff2f7
+    sha256: bbabfd4400b03ba6c50d0a55e777e0c3ba900af8dabedb9b8aded774484b5d53
+  manager: conda
+  name: annotated-types
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.5.0-pyhd8ed1ab_0.conda
+  version: 0.5.0
 - category: main
   dependencies:
     python: '>=3.6'
@@ -4144,32 +4176,32 @@ package:
     libgcc-ng: '>=12'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.0,<4.0a0'
+    openssl: '>=3.1.1,<4.0a0'
     pcre2: '>=10.40,<10.41.0a0'
     perl: 5.*
   hash:
-    md5: 0cb5ff348eb4c201b3b920eff851675d
-    sha256: 528c9fdaf799b38611276d6f676da6018da2aaf93fb5b0328c00923909e99432
+    md5: 14f8341e26b274362b026bbdc72b14fb
+    sha256: 46aac096868527843ad7083c254e32b5451fc1e304036dcac4243b66c08a8517
   manager: conda
   name: git
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/git-2.40.1-pl5321h86e50cf_0.conda
-  version: 2.40.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/git-2.41.0-pl5321h86e50cf_0.conda
+  version: 2.41.0
 - category: main
   dependencies:
     gitdb: '>=4.0.1,<5'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
   hash:
-    md5: f6e6b482110246a81c3f03e81c68752d
-    sha256: 77c531def610089bc190508fcf304cf96c085c5fe977ab8f7d7c1641769592ac
+    md5: 5809a12901d57388444c3293c975d0bb
+    sha256: 07008a94189e570fcabe003b99bd50b8263f60c824f36f81a8819bb7cf7eab1b
   manager: conda
   name: gitpython
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.31-pyhd8ed1ab_0.conda
-  version: 3.1.31
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.32-pyhd8ed1ab_0.conda
+  version: 3.1.32
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4190,29 +4222,29 @@ package:
   version: 7.3.0
 - category: main
   dependencies:
-    importlib_resources: '>=5.12.0,<5.12.1.0a0'
+    importlib_resources: '>=6.0.0,<6.0.1.0a0'
     python: '>=3.7'
   hash:
-    md5: 3544c818f0720c89eb16ae6940ab440b
-    sha256: 0675df2bf18e52d0ea2bc5e1009faac273f059361a0caf36c0e0edc7831098a9
+    md5: d69f29916f934f30adb1dd5fff4d9a8b
+    sha256: c0247e1a001393e9415c8814a0820cbc84c28a42625dbc3fd389ad1e5a87b796
   manager: conda
   name: importlib-resources
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-5.12.0-pyhd8ed1ab_0.conda
-  version: 5.12.0
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.0.0-pyhd8ed1ab_1.conda
+  version: 6.0.0
 - category: main
   dependencies:
-    importlib-metadata: '>=6.6.0,<6.6.1.0a0'
+    importlib-metadata: '>=6.8.0,<6.8.1.0a0'
   hash:
-    md5: 3cbc9615f10a3d471532b83e4250b971
-    sha256: 5de35d3c019d8a36e0a0deeb04a62689837bd68234a0a73a3355b860b442eca4
+    md5: b279b07ce18058034e5b3606ba103a8b
+    sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
   manager: conda
   name: importlib_metadata
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.6.0-hd8ed1ab_0.conda
-  version: 6.6.0
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+  version: 6.8.0
 - category: main
   dependencies:
     attrs: '>=17.4.0'
@@ -4255,14 +4287,14 @@ package:
     python_abi: 3.9.* *_cp39
     pytz: '>=2020.1'
   hash:
-    md5: de99b3f807c0b295a7df94623df0fb4c
-    sha256: 234e0474b55edc7159ddbdf03c99a9d9f53a0b32d9c505dc4be85698bab9bd6b
+    md5: cfe677f02e507f76d6767379e4ff09a9
+    sha256: b9a9de37da5f6c73979f317a47176c5954dc7fe84ef4ab107f11976bbf1a8f75
   manager: conda
   name: pandas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.2-py39h40cae4c_0.conda
-  version: 2.0.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.3-py39h40cae4c_1.conda
+  version: 2.0.3
 - category: main
   dependencies:
     pip: ''
@@ -4279,31 +4311,31 @@ package:
 - category: main
   dependencies:
     python: '>=3.7'
-    typing-extensions: '>=4.5'
+    typing-extensions: '>=4.6.3'
   hash:
-    md5: e2be672aece1f060adf7154f76531a35
-    sha256: d7845c01a9ee5a224cc9242782befed7d12dc6aac1103650ec87917b20f3579e
+    md5: e76070baecfaca6ecdb5fbd5af7c9309
+    sha256: b5012d6fd30f2462b6ca595539cfdae9aaf61b3b7a56e51ab94aef0fd9efcd3d
   manager: conda
   name: platformdirs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
-  version: 3.5.1
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.8.1-pyhd8ed1ab_0.conda
+  version: 3.8.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
     python: '>=3.9,<3.10.0a0'
     python_abi: 3.9.* *_cp39
-    typing-extensions: '>=4.2.0'
+    typing-extensions: '>=4.6.0'
   hash:
-    md5: 0b010892a3a2515a50f5f166543faa60
-    sha256: 0e914ff39c85afa91528900819f5fd9b39804db7518ee6297b59527e820e4090
+    md5: e52f02654a9613d84002a492b6f54a39
+    sha256: d8c6ba4a823b4a3e964b6155394206c598569393e5625f3b75fb3cf79a0b442c
   manager: conda
-  name: pydantic
+  name: pydantic-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-1.10.8-py39hd1e30aa_0.conda
-  version: 1.10.8
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.1.2-py39h9fdd4d6_0.conda
+  version: 2.1.2
 - category: main
   dependencies:
     cffi: '>=1.4.1'
@@ -4323,36 +4355,43 @@ package:
   version: 1.5.0
 - category: main
   dependencies:
-    colorama: ''
-    exceptiongroup: ''
-    importlib-metadata: '>=0.12'
-    iniconfig: ''
-    packaging: ''
-    pluggy: '>=0.12,<2.0'
-    python: '>=3.8'
-    tomli: '>=1.0.0'
+    pytest: '>=3.6.0'
+    python: ''
   hash:
-    md5: 547c7de697ec99b494a28ddde185b5a4
-    sha256: 42f89db577266b9dc195d09189b92f3af3354fb50c98b1f996c580322dffa8b5
+    md5: b6764e23dece9f9cda0469af044fafeb
+    sha256: bdb25a7daf3efb7255b1a19d7b5d41d7d4d96bc647b8e5f7407ec4dd9e384257
   manager: conda
-  name: pytest
+  name: pytest-dependency
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.3.1-pyhd8ed1ab_0.conda
-  version: 7.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-dependency-0.5.1-pyh9f0ad1d_0.tar.bz2
+  version: 0.5.1
+- category: main
+  dependencies:
+    pytest: '>=5.0'
+    python: '>=3.7'
+  hash:
+    md5: fcd2531bc3e492657aeb042349aeaf8a
+    sha256: d2f6a46fe31dea91b427bcc57302edc345eb763caf3c6b6dcd09b2aee002324b
+  manager: conda
+  name: pytest-mock
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.11.1-pyhd8ed1ab_0.conda
+  version: 3.11.1
 - category: main
   dependencies:
     pip: ''
     python: '>=3.7,<4.0'
   hash:
-    md5: 7a02fed21d1bf45cb41eaeaefc7eea25
-    sha256: 6ba480465154a4ac2ba1c08d10e4824dc10db30d8087b83b2b041df0ebba18e8
+    md5: ffabccdca64c44c1f23a8df134708897
+    sha256: dbc0641f63dbf6d2d2e9b17a21ae8e0b3cb8e24ffa675e06cf5ce6f76d6a58d8
   manager: conda
   name: types-awscrt
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.16.19-pyhd8ed1ab_0.conda
-  version: 0.16.19
+  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.16.23-pyhd8ed1ab_0.conda
+  version: 0.16.23
 - category: main
   dependencies:
     cffi: ''
@@ -4394,20 +4433,20 @@ package:
     python_abi: 3.9.* *_cp39
     zstd: '>=1.5.2,<1.6.0a0'
   hash:
-    md5: 6023bdb101f9c7fcf11595442cb832b0
-    sha256: 7297303784e4b4964fa15eac0d0559f3598d9abf8d941b33f51315c590e16eda
+    md5: 84ba0f78de14c9ac4418facd5f9c68ef
+    sha256: a8ad86ef09638293fd3f77a0f8298d4920dad19781dc697fc7d6662058e96a8e
   manager: conda
   name: zstandard
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py39h29414ee_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py39h6e5214e_2.conda
   version: 0.19.0
 - category: main
   dependencies:
     aiosignal: '>=1.1.2'
     async-timeout: <5.0,>=4.0.0a3
     attrs: '>=17.3.0'
-    charset-normalizer: '>=2.0,<3.0'
+    charset-normalizer: '>=2.0,<4.0'
     frozenlist: '>=1.1.1'
     libgcc-ng: '>=12'
     multidict: '>=4.5,<7.0'
@@ -4415,13 +4454,13 @@ package:
     python_abi: 3.9.* *_cp39
     yarl: '>=1.0,<2.0'
   hash:
-    md5: 0e856218fc838b36e1b340f574b7885f
-    sha256: 7f842b7b71cd366cf82a6aa0492ede328d31dc73738d9b56cf1866e7d10a708b
+    md5: 21e7462fc6c4657ad728a443f1634011
+    sha256: 76f3dac9041e3f827b8a8a0fb9c41bb15324ded084ea10f496557de7e9e398a7
   manager: conda
   name: aiohttp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.4-py39h72bdee0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.4-py39hd1e30aa_1.conda
   version: 3.8.4
 - category: main
   dependencies:
@@ -4429,14 +4468,14 @@ package:
     types-awscrt: ''
     typing_extensions: ''
   hash:
-    md5: f19106a30c5fb2c52d84d1dbf0b5e097
-    sha256: 8bf3c568732facd3ca9adf2f1867f91f84fc0e3779dba9e4da4c10f35ac0dfba
+    md5: 63ed81138f359d75fb3f8c1e8deadfe0
+    sha256: e181ec7110dc831c91b4660de20e0023b0adc898bcde34cc2048d7fc286b2fb3
   manager: conda
   name: botocore-stubs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.29.145-pyhd8ed1ab_0.conda
-  version: 1.29.145
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.29.165-pyhd8ed1ab_0.conda
+  version: 1.29.165
 - category: main
   dependencies:
     clang-format: 16.0.3 default_h1cdf331_2
@@ -4630,6 +4669,23 @@ package:
   version: 3.2.0
 - category: main
   dependencies:
+    annotated-types: '>=0.4.0'
+    libgcc-ng: '>=12'
+    pydantic-core: 2.1.2
+    python: '>=3.9,<3.10.0a0'
+    python_abi: 3.9.* *_cp39
+    typing-extensions: '>=4.6.1'
+  hash:
+    md5: f7d96146fbf4ab45ffc81107159a2683
+    sha256: e3b46f24441e27116feb02e5737efeab3f549684ec3c50eb7115104ffc652fd7
+  manager: conda
+  name: pydantic
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-2.0.2-py39hd1e30aa_1.conda
+  version: 2.0.2
+- category: main
+  dependencies:
     cryptography: '>=38.0.0,<42,!=40.0.0,!=40.0.1'
     python: '>=3.6'
   hash:
@@ -4641,32 +4697,6 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.2.0-pyhd8ed1ab_1.conda
   version: 23.2.0
-- category: main
-  dependencies:
-    pytest: '>=3.6.0'
-    python: ''
-  hash:
-    md5: b6764e23dece9f9cda0469af044fafeb
-    sha256: bdb25a7daf3efb7255b1a19d7b5d41d7d4d96bc647b8e5f7407ec4dd9e384257
-  manager: conda
-  name: pytest-dependency
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-dependency-0.5.1-pyh9f0ad1d_0.tar.bz2
-  version: 0.5.1
-- category: main
-  dependencies:
-    pytest: '>=5.0'
-    python: '>=3.7'
-  hash:
-    md5: db93caa9fe182f0cd20291aeb22f57ac
-    sha256: 87bb8edc9976403237a0e6c3bd7b2224c346c95e4c7345971f411aef21593450
-  manager: conda
-  name: pytest-mock
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.10.0-pyhd8ed1ab_0.tar.bz2
-  version: 3.10.0
 - category: main
   dependencies:
     cryptography: ''
@@ -4730,18 +4760,18 @@ package:
 - category: main
   dependencies:
     distlib: <1,>=0.3.6
-    filelock: <4,>=3.11
-    platformdirs: <4,>=3.2
+    filelock: <4,>=3.12
+    platformdirs: <4,>=3.5.1
     python: '>=3.8'
   hash:
-    md5: a920e114c4c2ced2280e266da65ab5e6
-    sha256: 13d667887ea08b6d1fe2eb09d2d737f9af7343735d3bfa5ffaa3f67eec8eaff7
+    md5: 838b85f656b078bdd882ef97978e7f40
+    sha256: 92dd17aef10e5c35289da3a588cbed3e593c22ee53478a00ccb1fdf92fe0e84e
   manager: conda
   name: virtualenv
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.23.0-pyhd8ed1ab_0.conda
-  version: 20.23.0
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.23.1-pyhd8ed1ab_0.conda
+  version: 20.23.1
 - category: main
   dependencies:
     conda-package-streaming: '>=0.7.0'
@@ -4797,14 +4827,14 @@ package:
     python_abi: 3.9.* *_cp39
     secretstorage: '>=3.2'
   hash:
-    md5: ae2df7a822f7671da22da24ead24cc0a
-    sha256: 107e6a5ba122dff162e9d34a87af1ffbb4dca1f7dd1547294646774ca9421524
+    md5: bca055aa9d1d8730c1a93a9ad138456a
+    sha256: d431310c2195bb77a6fc5184b3914b9018b7ed31b27d0faa2296dd681fe229e3
   manager: conda
   name: keyring
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-23.13.1-py39hf3d152e_0.conda
-  version: 23.13.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.2.0-py39hf3d152e_0.conda
+  version: 24.2.0
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4848,27 +4878,27 @@ package:
     pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
   hash:
-    md5: dbb0111b18ea5c9983fb8db0aef6000b
-    sha256: a55d8a19bb00c2c5bf8a074c94d5ac1ffed8d63c53c9df4cee76f3764ad7a304
+    md5: dd64a0e440754ed97610b3e6b502b6b1
+    sha256: 3df1434057ce827d88cdd84578732030b3d4b5a0bc6c58bff12b7f8001c1be5b
   manager: conda
   name: pre-commit
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.3.2-pyha770c72_0.conda
-  version: 3.3.2
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.3.3-pyha770c72_0.conda
+  version: 3.3.3
 - category: main
   dependencies:
     __unix: ''
     openjdk: '>=8'
   hash:
-    md5: 9db52fde2303937e5ae766d3c0c2c21e
-    sha256: 4a5967e73309839e57f254046e2a07cb16039a0c46d820d302382fd910751fde
+    md5: 67177beb0a5d0968d7b2935b7901d955
+    sha256: f0582f7f4f90231754f6532de13d9737ed422a5bb086962dcf0380c0ea2513df
   manager: conda
   name: sbt
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/sbt-1.8.2-hd8ed1ab_0.conda
-  version: 1.8.2
+  url: https://conda.anaconda.org/conda-forge/noarch/sbt-1.9.2-h707e725_0.conda
+  version: 1.9.2
 - category: main
   dependencies:
     brotlipy: '>=0.6.0'
@@ -4894,14 +4924,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
   hash:
-    md5: a1b8b2b1df2fa7a35fc15e561601cbe0
-    sha256: 61c711c9620821ef97ef04ad1991c23328debbe722ca1891e917821bc47f1611
+    md5: 0edc7c1cfd7921df59c922f2b734ff1c
+    sha256: 232a3ad207515d492274b004bf59bacc7254893086ac0d72fe0108cea2834dbf
   manager: conda
   name: botocore
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.29.145-pyhd8ed1ab_0.conda
-  version: 1.29.145
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.1-pyhd8ed1ab_0.conda
+  version: 1.31.1
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4969,14 +4999,14 @@ package:
     six: '>=1.11.0'
     typing-extensions: '>=4.0.1'
   hash:
-    md5: 4e49a7bd8f79a678c4fa2e871f4e2881
-    sha256: 485bd7bba4820ea7265990d335ec10ab2f431c6bb1cca19f3ce7b87879f62e72
+    md5: 5576496c2743cafa05111ac76267db29
+    sha256: 51951b49a43b7de818ad055d113348f7e438e225fc7a5f8f4c635998239c4c89
   manager: conda
   name: azure-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.27.0-pyhd8ed1ab_0.conda
-  version: 1.27.0
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.27.1-pyhd8ed1ab_0.conda
+  version: 1.27.1
 - category: main
   dependencies:
     msgpack-python: '>=0.5.2'
@@ -5023,14 +5053,14 @@ package:
     urllib3: '>=1.26.0'
     websocket-client: '>=0.32.0'
   hash:
-    md5: 543336c6aa9516cfb29c51d5c162b177
-    sha256: 5e01e15e20ee573c99b530633a0d5c71fd515e4ac6d2f5f5f57baece8b915cc3
+    md5: c95d23d8bae7e21491868cc7772d7c73
+    sha256: 7c3031602e92fd7682302ef98a45bdf7374d48a849cdd3900b7c68a32d162177
   manager: conda
   name: docker-py
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-6.1.0-pyhd8ed1ab_0.conda
-  version: 6.1.0
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-6.1.3-pyhd8ed1ab_0.conda
+  version: 6.1.3
 - category: main
   dependencies:
     appdirs: ''
@@ -5078,17 +5108,20 @@ package:
 - category: main
   dependencies:
     python: '>=3.7'
-    requests: '>=2.0,<3.0'
+    pyyaml: ''
+    requests: '>=2.22.0,<3.0'
+    types-pyyaml: ''
+    typing_extensions: ''
     urllib3: '>=1.25.10'
   hash:
-    md5: 5b21c0b72f49d216ee1d01a4e7f96f9e
-    sha256: 2a3046ef1902919b40f637c4c749100508a685a5c6a05e0f3834a0e3c94514df
+    md5: bf15c93720dfea117aaea3155cbebce5
+    sha256: c64db4a71de87e17fbcbd0b3af2186ab25d65428bb565bd7d070850324096f3b
   manager: conda
   name: responses
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.21.0-pyhd8ed1ab_0.tar.bz2
-  version: 0.21.0
+  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.23.1-pyhd8ed1ab_0.conda
+  version: 0.23.1
 - category: main
   dependencies:
     botocore: '>=1.12.36,<2.0a.0'
@@ -5133,7 +5166,7 @@ package:
   version: 5.1.1
 - category: main
   dependencies:
-    botocore: 1.29.145
+    botocore: 1.31.1
     colorama: '>=0.2.5,<0.4.5'
     docutils: '>=0.10,<0.17'
     python: '>=3.9,<3.10.0a0'
@@ -5142,29 +5175,29 @@ package:
     rsa: '>=3.1.2,<4.8'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 71af9e8fbd3e4f2cf7539ae7b98b84d9
-    sha256: 9cf3a2405209319da9080429647b820dd3d36270c79a79babdb9b151c31284bb
+    md5: fc7abf3233e1843ceccccdb17c4f2b99
+    sha256: d44ceac9af03e60b4f626b7c9263084ae92ecc2266116c37c438209b5058bc62
   manager: conda
   name: awscli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.27.145-py39hf3d152e_0.conda
-  version: 1.27.145
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.29.1-py39hf3d152e_0.conda
+  version: 1.29.1
 - category: main
   dependencies:
-    botocore: '>=1.29.145,<1.30.0'
+    botocore: '>=1.31.1,<1.32.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.7'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 09e0b5c5f94eb5b480477ae63072b7dd
-    sha256: 82d045f01c87a8202796eadf2f10350b7e2417b480e93c69bb85a8364b750f02
+    md5: 3a0123e890ea210f6468121bdfa6cfc0
+    sha256: 4fea48dc33349ea59efe4f8ddb6c4ec2fbec24c49a7482263893498bc6e506ca
   manager: conda
   name: boto3
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.26.145-pyhd8ed1ab_0.conda
-  version: 1.26.145
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.28.1-pyhd8ed1ab_0.conda
+  version: 1.28.1
 - category: main
   dependencies:
     cachecontrol: 0.13.0 pyhd8ed1ab_0
@@ -5290,14 +5323,14 @@ package:
     python: ''
     typing_extensions: ''
   hash:
-    md5: 1cc6dd0f40481c8a20eaa91a76f48ce5
-    sha256: c0c0c81cfaf11a662d331d934d7a8eca12adbf12fa89a1fd60b514318c87c6c8
+    md5: e07be93e70ff9affb934ff017a86c722
+    sha256: c3a63fce78c2b080803b2a40cc3f5fe9e5ade617efe278cf09b6b89c8f0ea232
   manager: conda
   name: boto3-stubs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.26.145-pyhd8ed1ab_0.conda
-  version: 1.26.145
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.28.1-pyhd8ed1ab_0.conda
+  version: 1.28.1
 - category: main
   dependencies:
     cachecontrol-with-filecache: '>=0.12.9'
@@ -5338,28 +5371,28 @@ package:
     python: '>=3.6'
     typing-extensions: ''
   hash:
-    md5: adb30ee4ef9f506b62f732c8a78d250b
-    sha256: 281ba68f92f05626bf37df32156abbf62e6ed963ab40b2205277a066391cc06f
+    md5: 1c53cbf18ef82bac6c4957398f107d61
+    sha256: 5bd251a81e5ee934e0945530d00f46944c4dc5e8fad001ce761ef89310f9c9cc
   manager: conda
   name: mypy-boto3-s3
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.26.127-pyhd8ed1ab_0.conda
-  version: 1.26.127
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.28.0-pyhd8ed1ab_0.conda
+  version: 1.28.0
 - category: main
   dependencies:
     boto3: ''
     python: '>=3.6'
     typing-extensions: ''
   hash:
-    md5: 2f58c5525f108a1525553e081c90f815
-    sha256: 66d980a4aa02be974410c64d0631ea54d26e538f49300ac5e3b46d44a4acec78
+    md5: 7af6a634a654ee7aac1941e05cf1568c
+    sha256: 4fee92b4e5580dfd13fe942ae307100666064121197b94de5c824c3dd98eb327
   manager: conda
   name: mypy_boto3_ec2
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.26.136-pyhd8ed1ab_0.conda
-  version: 1.26.136
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.28.0-pyhd8ed1ab_0.conda
+  version: 1.28.0
 - category: main
   dependencies:
     boto3: ''
@@ -5379,16 +5412,16 @@ package:
     docutils: <0.19
     python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*'
     sphinx: '>=1.6,<7'
-    sphinxcontrib-jquery: '>=2.0.0,!=3.0.0'
+    sphinxcontrib-jquery: '>=4,<5'
   hash:
-    md5: dd1ec3c6beac662d7bf9c996975f637f
-    sha256: 818659eb58b74da694e7ff6ecb907d417ae0de4db8231c42f0b0ba75f56ef3f4
+    md5: 5ef6aaf2cfb3b656cdadb431daed6a9f
+    sha256: 129cab0a4cddd57fa58930c306ca8363c8ac2c40bd40b784210603b17abb5639
   manager: conda
   name: sphinx_rtd_theme
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx_rtd_theme-1.2.1-pyha770c72_0.conda
-  version: 1.2.1
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx_rtd_theme-1.2.2-pyha770c72_0.conda
+  version: 1.2.2
 - category: main
   dependencies:
     aws-sam-translator: '>=1.55.0'
@@ -5438,14 +5471,14 @@ package:
     werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
     xmltodict: ''
   hash:
-    md5: 7f8865d0f6df238a407cab06d884c211
-    sha256: c51cc65dac1b0b1f5139860c07030b9465417cebcb8529ffa97fcd8615aba606
+    md5: 2ad89e262b7d71adc0820e207329d659
+    sha256: 4a348f91127ca5456c224114329705b68c18812d67060f3cc93bb0310e5ebeba
   manager: conda
   name: moto
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.1.10-pyhd8ed1ab_0.conda
-  version: 4.1.10
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.1.12-pyhd8ed1ab_0.conda
+  version: 4.1.12
 - category: main
   dependencies: {}
   hash:
@@ -5503,6 +5536,16 @@ package:
   source: null
   url: https://files.pythonhosted.org/packages/9f/53/1ac75eab589149b1e02e38185ecebf09e1b805fc3fdeadbc16d1a2b7d208/paramiko_ng-2.8.10-py2.py3-none-any.whl
   version: 2.8.10
+- dependencies:
+    typing-extensions: '>=4.2.0'
+  hash:
+    sha256: abade85268cc92dff86d6effcd917893130f0ff516f3d637f50dadc22ae93999
+  manager: pip
+  name: pydantic
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/65/d3/8ea06a592f4c218d3079ddb6d267015e6635c11ea4b282c2f5a9b62ca60b/pydantic-1.10.11-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  version: 1.10.11
 - category: main
   dependencies:
     ruamel.yaml.clib: '>=0.2.7'

--- a/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
+++ b/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
@@ -9,7 +9,7 @@
 # To update a single package to the latest version compatible with the version constraints in the source:
 #     conda-lock lock --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
-#     conda-lock -f /scratch/abejgonza/cy/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy/conda-reqs/riscv-tools.yaml -f /scratch/abejgonza/cy-check/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy-check/conda-reqs/riscv-tools.yaml --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml
+#     conda-lock -f /scratch/abejgonza/cy/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy/conda-reqs/riscv-tools.yaml -f /scratch/abejgonza/cy-check/conda-reqs/chipyard.yaml -f /scratch/abejgonza/cy-check/conda-reqs/riscv-tools.yaml -f /scratch/abejgonza/new-cy/conda-reqs/chipyard.yaml -f /scratch/abejgonza/new-cy/conda-reqs/riscv-tools.yaml --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml
 metadata:
   channels:
   - url: ucb-bar
@@ -29,6 +29,8 @@ metadata:
   - /scratch/abejgonza/cy/conda-reqs/riscv-tools.yaml
   - /scratch/abejgonza/cy-check/conda-reqs/chipyard.yaml
   - /scratch/abejgonza/cy-check/conda-reqs/riscv-tools.yaml
+  - /scratch/abejgonza/new-cy/conda-reqs/chipyard.yaml
+  - /scratch/abejgonza/new-cy/conda-reqs/riscv-tools.yaml
 package:
 - category: main
   dependencies: {}
@@ -143,58 +145,58 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: 199a7292b1d3535376ecf7670c231d1f
-    sha256: d6df7758b85d4f82baaa526bff1b9f0a9ae2b73b0df7fcb27cafdaf5e24fdefb
+    md5: 5ec50dcd74ba7461709c4ac9c4cc4190
+    sha256: 749dabbfe7b571affa19ef3ddb23e22e2eed12d5a699a9830a0f7fba2f296e02
   manager: conda
   name: libgcc-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.2.0-h3b97bd3_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-13.1.0-he3cc6c4_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 164b4b1acaedc47ee7e658ae6b308ca3
-    sha256: 03ea784edd12037dc3a7a0078ff3f9c3383feabb34d5ba910bb2fd7a21a2d961
+    md5: afb656a334c409dd9805508af1c89c7a
+    sha256: a06235f4c4b85b463d9b8a73c9e10c1b5b4105f8a0ea8ac1f2f5f64edac3dfe7
   manager: conda
   name: libgfortran5
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-12.2.0-h337968e_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.1.0-h15d22d2_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 277d373b57791ee71cafc3c5bfcf0641
-    sha256: 152a54b52b0bc0cda89b4394e43f010ce2a16f4012a3e706709d53a68407df46
+    md5: e703914ad2288ab24cf5ac94d812fc11
+    sha256: 21b95f21a80462c832caa348ece5413e10ba69d922dca01826706fe7b6f3a764
   manager: conda
   name: libstdcxx-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.2.0-h3b97bd3_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-13.1.0-he3cc6c4_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 1030b1f38c129f2634eae026f704fe60
-    sha256: 0289e6a7b9a5249161a3967909e12dcfb4ab4475cdede984635d3fb65c606f08
+    md5: 067bcc23164642f4c226da631f2a2e1d
+    sha256: 6f9eb2d7a96687938c0001166a3b308460a8eb02b10e9d0dd9e251f0219ea05c
   manager: conda
   name: libstdcxx-ng
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-12.2.0-h46fd767_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
+  version: 13.1.0
 - category: main
   dependencies: {}
   hash:
-    md5: 0299e410bfb4300540bdc0012a7985ef
-    sha256: 8572efb7092c72fe7b73d2a0f1e5e27159a8edea0371e1bef533bcb7d85b19c6
+    md5: 374b3bf084169a90f41675d19b0ad35a
+    sha256: f8d37016976d69b9b983a9299783884fd746258666f7e47a0dd1f5b3b0259568
   manager: conda
   name: open_pdks.sky130a
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.406_0_g0c37b7c-20230412_103222.tar.bz2
-  version: 1.0.406_0_g0c37b7c
+  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.422_0_gd9f6d38-20230709_210322.tar.bz2
+  version: 1.0.422_0_gd9f6d38
 - category: main
   dependencies: {}
   hash:
@@ -246,28 +248,28 @@ package:
   version: 3.10.0
 - category: main
   dependencies:
-    libgfortran5: 12.2.0 h337968e_19
+    libgfortran5: 13.1.0 h15d22d2_0
   hash:
-    md5: cd7a806282c16e1f2d39a7e80d3a3e0d
-    sha256: c7d061f323e80fbc09564179073d8af303bf69b953b0caddcf79b47e352c746f
+    md5: 506dc07710dd5b0ba63cbf134897fc10
+    sha256: 429e1d8a3e70b632df5b876e3fc322a56f769756693daa07114c46fa5098684e
   manager: conda
   name: libgfortran-ng
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-12.2.0-h69a702a_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.1.0-h69a702a_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     _libgcc_mutex: 0.1 conda_forge
   hash:
-    md5: cedcee7c064c01c403f962c9e8d3c373
-    sha256: 81a76d20cfdee9fe0728b93ef057ba93494fd1450d42bc3717af4e468235661e
+    md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
+    sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
   manager: conda
   name: libgomp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-12.2.0-h65d4601_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     _libgcc_mutex: 0.1 conda_forge
@@ -324,14 +326,14 @@ package:
     _libgcc_mutex: 0.1 conda_forge
     _openmp_mutex: '>=4.5'
   hash:
-    md5: e4c94f80aef025c17ab0828cd85ef535
-    sha256: f3899c26824cee023f1e360bd0859b0e149e2b3e8b1668bc6dd04bfc70dcd659
+    md5: cd93f779ff018dd85c7544c015c9db3c
+    sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
   manager: conda
   name: libgcc-ng
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-12.2.0-h65d4601_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -559,25 +561,25 @@ package:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
   hash:
-    md5: f67106643beadfc737b94ca0bfd6d8e3
-    sha256: 1778dc86603df24aaf6865f7f3e1ffc5c793a0f1fc4570add2a6ccb4c0a62785
+    md5: d1db1b8be7c3a8983dcbbbfe4f0765de
+    sha256: 3c6fab31ed4dc8428605588454596b307b1bd59d33b0c7073c407ab51408b011
   manager: conda
   name: libabseil
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230125.2-cxx17_h59595ed_2.conda
-  version: '20230125.2'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230125.3-cxx17_h59595ed_0.conda
+  version: '20230125.3'
 - category: main
   dependencies:
     libgcc-ng: '>=12'
   hash:
-    md5: 9194c9bf9428035a05352d031462eae4
-    sha256: ddc961a36d498aaafd5b71078836ad5dd247cc6ba7924157f3801a2f09b77b14
+    md5: 61641e239f96eae2b8492dc7e755828c
+    sha256: fc57c0876695c5b4ab7173438580c1d7eaa7dccaf14cb6467ca9e0e97abe0cf0
   manager: conda
   name: libbrotlicommon
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
@@ -679,28 +681,28 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libgfortran-ng: ''
-    libgfortran5: '>=10.4.0'
+    libgfortran5: '>=11.3.0'
   hash:
-    md5: 8c5963a49b6035c40646a763293fbb35
-    sha256: 018372af663987265cb3ca8f37ac8c22b5f39219f65a0c162b056a30af11bba0
+    md5: 9c5ea51ccb8ffae7d06c645869d24ce6
+    sha256: 00aee12d04979d024c7f9cabccff5f5db2852c934397ec863a4abde3e09d5a79
   manager: conda
   name: libopenblas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.21-pthreads_h78a6416_3.tar.bz2
-  version: 0.3.21
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.23-pthreads_h80387f5_0.conda
+  version: 0.3.23
 - category: main
   dependencies:
-    libgcc-ng: '>=12.2.0'
+    libgcc-ng: '>=13.1.0'
   hash:
-    md5: 80d0e00150401e9c06a055f36e8e73f2
-    sha256: 6cf904606c091e1cab5cf3b1f1bb0d6756474e6e37b1a97a502fc1255d71641b
+    md5: 7594fd17fb4d1b8b0e47a6b306fe01ae
+    sha256: 49214f61c270400e4da89f00b6b24565dc59d1d8b869fa003a22aeacaeca3851
   manager: conda
   name: libsanitizer
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.2.0-h46fd767_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.1.0-hfd8a6a1_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -777,25 +779,25 @@ package:
   dependencies:
     libgcc-ng: '>=12'
   hash:
-    md5: 0d4a7508d8c6c65314f2b9c1f56ad408
-    sha256: ac3e073ea77803da71eb77e7fcef07defb345bda95eee3327c73ddf85b5714da
+    md5: 82bf6f63eb15ef719b556b63feec3a77
+    sha256: 66658d5cdcf89169e284488d280b6ce693c98c0319d7eabebcedac0929140a73
   manager: conda
   name: libwebp-base
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.0-h0b41bf4_0.conda
-  version: 1.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.1-hd590300_0.conda
+  version: 1.3.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
   hash:
-    md5: f3f9de449d32ca9b9c66a22863c96f41
-    sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
+    md5: f36c115f1ee199da648e0597ec2047ad
+    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
   manager: conda
   name: libzlib
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
   version: 1.2.13
 - category: main
   dependencies:
@@ -848,16 +850,16 @@ package:
   version: '4.3'
 - category: main
   dependencies:
-    libgcc-ng: '>=10.3.0'
+    libgcc-ng: '>=12'
   hash:
-    md5: 4acfc691e64342b9dae57cf2adc63238
-    sha256: b801e8cf4b2c9a30bce5616746c6c2a4e36427f045b46d9fc08a4ed40a9f7065
+    md5: 681105bccc2a3f7f1a837d47d39c9179
+    sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
   manager: conda
   name: ncurses
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2
-  version: '6.3'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
+  version: '6.4'
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1207,21 +1209,21 @@ package:
 - category: main
   dependencies:
     binutils_impl_linux-64: '>=2.39'
-    libgcc-devel_linux-64: 12.2.0 h3b97bd3_19
-    libgcc-ng: '>=12.2.0'
-    libgomp: '>=12.2.0'
-    libsanitizer: 12.2.0 h46fd767_19
-    libstdcxx-ng: '>=12.2.0'
+    libgcc-devel_linux-64: 13.1.0 he3cc6c4_0
+    libgcc-ng: '>=13.1.0'
+    libgomp: '>=13.1.0'
+    libsanitizer: 13.1.0 hfd8a6a1_0
+    libstdcxx-ng: '>=13.1.0'
     sysroot_linux-64: ''
   hash:
-    md5: bb48ea333c8e6dcc159a1575f04d869e
-    sha256: 1e67063ca887c0569c647d7e8e3da9d09234585ed0fce7f728d6709d7314d0f5
+    md5: 99d1a8a8ee1665ee9435f8d160df69fe
+    sha256: d728da49acc79f2a46f9abe1f603fd4ccc9fc96f533b1647e3c836985caa5924
   manager: conda
   name: gcc_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.2.0-hcc96c02_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.1.0-hc4be1a9_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1237,41 +1239,41 @@ package:
   version: '1.6'
 - category: main
   dependencies:
-    libopenblas: '>=0.3.21,<1.0a0'
+    libopenblas: '>=0.3.23,<1.0a0'
   hash:
-    md5: d9b7a8639171f6c6fa0a983edabcfe2b
-    sha256: 4e4c60d3fe0b95ffb25911dace509e3532979f5deef4364141c533c5ca82dd39
+    md5: 57fb44770b1bc832fb2dbefa1bd502de
+    sha256: 5a9dfeb9ede4b7ac136ac8c0b589309f8aba5ce79d14ca64ad8bffb3876eb04b
   manager: conda
   name: libblas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-16_linux64_openblas.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-17_linux64_openblas.conda
   version: 3.9.0
 - category: main
   dependencies:
-    libbrotlicommon: 1.0.9 h166bdaf_8
+    libbrotlicommon: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: 4ae4d7795d33e02bd20f6b23d91caf82
-    sha256: d88ba07c3be27c89cb4975cc7edf63ee7b1c62d01f70d5c3f7efeb987c82b052
+    md5: 081aa22f4581c08e4372b0b6c2f8478e
+    sha256: 564f301430c3c61bc5e149e74157ec181ed2a758befc89f7c38466d515a0f614
   manager: conda
   name: libbrotlidec
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
-    libbrotlicommon: 1.0.9 h166bdaf_8
+    libbrotlicommon: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: 04bac51ba35ea023dc48af73c1c88c25
-    sha256: a0468858b2f647f51509a32040e93512818a8f9980f20b3554cccac747bcc4be
+    md5: 1f0a03af852a9659ed2bf08f2f1704fd
+    sha256: d27bc2562ea3f3b2bfd777f074f1cac6bfa4a737233dad288cd87c4634a9bb3a
   manager: conda
   name: libbrotlienc
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
@@ -1350,14 +1352,14 @@ package:
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
   hash:
-    md5: 498393f87a3979b097e4c14d9c53438a
-    sha256: ea98b575ac097670bc3179389322967c9da3e67adc30ffa2cff8d4a70f9a19a2
+    md5: c8da7f04073ed0fabcb60885a4c1a722
+    sha256: b0255d3c46c71e184d0513566a770356abf2cede5e795c4944521c4f7b6a26d4
   manager: conda
   name: libprotobuf
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.2-hd1fb520_2.conda
-  version: 4.23.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.3-hd1fb520_0.conda
+  version: 4.23.3
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1374,17 +1376,17 @@ package:
 - category: main
   dependencies:
     libgcc-ng: '>=12'
-    libzlib: '>=1.2.12,<1.3.0a0'
-    openssl: '>=3.0.5,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.1,<4.0a0'
   hash:
-    md5: d85acad4b47dff4e3def14a769a97906
-    sha256: 9a9a01f35d2d50326eb8ca7c0a92d0c45b2d0f77d9ea117680c70094ff480c0c
+    md5: 1f5a58e686b13bcfde88b93f547d23fe
+    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
   manager: conda
   name: libssh2
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.10.0-hf14f497_3.tar.bz2
-  version: 1.10.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  version: 1.11.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1472,16 +1474,16 @@ package:
   version: '10.40'
 - category: main
   dependencies:
-    libgcc-ng: '>=9.4.0'
+    libgcc-ng: '>=12'
     libnsl: '>=2.0.0,<2.1.0a0'
   hash:
-    md5: 09ba115862623f00962e9809ea248f1a
-    sha256: a116c1d3c64a072280b441c43d893d341a1d37d16ec18afc76eee40299deabfa
+    md5: 53dc30c420516340641b00ec1571dd53
+    sha256: 7e282c6b4106ccb00b3e5be9fc7f863b003d732ba51f76696ab23544a047a4fb
   manager: conda
   name: perl
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-2_h7f98852_perl5.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-3_hd590300_perl5.conda
   version: 5.32.1
 - category: main
   dependencies:
@@ -1578,15 +1580,15 @@ package:
 - category: main
   dependencies:
     libgcc-ng: '>=12'
-    libzlib: 1.2.13 h166bdaf_4
+    libzlib: 1.2.13 hd590300_5
   hash:
-    md5: 4b11e365c0275b808be78b30f904e295
-    sha256: 282ce274ebe6da1fbd52efbb61bd5a93dec0365b14d64566e6819d1691b75300
+    md5: 68c34ec6149623be41a1933ab996a209
+    sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
   manager: conda
   name: zlib
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h166bdaf_4.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
   version: 1.2.13
 - category: main
   dependencies:
@@ -1594,13 +1596,13 @@ package:
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
   hash:
-    md5: 6b63daed8feeca47be78f323e793d555
-    sha256: fbe49a8c8df83c2eccb37c5863ad98baeb29796ec96f2c503783d7b89bf80c98
+    md5: 32ae18eb2a687912fc9e92a501c0a11b
+    sha256: a7f7e765dfb7af5265a38080e46f18cb07cfeecf81fe28fad23c4538e7d521c3
   manager: conda
   name: zstd
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-h3eb15da_6.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-hfc55251_7.conda
   version: 1.5.2
 - category: main
   dependencies:
@@ -1645,30 +1647,30 @@ package:
   version: 3.8.2
 - category: main
   dependencies:
-    libbrotlidec: 1.0.9 h166bdaf_8
-    libbrotlienc: 1.0.9 h166bdaf_8
+    libbrotlidec: 1.0.9 h166bdaf_9
+    libbrotlienc: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: e5613f2bc717e9945840ff474419b8e4
-    sha256: ab1994e03bdd88e4b27f9f802ac18e45ed29b92cce25e1fd86da43b89734950f
+    md5: d47dee1856d9cb955b8076eeff304a5b
+    sha256: 1c128f136a59ee2fa47d7fbd9b6fc8afa8460d340e4ae0e6f5419ebbd7539a10
   manager: conda
   name: brotli-bin
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
-    gcc_impl_linux-64: '>=12.2.0,<12.2.1.0a0'
+    gcc_impl_linux-64: '>=13.1.0,<13.1.1.0a0'
   hash:
-    md5: 8b6a817ae6f518315cd82a8e826077e8
-    sha256: d5230896809664dec267b3f06b50586de5d7cda22a914b82dc5ab136251d94fd
+    md5: bf50acee3dbe6198ad304538eedd9413
+    sha256: a89b1750b88e5b2d3f3326a1755267dcd20ee1998cef9e961dde1d67890c584c
   manager: conda
   name: conda-gcc-specs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-12.2.0-he6d4335_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.1.0-h0612280_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1712,16 +1714,16 @@ package:
   version: 2.12.1
 - category: main
   dependencies:
-    gcc_impl_linux-64: 12.2.0.*
+    gcc_impl_linux-64: 13.1.0.*
   hash:
-    md5: ec93d13e0fe8514f65842120dbae1b16
-    sha256: 5478f5b7672b6c2d5b644aaa9fe18fbb1468ca6ea9cea1b0f0a2254459438e24
+    md5: 847c6849a2a4ca12e907c17872694d23
+    sha256: b6ee942b1d9b30c2d6eda2a2c36ba05f26a4a8a625d8aa27d5fbaa13045399ab
   manager: conda
   name: gcc
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.2.0-h26027b1_13.conda
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.1.0-h8e92de4_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1741,18 +1743,18 @@ package:
   version: 3.7.8
 - category: main
   dependencies:
-    gcc_impl_linux-64: 12.2.0 hcc96c02_19
-    libstdcxx-devel_linux-64: 12.2.0 h3b97bd3_19
+    gcc_impl_linux-64: 13.1.0 hc4be1a9_0
+    libstdcxx-devel_linux-64: 13.1.0 he3cc6c4_0
     sysroot_linux-64: ''
   hash:
-    md5: 698aae34e4f5e0ea8eac0d529c8f20b6
-    sha256: eaca73bdeabe7d862f41e88be18788d00bd2135bc6003bbe7423e96c4275b944
+    md5: e6591b3c81fc5fb83e342b20a2506e80
+    sha256: a2e154839f057a4fc540c038de13db3c562bccf361a06ed5072e1c74691c4062
   manager: conda
   name: gxx_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.2.0-hcc96c02_19.tar.bz2
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.1.0-hc4be1a9_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     keyutils: '>=1.6.1,<2.0a0'
@@ -1791,15 +1793,15 @@ package:
   version: 3.5.2
 - category: main
   dependencies:
-    libblas: 3.9.0 16_linux64_openblas
+    libblas: 3.9.0 17_linux64_openblas
   hash:
-    md5: 20bae26d0a1db73f758fc3754cab4719
-    sha256: e4ceab90a49cb3ac1af20177016dc92066aa278eded19646bb928d261b98367f
+    md5: 7ef0969b00fe3d6eef56a8151d3afb29
+    sha256: 535bc0a6bc7641090b1bdd00a001bb6c4ac43bce2a11f238bc6676252f53eb3f
   manager: conda
   name: libcblas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-16_linux64_openblas.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-17_linux64_openblas.conda
   version: 3.9.0
 - category: main
   dependencies:
@@ -1811,25 +1813,25 @@ package:
     libzlib: '>=1.2.13,<1.3.0a0'
     pcre2: '>=10.40,<10.41.0a0'
   hash:
-    md5: a64f11b244b2c112cd3fa1cbe9493999
-    sha256: 6a34c6b123f06fcee7e28e981ec0daad09bce35616ad8e9e61ef84be7fad4d92
+    md5: c6f951789c888f7bbd2dd6858eab69de
+    sha256: e909b5e648d1ace172aac2ddf9d755f72429b134155a9b07156acb58a77ceee1
   manager: conda
   name: libglib
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.76.3-hebfc3b9_0.conda
-  version: 2.76.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.76.4-hebfc3b9_0.conda
+  version: 2.76.4
 - category: main
   dependencies:
-    libblas: 3.9.0 16_linux64_openblas
+    libblas: 3.9.0 17_linux64_openblas
   hash:
-    md5: 955d993f41f9354bf753d29864ea20ad
-    sha256: f5f30b8049dfa368599e5a08a4f35cb1966af0abc539d1fd1f50d93db76a74e6
+    md5: a2103882c46492e26500fcb56c03de8b
+    sha256: 45128394d2f4d4caf949c1b02bff1cace3ef2e33762dbe8f0edec7701a16aaa9
   manager: conda
   name: liblapack
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_openblas.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-17_linux64_openblas.conda
   version: 3.9.0
 - category: main
   dependencies:
@@ -1859,31 +1861,31 @@ package:
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.2,<1.6.0a0'
   hash:
-    md5: 4e5ee4b062c21519efbee7e2ae608748
-    sha256: caacb23e1b95fbdd8115be69228f9c82068ed87bf57f055027e31d093ae6a1a2
+    md5: 8ad377fb60abab446a9f02c62b3c2190
+    sha256: 920943ad46869938bd070ccd4c0117594e07538bc6b27b75462594c67b6f215d
   manager: conda
   name: libtiff
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-ha587672_6.conda
-  version: 4.5.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.1-h8b53f26_0.conda
+  version: 4.5.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
-    libprotobuf: '>=4.23.2,<4.23.3.0a0'
+    libprotobuf: '>=4.23.3,<4.23.4.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.3,<7.0a0'
-    openssl: '>=3.1.0,<4.0a0'
+    ncurses: '>=6.4,<7.0a0'
+    openssl: '>=3.1.1,<4.0a0'
     perl: '>=5.32.1,<5.33.0a0 *_perl5'
   hash:
-    md5: 2cf0c4f7a0a46c75e27735d16fab1501
-    sha256: 412157ab852270658e1b96e6f66e00f8ca7039ea8d4ae24090b1d3f726fadfac
+    md5: 434a2df8dbd192cb511290763a4f93d8
+    sha256: b0424b21c5d1790c04e96a7d62e10326fa3c8b0c263ad8cb4eda707b94317f98
   manager: conda
   name: mosh
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mosh-1.4.0-pl5321h4605741_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/mosh-1.4.0-pl5321hc529e37_2.conda
   version: 1.4.0
 - category: main
   dependencies:
@@ -1906,24 +1908,24 @@ package:
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libnsl: '>=2.0.0,<2.1.0a0'
-    libsqlite: '>=3.41.2,<4.0a0'
+    libsqlite: '>=3.42.0,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.3,<7.0a0'
-    openssl: '>=3.1.0,<4.0a0'
+    ncurses: '>=6.4,<7.0a0'
+    openssl: '>=3.1.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.12,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
   hash:
-    md5: 7439c9d24378a82b73a7a53868dacdf1
-    sha256: 6682c75caf3456796fb76313a25475738d85729b43f8c0e904407c0ed8362ede
+    md5: eb6f1df105f37daedd6dca78523baa75
+    sha256: 05e2a7ce916d259f11979634f770f31027d0a5d18463b094e64a30500f900699
   manager: conda
   name: python
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.11-he550d4f_0_cpython.conda
-  version: 3.10.11
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.12-hd12c33a_0_cpython.conda
+  version: 3.10.12
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1983,14 +1985,14 @@ package:
     xorg-xextproto: '>=7.3.0,<8.0a0'
     xorg-xproto: ''
   hash:
-    md5: 52d09ea80a42c0466214609ef0a2d62d
-    sha256: 26e5c72def9f1b191afea84aa2d09622d34b2f547a446eac201ecf894521e5ee
+    md5: 7590b76c3d11d21caa44f3fc38ac584a
+    sha256: 3360f81f7687179959a6bf1c762938240172e8bb3aef957e0a14fb12a0b7c105
   manager: conda
   name: xorg-libx11
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h8ee46fc_1.conda
-  version: 1.8.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.6-h8ee46fc_0.conda
+  version: 1.8.6
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2017,16 +2019,16 @@ package:
   version: 1.4.4
 - category: main
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
   hash:
-    md5: 0b3460f5bf4ae27dfd72fdcccc9667a9
-    sha256: 18aad01518cb08e4eff18e507e14ebf6c522d89ef53ca267c48080933c4435f7
+    md5: 964bace0c38ce4733851a2a29679e3f9
+    sha256: 1fe9b55d3daeb26ac404ec51f106ce8792d7d6548810ca87600cd9b9e9cfbd6e
   manager: conda
   name: argcomplete
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.0.8-pyhd8ed1ab_0.conda
-  version: 3.0.8
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.1-pyhd8ed1ab_0.conda
+  version: 3.1.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -2067,18 +2069,18 @@ package:
   version: 1.6.2
 - category: main
   dependencies:
-    brotli-bin: 1.0.9 h166bdaf_8
-    libbrotlidec: 1.0.9 h166bdaf_8
-    libbrotlienc: 1.0.9 h166bdaf_8
+    brotli-bin: 1.0.9 h166bdaf_9
+    libbrotlidec: 1.0.9 h166bdaf_9
+    libbrotlienc: 1.0.9 h166bdaf_9
     libgcc-ng: '>=12'
   hash:
-    md5: 2ff08978892a3e8b954397c461f18418
-    sha256: 74c0fa22ea7c62d2c8f7a7aea03a3bd4919f7f3940ef5b027ce0dfb5feb38c06
+    md5: 4601544b4982ba1861fa9b9c607b2c06
+    sha256: 2357d205931912def55df0dc53573361156b27856f9bf359d464da162812ec1f
   manager: conda
   name: brotli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_8.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
   version: 1.0.9
 - category: main
   dependencies:
@@ -2118,29 +2120,29 @@ package:
   version: 3.3.1
 - category: main
   dependencies:
-    python: '>=3.6'
+    python: '>=3.7'
   hash:
-    md5: c1d5b294fbf9a795dec349a6f4d8be8e
-    sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
+    md5: 313516e9a4b08b12dfb1e1cd390a96e3
+    sha256: 0666a95fbbd2299008162e2126c009191e5953d1cad1878bf9f4d8d634af1dd4
   manager: conda
   name: charset-normalizer
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2
-  version: 2.1.1
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.2.0-pyhd8ed1ab_0.conda
+  version: 3.2.0
 - category: main
   dependencies:
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.* *_cp310
+    __unix: ''
+    python: '>=3.8'
   hash:
-    md5: 9bb8d28c0899d583a062c17b15ee3e89
-    sha256: 550b1266fed8a3bbfc2e7d5cbe646668aca5b5f1c3b4ac9a17ca2d215d06785a
+    md5: fcae73fbdce7981fd500c626bb1ba6ab
+    sha256: 63f2b103488ba80b274f25bade66394fdd02344024fce45ab44e45861931c61d
   manager: conda
   name: click
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/click-8.1.3-py310hff52083_1.tar.bz2
-  version: 8.1.3
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.4-unix_pyh707e725_0.conda
+  version: 8.1.4
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2232,26 +2234,26 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 7312299d7a0ea4993159229b7d2dceb2
-    sha256: f073c3ba993912f1c0027bc34a54975642885f0a4cd5f9dc42a17ca945df2c18
+    md5: de4cb3384374e1411f0454edcf546cdb
+    sha256: 7b23ea0169fa6e7c3a0867d96d9eacd312759f83e5d83ad0fcc93e85379c16ae
   manager: conda
   name: exceptiongroup
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.1-pyhd8ed1ab_0.conda
-  version: 1.1.1
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.2-pyhd8ed1ab_0.conda
+  version: 1.1.2
 - category: main
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 650f18a56f366dbf419c15b543592c2d
-    sha256: 68db3a6280d6786be76f2c7c6cf41dd878c5d1a24f5de10f7f0af82c6fcfade6
+    md5: 53522ec72e6adae42bd373ef58357230
+    sha256: 1cbae9f05860f2e566e2977f14dfcd5494beb22c028b0a853ade4ec381d9de71
   manager: conda
   name: filelock
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.12.0-pyhd8ed1ab_0.conda
-  version: 3.12.0
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.12.2-pyhd8ed1ab_0.conda
+  version: 3.12.2
 - category: main
   dependencies:
     expat: '>=2.5.0,<3.0a0'
@@ -2286,14 +2288,14 @@ package:
   dependencies:
     python: '>=3.8'
   hash:
-    md5: 20edd290b319aa0eff3e9055375756dc
-    sha256: cbb5c77c0217cda9bf4f4240158de11822a099a6eaa05ba626e822819a54f46d
+    md5: 50ea2067ec92dfcc38b4f07992d7e235
+    sha256: 0015e12d85b454ca8e09085e9e788a6156f4f1da1b270019cab2658381d60258
   manager: conda
   name: fsspec
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.5.0-pyh1a96a4e_0.conda
-  version: 2023.5.0
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.6.0-pyh1a96a4e_0.conda
+  version: 2023.6.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -2330,31 +2332,31 @@ package:
   version: 2.1.2
 - category: main
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    libglib: '>=2.66.4,<3.0a0'
-    libstdcxx-ng: '>=9.3.0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.76.3,<3.0a0'
+    libstdcxx-ng: '>=12'
   hash:
-    md5: 112eb9b5b93f0c02e59aea4fd1967363
-    sha256: ed9ae774aa867ad41bb0aa3f4a088f326dec32ab3468040322dbbd6c5bf33b0a
+    md5: 4d8df0b0db060d33c9a702ada998a8fe
+    sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
   manager: conda
   name: gts
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h64030ff_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
   version: 0.7.6
 - category: main
   dependencies:
-    gcc: 12.2.0.*
-    gxx_impl_linux-64: 12.2.0.*
+    gcc: 13.1.0.*
+    gxx_impl_linux-64: 13.1.0.*
   hash:
-    md5: de605ff437f3fdc010f1b529642339f1
-    sha256: 58bc0a7ff843c4ac2fd53b1370d266d635b59cf8d1d6f165cc26cf1f5324c9f8
+    md5: 5592c3280d50f5dc8dc548ba98c6e9ba
+    sha256: 3c99a6df3f0cac1b8730fea9cc32fab07475b1b8a9b1e7a10d3951bdf29a415f
   manager: conda
   name: gxx
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.2.0-h26027b1_13.conda
-  version: 12.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.1.0-h8e92de4_0.conda
+  version: 13.1.0
 - category: main
   dependencies:
     python: '>=3.10,<3.11.0a0'
@@ -2559,14 +2561,14 @@ package:
     gnutls: '>=3.7.8,<3.8.0a0'
     libgcc-ng: '>=12'
   hash:
-    md5: a946cb6b36807a772748b55f59089a08
-    sha256: 33ddfa3d91816ee44df405424ee2fedf5df5c02a1ffa1819aa4c956eedae4533
+    md5: 20e3667699ceaae97d6ba110a098e8f8
+    sha256: 8530794bb59332eefea6af1e7e3e7289a5fe40d2c4d265357af72b67ff6ee38e
   manager: conda
   name: libmicrohttpd
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.76-h87ba234_0.conda
-  version: 0.9.76
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-0.9.77-h97afed2_0.conda
+  version: 0.9.77
 - category: main
   dependencies:
     python: '>=3.4'
@@ -2585,17 +2587,17 @@ package:
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=2.1.5.1,<3.0a0'
     libpng: '>=1.6.39,<1.7.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
-    libwebp-base: '>=1.3.0,<2.0a0'
+    libtiff: '>=4.5.1,<4.6.0a0'
+    libwebp-base: '>=1.3.1,<2.0a0'
   hash:
-    md5: 9cfd7ad6e1539ca1ad172083586b3301
-    sha256: 461fe2c0279309c21f206f114f3bd6592e906ef6f8cc181b2e28482941b8b925
+    md5: 4963f3f12db45a576f2b8fbe9a0b8569
+    sha256: b0428f43bb3bc4544b997fcd9dfeb5593ee10701e8895cef22212105a8d8aa8d
   manager: conda
   name: libwebp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.3.0-hb47c5f0_0.conda
-  version: 1.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-1.3.1-hbf2b3c1_0.conda
+  version: 1.3.1
 - category: main
   dependencies:
     python: ''
@@ -2614,14 +2616,14 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.* *_cp310
   hash:
-    md5: a1f0db6709778b77b5903541eeac4032
-    sha256: f62b2aeafe968472b20b6935fa7b2290d27ac38b65d98b2708c7cf0b689f9f19
+    md5: 5597d9f9778af6883ae64f0e7d39416c
+    sha256: 91509d88d073f5baf30866219cee9c8ecef839fa9874fee600e46531c2822621
   manager: conda
   name: markupsafe
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.2-py310h1fa729e_0.conda
-  version: 2.1.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_0.conda
+  version: 2.1.3
 - category: main
   dependencies:
     python: '>=3.6'
@@ -2709,14 +2711,14 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.* *_cp310
   hash:
-    md5: 844b150744d30f256d7937f3f60fcd2f
-    sha256: d531c8dcbecb2d47d26fcafce00dd244bfb4fdc787eddea40e61b5b57b0e5da2
+    md5: 3810cbf2635cb1d0edb97715d4ad74e7
+    sha256: 38ec15fe0afe9fb90bd50314ccd506f0e7d1642db0c7eb2b77627d448aa9ee6c
   manager: conda
   name: numpy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.3-py310ha4c1d20_0.conda
-  version: 1.24.3
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.25.1-py310ha4c1d20_0.conda
+  version: 1.25.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -2771,17 +2773,16 @@ package:
   version: 1.9.6
 - category: main
   dependencies:
-    python: '>=3.10,<3.11.0a0'
-    python_abi: 3.10.* *_cp310
+    python: '>=3.8'
   hash:
-    md5: 02e428ab589e3cefe070352c905cefec
-    sha256: 28967130059ac29a1298de5f4555c0ec6344ea56e32642c44f40c19d83f38162
+    md5: 7263924c642d22e311d9e59b839f1b33
+    sha256: ff1f70e0bd50693be7e2bad0efb2539f5dcc5ec4d638e787e703f28098e72de4
   manager: conda
   name: pluggy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pluggy-1.0.0-py310hff52083_4.tar.bz2
-  version: 1.0.0
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.2.0-pyhd8ed1ab_0.conda
+  version: 1.2.0
 - category: main
   dependencies:
     python: '>=3.10,<3.11.0a0'
@@ -2887,14 +2888,14 @@ package:
   dependencies:
     python: '>=3.6'
   hash:
-    md5: e8fbc1b54b25f4b08281467bc13b70cc
-    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    md5: d3ed087d1f7f8f5590e8e87b57a8ce64
+    sha256: 18e3bd52c64f23bbc7c200fd2fc4152dd29423936dc43e8f129cb43f1af0136c
   manager: conda
   name: pyparsing
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
-  version: 3.0.9
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.0-pyhd8ed1ab_0.conda
+  version: 3.1.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3026,14 +3027,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 3b68bc43ec6baa48f7354a446267eefe
-    sha256: 3ac44771fce01f19218bcdf3992e24984748048db69889a9df65abcc6a10e29b
+    md5: 5a7739d0f57ee64133c9d32e6507c46d
+    sha256: 083a0913f5b56644051f31ac40b4eeea762a88c00aa12437817191b85a753cec
   manager: conda
   name: setuptools
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-67.7.2-pyhd8ed1ab_0.conda
-  version: 67.7.2
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.0.0-pyhd8ed1ab_0.conda
+  version: 68.0.0
 - category: main
   dependencies:
     python: ''
@@ -3244,14 +3245,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: 5a4a270e5a3f93846d6bade2f71fa440
-    sha256: 8af96d7b665daabe3e60fa9c7457986237db1ad54469b01af3f4736bc18be284
+    md5: c39d6a09fe819de4951c2642629d9115
+    sha256: 6edd6d5be690be492712cb747b6d62707f0d0c34ef56eefc796d91e5a03187d1
   manager: conda
   name: typing_extensions
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.6.2-pyha770c72_0.conda
-  version: 4.6.2
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.7.1-pyha770c72_0.conda
+  version: 4.7.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3301,14 +3302,14 @@ package:
   dependencies:
     python: '>=3.7'
   hash:
-    md5: bfe7e7cd1476092f51efbcde15dfb110
-    sha256: 85310b382c4220d7846fa8f046216fd722b88db07991f07bd7decdf2e5dc3446
+    md5: c34d9325a609381a0b0e8a5b4f325147
+    sha256: c71cb65ac49692adb33735f3114b99a96c0c5140db1d56cf4ccef4fe92ea9a4c
   manager: conda
   name: websocket-client
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.5.2-pyhd8ed1ab_0.conda
-  version: 1.5.2
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.1-pyhd8ed1ab_0.conda
+  version: 1.6.1
 - category: main
   dependencies:
     python: '>=3.7'
@@ -3377,18 +3378,18 @@ package:
   version: 5.0.3
 - category: main
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-libx11: '>=1.7.0,<2.0a0'
+    libgcc-ng: '>=12'
+    xorg-libx11: '>=1.8.6,<2.0a0'
     xorg-renderproto: ''
   hash:
-    md5: f59c1242cc1dd93e72c2ee2b360979eb
-    sha256: 7d907ed9e2ec5af5d7498fb3ab744accc298914ae31497ab6dcc6ef8bd134d00
+    md5: ed67c36f215b310412b2af935bf3e530
+    sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
   manager: conda
   name: xorg-libxrender
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2
-  version: 0.9.10
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+  version: 0.9.11
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3408,16 +3409,16 @@ package:
   version: 1.3.0
 - category: main
   dependencies:
-    python: '>=3.7'
+    python: '>=3.8'
   hash:
-    md5: 13018819ca8f5b7cc675a8faf1f5fedf
-    sha256: 241de30545299be9bcea3addf8a2c22a3b3d4ba6730890e150ab690ac937a3d2
+    md5: 0ea0b5003b96e53769a5f70175ff5264
+    sha256: 14b78fc742efdf46e3ecff0a4b89cbdf780b8cf22c822024cc642e4284339ea4
   manager: conda
   name: zipp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
-  version: 3.15.0
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.0-pyhd8ed1ab_1.conda
+  version: 3.16.0
 - category: main
   dependencies:
     frozenlist: '>=1.1.0'
@@ -3561,14 +3562,14 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.* *_cp310
   hash:
-    md5: 7bf9d8c765b6b04882c719509652c6d6
-    sha256: 670b736e895ed1b37187e0cbc73fd528414076f370068975135db2420af8663d
+    md5: 684399f9ddc0b9d6f3b6164f6107098e
+    sha256: 709dae7fbfdb1ab7aeeb060bae9095e5a18bd3849fd3afbf618a7be3a4117e76
   manager: conda
   name: contourpy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.0.7-py310hdf3cbec_0.conda
-  version: 1.0.7
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.0-py310hd41b1e2_0.conda
+  version: 1.1.0
 - category: main
   dependencies:
     krb5: '>=1.20.1,<1.21.0a0'
@@ -3631,14 +3632,14 @@ package:
     python_abi: 3.10.* *_cp310
     unicodedata2: '>=14.0.0'
   hash:
-    md5: 76426eaff204520e719207700359a855
-    sha256: 253a41d41f4ccaef49412c3c628dc2032526821a3bad26b8cd65b311d6346519
+    md5: d3d83b419c81ac718a9221442707882b
+    sha256: e5d22bcf75a4414d84000a3d905c70d4d2a1db96c0dfbf5a89169817351b2bb7
   manager: conda
   name: fonttools
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.39.4-py310h2372a71_0.conda
-  version: 4.39.4
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.40.0-py310h2372a71_0.conda
+  version: 4.40.0
 - category: main
   dependencies:
     python: '>=3.4'
@@ -3684,14 +3685,14 @@ package:
     python: '>=3.8'
     zipp: '>=0.5'
   hash:
-    md5: f91a5d5175fb7ff2a91952ec7da59cb9
-    sha256: 33d49065756a73fbb92277c756fa00a41891408528eb90ae05ff3367a401ae6e
+    md5: 4e9f59a060c3be52bc4ddc46ee9b6946
+    sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
   manager: conda
   name: importlib-metadata
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.6.0-pyha770c72_0.conda
-  version: 6.6.0
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
+  version: 6.8.0
 - category: main
   dependencies:
     more-itertools: ''
@@ -3793,14 +3794,14 @@ package:
     tomli: '>=1.1.0'
     typing_extensions: '>=3.10'
   hash:
-    md5: e090e0c360bf9b1f846c2608c70422da
-    sha256: 95047c6684009b08c6b9e45eb9693585fc6ed40758bb93ebc5e76376c643939f
+    md5: b5750d448bc0ce0d0a10da0bb7bd9d96
+    sha256: 5322d2c5cb45a1abfb7807ac1190cc949654c9fd91e0ae5a2b70f4279be995db
   manager: conda
   name: mypy
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.3.0-py310h2372a71_0.conda
-  version: 1.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.4.1-py310h2372a71_0.conda
+  version: 1.4.1
 - category: main
   dependencies:
     python: 2.7|>=3.7
@@ -3820,8 +3821,8 @@ package:
     lcms2: '>=2.15,<3.0a0'
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
-    libwebp-base: '>=1.3.0,<2.0a0'
+    libtiff: '>=4.5.1,<4.6.0a0'
+    libwebp-base: '>=1.3.1,<2.0a0'
     libxcb: '>=1.15,<1.16.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openjpeg: '>=2.5.0,<3.0a0'
@@ -3829,14 +3830,14 @@ package:
     python_abi: 3.10.* *_cp310
     tk: '>=8.6.12,<8.7.0a0'
   hash:
-    md5: cf62f6cff3536eafaaa0c740b0bf7465
-    sha256: 1fd549c5f9e229890fd2b31e54c0718994120d850f5abbf1d2b7614791b4bd60
+    md5: adcc7ea52e4d39d0a93f6a2ef36c7fd4
+    sha256: 26d41f3e6278f42cc61499576e6f39a0bb84b5f21673250d89f8f958e9f6f4b0
   manager: conda
   name: pillow
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.5.0-py310h582fbeb_1.conda
-  version: 9.5.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.0-py310h582fbeb_0.conda
+  version: 10.0.0
 - category: main
   dependencies:
     python: '>=3.7'
@@ -3851,6 +3852,24 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/noarch/pip-23.1.2-pyhd8ed1ab_0.conda
   version: 23.1.2
+- category: main
+  dependencies:
+    colorama: ''
+    exceptiongroup: '>=1.0.0rc8'
+    iniconfig: ''
+    packaging: ''
+    pluggy: '>=0.12,<2.0'
+    python: '>=3.7'
+    tomli: '>=1.0.0'
+  hash:
+    md5: 3cfe9b9e958e7238a386933c75d190db
+    sha256: 52b2eb4e8d0380d92d45643d0c9706725e691ce8404dab4c2db4aaf58e48a23c
+  manager: conda
+  name: pytest
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.0-pyhd8ed1ab_0.conda
+  version: 7.4.0
 - category: main
   dependencies:
     python: '>=3.6'
@@ -3904,14 +3923,14 @@ package:
     ruamel.yaml.clib: '>=0.1.2'
     setuptools: ''
   hash:
-    md5: 41e89112e1ec653fb3e62240d06a0e61
-    sha256: 390860e10ad461c1ea45f18e20526978bb785ec6c7ba91a2e1d8d8832d3bbb93
+    md5: 9a03abf74d5069bda767c1bce7a41e0b
+    sha256: bdbd5b73bc92f3bd4eea8b8475d912a9d42562ed494163fd3987404f514beb70
   manager: conda
   name: ruamel.yaml
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.31-py310h2372a71_0.conda
-  version: 0.17.31
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.32-py310h2372a71_0.conda
+  version: 0.17.32
 - category: main
   dependencies:
     colorama: ''
@@ -3940,16 +3959,16 @@ package:
   version: 2.31.0.1
 - category: main
   dependencies:
-    typing_extensions: 4.6.2 pyha770c72_0
+    typing_extensions: 4.7.1 pyha770c72_0
   hash:
-    md5: f676553904bb8f7c1dfe71c9db0d9ba7
-    sha256: 5c6dcf5ff0d6be8a15d6bf5297867d9cb0154b6b946e8c87f69becf8a356e71b
+    md5: f96688577f1faa58096d06a45136afa2
+    sha256: d5d19b8f5b275240c19616a46d67ec57250b3720ba88200da8c732c3fcbfc21d
   manager: conda
   name: typing-extensions
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.6.2-hd8ed1ab_0.conda
-  version: 4.6.2
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.7.1-hd8ed1ab_0.conda
+  version: 4.7.1
 - category: main
   dependencies:
     gettext: '>=0.21.1,<1.0a0'
@@ -3975,14 +3994,14 @@ package:
     markupsafe: '>=2.1.1'
     python: '>=3.8'
   hash:
-    md5: 23ddbe41ab0115bc0bfb75dcbf5de7cf
-    sha256: 2df1970270839b36e13a4ba7e4b393cfa95aa1d7438909aa8c3db14170ea207c
+    md5: 55fbbb3e67185820ee2007395bfe0073
+    sha256: 28515f7ddb8a20f1436b9ac3a6ba2aa9be337995e4ee63c72d0f5d0efd6a2062
   manager: conda
   name: werkzeug
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.4-pyhd8ed1ab_0.conda
-  version: 2.3.4
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.6-pyhd8ed1ab_0.conda
+  version: 2.3.6
 - category: main
   dependencies:
     libgcc-ng: '>=9.3.0'
@@ -4015,6 +4034,19 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.2-py310h2372a71_0.conda
   version: 1.9.2
+- category: main
+  dependencies:
+    python: '>=3.7'
+    typing-extensions: '>=4.0.0'
+  hash:
+    md5: 578ae086f225bc2380c79f3b551ff2f7
+    sha256: bbabfd4400b03ba6c50d0a55e777e0c3ba900af8dabedb9b8aded774484b5d53
+  manager: conda
+  name: annotated-types
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.5.0-pyhd8ed1ab_0.conda
+  version: 0.5.0
 - category: main
   dependencies:
     python: '>=3.6'
@@ -4132,32 +4164,32 @@ package:
     libgcc-ng: '>=12'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.0,<4.0a0'
+    openssl: '>=3.1.1,<4.0a0'
     pcre2: '>=10.40,<10.41.0a0'
     perl: 5.*
   hash:
-    md5: 0cb5ff348eb4c201b3b920eff851675d
-    sha256: 528c9fdaf799b38611276d6f676da6018da2aaf93fb5b0328c00923909e99432
+    md5: 14f8341e26b274362b026bbdc72b14fb
+    sha256: 46aac096868527843ad7083c254e32b5451fc1e304036dcac4243b66c08a8517
   manager: conda
   name: git
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/git-2.40.1-pl5321h86e50cf_0.conda
-  version: 2.40.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/git-2.41.0-pl5321h86e50cf_0.conda
+  version: 2.41.0
 - category: main
   dependencies:
     gitdb: '>=4.0.1,<5'
     python: '>=3.7'
     typing_extensions: '>=3.7.4.3'
   hash:
-    md5: f6e6b482110246a81c3f03e81c68752d
-    sha256: 77c531def610089bc190508fcf304cf96c085c5fe977ab8f7d7c1641769592ac
+    md5: 5809a12901d57388444c3293c975d0bb
+    sha256: 07008a94189e570fcabe003b99bd50b8263f60c824f36f81a8819bb7cf7eab1b
   manager: conda
   name: gitpython
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.31-pyhd8ed1ab_0.conda
-  version: 3.1.31
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.32-pyhd8ed1ab_0.conda
+  version: 3.1.32
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4178,16 +4210,16 @@ package:
   version: 7.3.0
 - category: main
   dependencies:
-    importlib-metadata: '>=6.6.0,<6.6.1.0a0'
+    importlib-metadata: '>=6.8.0,<6.8.1.0a0'
   hash:
-    md5: 3cbc9615f10a3d471532b83e4250b971
-    sha256: 5de35d3c019d8a36e0a0deeb04a62689837bd68234a0a73a3355b860b442eca4
+    md5: b279b07ce18058034e5b3606ba103a8b
+    sha256: b96e01dc42d547d6d9ceb1c5b52a5232cc04e40153534350f702c3e0418a6b3f
   manager: conda
   name: importlib_metadata
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.6.0-hd8ed1ab_0.conda
-  version: 6.6.0
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
+  version: 6.8.0
 - category: main
   dependencies:
     attrs: '>=17.4.0'
@@ -4257,14 +4289,14 @@ package:
     python_abi: 3.10.* *_cp310
     pytz: '>=2020.1'
   hash:
-    md5: e0b845c6b29a1ed2e409bef6c0f5d96b
-    sha256: 38b0937c9b099cc5bf7cd4b19dfb03f8b2a8454e1895d65dfa888d189e3a3ab5
+    md5: 11e0099d4571b4974c04386e4ce679ed
+    sha256: e8937c160b6eb469c5d80971046b25ed305fd97a8b1d6880de7c4a660cd245c3
   manager: conda
   name: pandas
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.2-py310h7cbd5c2_0.conda
-  version: 2.0.2
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.3-py310h7cbd5c2_1.conda
+  version: 2.0.3
 - category: main
   dependencies:
     pip: ''
@@ -4281,31 +4313,31 @@ package:
 - category: main
   dependencies:
     python: '>=3.7'
-    typing-extensions: '>=4.5'
+    typing-extensions: '>=4.6.3'
   hash:
-    md5: e2be672aece1f060adf7154f76531a35
-    sha256: d7845c01a9ee5a224cc9242782befed7d12dc6aac1103650ec87917b20f3579e
+    md5: e76070baecfaca6ecdb5fbd5af7c9309
+    sha256: b5012d6fd30f2462b6ca595539cfdae9aaf61b3b7a56e51ab94aef0fd9efcd3d
   manager: conda
   name: platformdirs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.5.1-pyhd8ed1ab_0.conda
-  version: 3.5.1
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.8.1-pyhd8ed1ab_0.conda
+  version: 3.8.1
 - category: main
   dependencies:
     libgcc-ng: '>=12'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.* *_cp310
-    typing-extensions: '>=4.2.0'
+    typing-extensions: '>=4.6.0'
   hash:
-    md5: 38ba96ab3cb505a83ca294a82aa95f6a
-    sha256: 25ce5ed5f662abe3c5a8be3cbad8e886a180886da7aee46ecc6d38189985d324
+    md5: cebe5d122c8b1902f6c0ca7e3c63344f
+    sha256: b6b097058ae9f378b9db07b2396d7baba8ccaf9c7f0666795caccdb69c36274a
   manager: conda
-  name: pydantic
+  name: pydantic-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-1.10.8-py310h2372a71_0.conda
-  version: 1.10.8
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.1.2-py310hcb5633a_0.conda
+  version: 2.1.2
 - category: main
   dependencies:
     cffi: '>=1.4.1'
@@ -4325,36 +4357,43 @@ package:
   version: 1.5.0
 - category: main
   dependencies:
-    colorama: ''
-    exceptiongroup: ''
-    importlib-metadata: '>=0.12'
-    iniconfig: ''
-    packaging: ''
-    pluggy: '>=0.12,<2.0'
-    python: '>=3.8'
-    tomli: '>=1.0.0'
+    pytest: '>=3.6.0'
+    python: ''
   hash:
-    md5: 547c7de697ec99b494a28ddde185b5a4
-    sha256: 42f89db577266b9dc195d09189b92f3af3354fb50c98b1f996c580322dffa8b5
+    md5: b6764e23dece9f9cda0469af044fafeb
+    sha256: bdb25a7daf3efb7255b1a19d7b5d41d7d4d96bc647b8e5f7407ec4dd9e384257
   manager: conda
-  name: pytest
+  name: pytest-dependency
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.3.1-pyhd8ed1ab_0.conda
-  version: 7.3.1
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-dependency-0.5.1-pyh9f0ad1d_0.tar.bz2
+  version: 0.5.1
+- category: main
+  dependencies:
+    pytest: '>=5.0'
+    python: '>=3.7'
+  hash:
+    md5: fcd2531bc3e492657aeb042349aeaf8a
+    sha256: d2f6a46fe31dea91b427bcc57302edc345eb763caf3c6b6dcd09b2aee002324b
+  manager: conda
+  name: pytest-mock
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.11.1-pyhd8ed1ab_0.conda
+  version: 3.11.1
 - category: main
   dependencies:
     pip: ''
     python: '>=3.7,<4.0'
   hash:
-    md5: 7a02fed21d1bf45cb41eaeaefc7eea25
-    sha256: 6ba480465154a4ac2ba1c08d10e4824dc10db30d8087b83b2b041df0ebba18e8
+    md5: ffabccdca64c44c1f23a8df134708897
+    sha256: dbc0641f63dbf6d2d2e9b17a21ae8e0b3cb8e24ffa675e06cf5ce6f76d6a58d8
   manager: conda
   name: types-awscrt
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.16.19-pyhd8ed1ab_0.conda
-  version: 0.16.19
+  url: https://conda.anaconda.org/conda-forge/noarch/types-awscrt-0.16.23-pyhd8ed1ab_0.conda
+  version: 0.16.23
 - category: main
   dependencies:
     cffi: ''
@@ -4396,20 +4435,20 @@ package:
     python_abi: 3.10.* *_cp310
     zstd: '>=1.5.2,<1.6.0a0'
   hash:
-    md5: 2cce1a48e6687f64d371d2e7fc9c7fbf
-    sha256: 97f69cae6513a1c64ce2ec87380f9a177e386af398300921a869c07e826b4949
+    md5: a2b48edcd52593cdf007158ce10e1520
+    sha256: 76a443ffcda1c290dbcc8c0bbe15a0f0ee0b57009cf842940f3382672780ddd8
   manager: conda
   name: zstandard
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py310hdeb6495_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.19.0-py310h1275a96_2.conda
   version: 0.19.0
 - category: main
   dependencies:
     aiosignal: '>=1.1.2'
     async-timeout: <5.0,>=4.0.0a3
     attrs: '>=17.3.0'
-    charset-normalizer: '>=2.0,<3.0'
+    charset-normalizer: '>=2.0,<4.0'
     frozenlist: '>=1.1.1'
     libgcc-ng: '>=12'
     multidict: '>=4.5,<7.0'
@@ -4417,13 +4456,13 @@ package:
     python_abi: 3.10.* *_cp310
     yarl: '>=1.0,<2.0'
   hash:
-    md5: ad96f1f4a5a53f6e474953539d0f73ea
-    sha256: 0ea7c35b73cb454d1479bef3328ab3abfec6908449cef925d10a33725e53d294
+    md5: 05d01d95b7838f86796b18a80fd42584
+    sha256: 475f5618a9b6228bd1b5ac37c1866ff01d52c39d04fe2c53ddd3ae888f6d19a1
   manager: conda
   name: aiohttp
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.4-py310h1fa729e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.8.4-py310h2372a71_1.conda
   version: 3.8.4
 - category: main
   dependencies:
@@ -4431,14 +4470,14 @@ package:
     types-awscrt: ''
     typing_extensions: ''
   hash:
-    md5: f19106a30c5fb2c52d84d1dbf0b5e097
-    sha256: 8bf3c568732facd3ca9adf2f1867f91f84fc0e3779dba9e4da4c10f35ac0dfba
+    md5: 63ed81138f359d75fb3f8c1e8deadfe0
+    sha256: e181ec7110dc831c91b4660de20e0023b0adc898bcde34cc2048d7fc286b2fb3
   manager: conda
   name: botocore-stubs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.29.145-pyhd8ed1ab_0.conda
-  version: 1.29.145
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-stubs-1.29.165-pyhd8ed1ab_0.conda
+  version: 1.29.165
 - category: main
   dependencies:
     clang-format: 16.0.3 default_h1cdf331_2
@@ -4604,6 +4643,23 @@ package:
   version: 3.2.0
 - category: main
   dependencies:
+    annotated-types: '>=0.4.0'
+    libgcc-ng: '>=12'
+    pydantic-core: 2.1.2
+    python: '>=3.10,<3.11.0a0'
+    python_abi: 3.10.* *_cp310
+    typing-extensions: '>=4.6.1'
+  hash:
+    md5: 4f6be3167ecdaa7a0da00a9774be695a
+    sha256: a056749c12c9e287d60aeb8a6796086138dea348b04da1e100ddc19949f1dc7d
+  manager: conda
+  name: pydantic
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-2.0.2-py310h2372a71_1.conda
+  version: 2.0.2
+- category: main
+  dependencies:
     cryptography: '>=38.0.0,<42,!=40.0.0,!=40.0.1'
     python: '>=3.6'
   hash:
@@ -4615,32 +4671,6 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.2.0-pyhd8ed1ab_1.conda
   version: 23.2.0
-- category: main
-  dependencies:
-    pytest: '>=3.6.0'
-    python: ''
-  hash:
-    md5: b6764e23dece9f9cda0469af044fafeb
-    sha256: bdb25a7daf3efb7255b1a19d7b5d41d7d4d96bc647b8e5f7407ec4dd9e384257
-  manager: conda
-  name: pytest-dependency
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-dependency-0.5.1-pyh9f0ad1d_0.tar.bz2
-  version: 0.5.1
-- category: main
-  dependencies:
-    pytest: '>=5.0'
-    python: '>=3.7'
-  hash:
-    md5: db93caa9fe182f0cd20291aeb22f57ac
-    sha256: 87bb8edc9976403237a0e6c3bd7b2224c346c95e4c7345971f411aef21593450
-  manager: conda
-  name: pytest-mock
-  optional: false
-  platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.10.0-pyhd8ed1ab_0.tar.bz2
-  version: 3.10.0
 - category: main
   dependencies:
     cryptography: ''
@@ -4704,18 +4734,18 @@ package:
 - category: main
   dependencies:
     distlib: <1,>=0.3.6
-    filelock: <4,>=3.11
-    platformdirs: <4,>=3.2
+    filelock: <4,>=3.12
+    platformdirs: <4,>=3.5.1
     python: '>=3.8'
   hash:
-    md5: a920e114c4c2ced2280e266da65ab5e6
-    sha256: 13d667887ea08b6d1fe2eb09d2d737f9af7343735d3bfa5ffaa3f67eec8eaff7
+    md5: 838b85f656b078bdd882ef97978e7f40
+    sha256: 92dd17aef10e5c35289da3a588cbed3e593c22ee53478a00ccb1fdf92fe0e84e
   manager: conda
   name: virtualenv
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.23.0-pyhd8ed1ab_0.conda
-  version: 20.23.0
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.23.1-pyhd8ed1ab_0.conda
+  version: 20.23.1
 - category: main
   dependencies:
     conda-package-streaming: '>=0.7.0'
@@ -4771,14 +4801,14 @@ package:
     python_abi: 3.10.* *_cp310
     secretstorage: '>=3.2'
   hash:
-    md5: 85da2982e8456156e2f38e6a3f75cd89
-    sha256: c709408ded9e04b193a5f6c77f6586ab4ab93bdb5a5413eeecc9530165ccf312
+    md5: c6138432d67b31a98a55af46b3f693c1
+    sha256: d01df199b2db95622e6b0b87128239e60c4a170f46e9b58fdfde15f948515dfd
   manager: conda
   name: keyring
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-23.13.1-py310hff52083_0.conda
-  version: 23.13.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.2.0-py310hff52083_0.conda
+  version: 24.2.0
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4822,27 +4852,27 @@ package:
     pyyaml: '>=5.1'
     virtualenv: '>=20.10.0'
   hash:
-    md5: dbb0111b18ea5c9983fb8db0aef6000b
-    sha256: a55d8a19bb00c2c5bf8a074c94d5ac1ffed8d63c53c9df4cee76f3764ad7a304
+    md5: dd64a0e440754ed97610b3e6b502b6b1
+    sha256: 3df1434057ce827d88cdd84578732030b3d4b5a0bc6c58bff12b7f8001c1be5b
   manager: conda
   name: pre-commit
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.3.2-pyha770c72_0.conda
-  version: 3.3.2
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.3.3-pyha770c72_0.conda
+  version: 3.3.3
 - category: main
   dependencies:
     __unix: ''
     openjdk: '>=8'
   hash:
-    md5: 9db52fde2303937e5ae766d3c0c2c21e
-    sha256: 4a5967e73309839e57f254046e2a07cb16039a0c46d820d302382fd910751fde
+    md5: 67177beb0a5d0968d7b2935b7901d955
+    sha256: f0582f7f4f90231754f6532de13d9737ed422a5bb086962dcf0380c0ea2513df
   manager: conda
   name: sbt
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/sbt-1.8.2-hd8ed1ab_0.conda
-  version: 1.8.2
+  url: https://conda.anaconda.org/conda-forge/noarch/sbt-1.9.2-h707e725_0.conda
+  version: 1.9.2
 - category: main
   dependencies:
     brotlipy: '>=0.6.0'
@@ -4868,14 +4898,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
   hash:
-    md5: a1b8b2b1df2fa7a35fc15e561601cbe0
-    sha256: 61c711c9620821ef97ef04ad1991c23328debbe722ca1891e917821bc47f1611
+    md5: 0edc7c1cfd7921df59c922f2b734ff1c
+    sha256: 232a3ad207515d492274b004bf59bacc7254893086ac0d72fe0108cea2834dbf
   manager: conda
   name: botocore
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.29.145-pyhd8ed1ab_0.conda
-  version: 1.29.145
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.1-pyhd8ed1ab_0.conda
+  version: 1.31.1
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4943,14 +4973,14 @@ package:
     six: '>=1.11.0'
     typing-extensions: '>=4.0.1'
   hash:
-    md5: 4e49a7bd8f79a678c4fa2e871f4e2881
-    sha256: 485bd7bba4820ea7265990d335ec10ab2f431c6bb1cca19f3ce7b87879f62e72
+    md5: 5576496c2743cafa05111ac76267db29
+    sha256: 51951b49a43b7de818ad055d113348f7e438e225fc7a5f8f4c635998239c4c89
   manager: conda
   name: azure-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.27.0-pyhd8ed1ab_0.conda
-  version: 1.27.0
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.27.1-pyhd8ed1ab_0.conda
+  version: 1.27.1
 - category: main
   dependencies:
     msgpack-python: '>=0.5.2'
@@ -4997,14 +5027,14 @@ package:
     urllib3: '>=1.26.0'
     websocket-client: '>=0.32.0'
   hash:
-    md5: 543336c6aa9516cfb29c51d5c162b177
-    sha256: 5e01e15e20ee573c99b530633a0d5c71fd515e4ac6d2f5f5f57baece8b915cc3
+    md5: c95d23d8bae7e21491868cc7772d7c73
+    sha256: 7c3031602e92fd7682302ef98a45bdf7374d48a849cdd3900b7c68a32d162177
   manager: conda
   name: docker-py
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-6.1.0-pyhd8ed1ab_0.conda
-  version: 6.1.0
+  url: https://conda.anaconda.org/conda-forge/noarch/docker-py-6.1.3-pyhd8ed1ab_0.conda
+  version: 6.1.3
 - category: main
   dependencies:
     appdirs: ''
@@ -5052,17 +5082,20 @@ package:
 - category: main
   dependencies:
     python: '>=3.7'
-    requests: '>=2.0,<3.0'
+    pyyaml: ''
+    requests: '>=2.22.0,<3.0'
+    types-pyyaml: ''
+    typing_extensions: ''
     urllib3: '>=1.25.10'
   hash:
-    md5: 5b21c0b72f49d216ee1d01a4e7f96f9e
-    sha256: 2a3046ef1902919b40f637c4c749100508a685a5c6a05e0f3834a0e3c94514df
+    md5: bf15c93720dfea117aaea3155cbebce5
+    sha256: c64db4a71de87e17fbcbd0b3af2186ab25d65428bb565bd7d070850324096f3b
   manager: conda
   name: responses
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.21.0-pyhd8ed1ab_0.tar.bz2
-  version: 0.21.0
+  url: https://conda.anaconda.org/conda-forge/noarch/responses-0.23.1-pyhd8ed1ab_0.conda
+  version: 0.23.1
 - category: main
   dependencies:
     botocore: '>=1.12.36,<2.0a.0'
@@ -5107,7 +5140,7 @@ package:
   version: 5.1.1
 - category: main
   dependencies:
-    botocore: 1.29.145
+    botocore: 1.31.1
     colorama: '>=0.2.5,<0.4.5'
     docutils: '>=0.10,<0.17'
     python: '>=3.10,<3.11.0a0'
@@ -5116,29 +5149,29 @@ package:
     rsa: '>=3.1.2,<4.8'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 72db444c038161792bce84c115badf4f
-    sha256: d3ca2cd8c3cf320828c19d4afcb5e06aa42a2782c2e4cd43b511a812fa0242fd
+    md5: 97290e3028c5cdc775e55873dc8e3f03
+    sha256: 8715e45be127be2e25d872137ba27fc27673f354baae2a55c9060bfce701ad57
   manager: conda
   name: awscli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.27.145-py310hff52083_0.conda
-  version: 1.27.145
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.29.1-py310hff52083_0.conda
+  version: 1.29.1
 - category: main
   dependencies:
-    botocore: '>=1.29.145,<1.30.0'
+    botocore: '>=1.31.1,<1.32.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.7'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 09e0b5c5f94eb5b480477ae63072b7dd
-    sha256: 82d045f01c87a8202796eadf2f10350b7e2417b480e93c69bb85a8364b750f02
+    md5: 3a0123e890ea210f6468121bdfa6cfc0
+    sha256: 4fea48dc33349ea59efe4f8ddb6c4ec2fbec24c49a7482263893498bc6e506ca
   manager: conda
   name: boto3
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.26.145-pyhd8ed1ab_0.conda
-  version: 1.26.145
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.28.1-pyhd8ed1ab_0.conda
+  version: 1.28.1
 - category: main
   dependencies:
     cachecontrol: 0.13.0 pyhd8ed1ab_0
@@ -5264,14 +5297,14 @@ package:
     python: ''
     typing_extensions: ''
   hash:
-    md5: 1cc6dd0f40481c8a20eaa91a76f48ce5
-    sha256: c0c0c81cfaf11a662d331d934d7a8eca12adbf12fa89a1fd60b514318c87c6c8
+    md5: e07be93e70ff9affb934ff017a86c722
+    sha256: c3a63fce78c2b080803b2a40cc3f5fe9e5ade617efe278cf09b6b89c8f0ea232
   manager: conda
   name: boto3-stubs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.26.145-pyhd8ed1ab_0.conda
-  version: 1.26.145
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.28.1-pyhd8ed1ab_0.conda
+  version: 1.28.1
 - category: main
   dependencies:
     cachecontrol-with-filecache: '>=0.12.9'
@@ -5312,28 +5345,28 @@ package:
     python: '>=3.6'
     typing-extensions: ''
   hash:
-    md5: adb30ee4ef9f506b62f732c8a78d250b
-    sha256: 281ba68f92f05626bf37df32156abbf62e6ed963ab40b2205277a066391cc06f
+    md5: 1c53cbf18ef82bac6c4957398f107d61
+    sha256: 5bd251a81e5ee934e0945530d00f46944c4dc5e8fad001ce761ef89310f9c9cc
   manager: conda
   name: mypy-boto3-s3
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.26.127-pyhd8ed1ab_0.conda
-  version: 1.26.127
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy-boto3-s3-1.28.0-pyhd8ed1ab_0.conda
+  version: 1.28.0
 - category: main
   dependencies:
     boto3: ''
     python: '>=3.6'
     typing-extensions: ''
   hash:
-    md5: 2f58c5525f108a1525553e081c90f815
-    sha256: 66d980a4aa02be974410c64d0631ea54d26e538f49300ac5e3b46d44a4acec78
+    md5: 7af6a634a654ee7aac1941e05cf1568c
+    sha256: 4fee92b4e5580dfd13fe942ae307100666064121197b94de5c824c3dd98eb327
   manager: conda
   name: mypy_boto3_ec2
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.26.136-pyhd8ed1ab_0.conda
-  version: 1.26.136
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_boto3_ec2-1.28.0-pyhd8ed1ab_0.conda
+  version: 1.28.0
 - category: main
   dependencies:
     boto3: ''
@@ -5353,16 +5386,16 @@ package:
     docutils: <0.19
     python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*'
     sphinx: '>=1.6,<7'
-    sphinxcontrib-jquery: '>=2.0.0,!=3.0.0'
+    sphinxcontrib-jquery: '>=4,<5'
   hash:
-    md5: dd1ec3c6beac662d7bf9c996975f637f
-    sha256: 818659eb58b74da694e7ff6ecb907d417ae0de4db8231c42f0b0ba75f56ef3f4
+    md5: 5ef6aaf2cfb3b656cdadb431daed6a9f
+    sha256: 129cab0a4cddd57fa58930c306ca8363c8ac2c40bd40b784210603b17abb5639
   manager: conda
   name: sphinx_rtd_theme
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/sphinx_rtd_theme-1.2.1-pyha770c72_0.conda
-  version: 1.2.1
+  url: https://conda.anaconda.org/conda-forge/noarch/sphinx_rtd_theme-1.2.2-pyha770c72_0.conda
+  version: 1.2.2
 - category: main
   dependencies:
     aws-sam-translator: '>=1.55.0'
@@ -5412,14 +5445,14 @@ package:
     werkzeug: '>=0.5,!=2.2.0,!=2.2.1'
     xmltodict: ''
   hash:
-    md5: 7f8865d0f6df238a407cab06d884c211
-    sha256: c51cc65dac1b0b1f5139860c07030b9465417cebcb8529ffa97fcd8615aba606
+    md5: 2ad89e262b7d71adc0820e207329d659
+    sha256: 4a348f91127ca5456c224114329705b68c18812d67060f3cc93bb0310e5ebeba
   manager: conda
   name: moto
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.1.10-pyhd8ed1ab_0.conda
-  version: 4.1.10
+  url: https://conda.anaconda.org/conda-forge/noarch/moto-4.1.12-pyhd8ed1ab_0.conda
+  version: 4.1.12
 - category: main
   dependencies: {}
   hash:
@@ -5477,6 +5510,16 @@ package:
   source: null
   url: https://files.pythonhosted.org/packages/9f/53/1ac75eab589149b1e02e38185ecebf09e1b805fc3fdeadbc16d1a2b7d208/paramiko_ng-2.8.10-py2.py3-none-any.whl
   version: 2.8.10
+- dependencies:
+    typing-extensions: '>=4.2.0'
+  hash:
+    sha256: 16928fdc9cb273c6af00d9d5045434c39afba5f42325fb990add2c241402d151
+  manager: pip
+  name: pydantic
+  platform: linux-64
+  source: null
+  url: https://files.pythonhosted.org/packages/b6/8e/7dd215f91528487535e7aa048e4092c20ecd0168df958e58809e2235cece/pydantic-1.10.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  version: 1.10.11
 - category: main
   dependencies:
     ruamel.yaml.clib: '>=0.2.7'

--- a/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
+++ b/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
@@ -21,7 +21,7 @@ metadata:
   - url: nodefaults
     used_env_vars: []
   content_hash:
-    linux-64: 226203ede9b0f046c54182afa8a2500b066f69e90eb7d1231892fa08d33241b5
+    linux-64: c21b046554fff6a17a993f763664cc9d9994650e380510f7391ababd82f27219
   platforms:
   - linux-64
   sources:
@@ -145,14 +145,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: 5ec50dcd74ba7461709c4ac9c4cc4190
-    sha256: 749dabbfe7b571affa19ef3ddb23e22e2eed12d5a699a9830a0f7fba2f296e02
+    md5: b9ae31bc2e565684ebaf82d4bd954d55
+    sha256: 257495088b78d4344c7ea21145581ed6da1c5bf8320f49b659ce2ed2d6265f76
   manager: conda
   name: libgcc-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-13.1.0-he3cc6c4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_0.conda
+  version: 12.3.0
 - category: main
   dependencies: {}
   hash:
@@ -167,14 +167,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: e703914ad2288ab24cf5ac94d812fc11
-    sha256: 21b95f21a80462c832caa348ece5413e10ba69d922dca01826706fe7b6f3a764
+    md5: 7c80158949230e6d837186b20b2fcf13
+    sha256: b311dad92ffafd29668fca6330dc707f4d7f154a4fa4c3859832897416de39ec
   manager: conda
   name: libstdcxx-devel_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-13.1.0-he3cc6c4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_0.conda
+  version: 12.3.0
 - category: main
   dependencies: {}
   hash:
@@ -189,14 +189,14 @@ package:
 - category: main
   dependencies: {}
   hash:
-    md5: 374b3bf084169a90f41675d19b0ad35a
-    sha256: f8d37016976d69b9b983a9299783884fd746258666f7e47a0dd1f5b3b0259568
+    md5: 0fde972b336190cd618fe158e7b8f295
+    sha256: b72044c8657645a8a8f7a7e1b8f37b552080cd67df06ef1054e34831677ca66d
   manager: conda
   name: open_pdks.sky130a
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.422_0_gd9f6d38-20230709_210322.tar.bz2
-  version: 1.0.422_0_gd9f6d38
+  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.423_0_g1604945-20230709_210322.tar.bz2
+  version: 1.0.423_0_g1604945
 - category: main
   dependencies: {}
   hash:
@@ -693,16 +693,16 @@ package:
   version: 0.3.23
 - category: main
   dependencies:
-    libgcc-ng: '>=13.1.0'
+    libgcc-ng: '>=12.3.0'
   hash:
-    md5: 7594fd17fb4d1b8b0e47a6b306fe01ae
-    sha256: 49214f61c270400e4da89f00b6b24565dc59d1d8b869fa003a22aeacaeca3851
+    md5: bbc8fef17925480272a671b1d83431fa
+    sha256: 2fa38e53f7d58789283af351f014748a485ec8f4e7db3f150ed6274f50983663
   manager: conda
   name: libsanitizer
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.1.0-hfd8a6a1_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1209,21 +1209,21 @@ package:
 - category: main
   dependencies:
     binutils_impl_linux-64: '>=2.39'
-    libgcc-devel_linux-64: 13.1.0 he3cc6c4_0
-    libgcc-ng: '>=13.1.0'
-    libgomp: '>=13.1.0'
-    libsanitizer: 13.1.0 hfd8a6a1_0
-    libstdcxx-ng: '>=13.1.0'
+    libgcc-devel_linux-64: 12.3.0 h8bca6fd_0
+    libgcc-ng: '>=12.3.0'
+    libgomp: '>=12.3.0'
+    libsanitizer: 12.3.0 h0f45ef3_0
+    libstdcxx-ng: '>=12.3.0'
     sysroot_linux-64: ''
   hash:
-    md5: 99d1a8a8ee1665ee9435f8d160df69fe
-    sha256: d728da49acc79f2a46f9abe1f603fd4ccc9fc96f533b1647e3c836985caa5924
+    md5: 1e41f51d89695fd3f810e2245517460b
+    sha256: ccbbb82de1ca95b02477e4340c5791e49424b379c6caa27e89bae3c40b7ad296
   manager: conda
   name: gcc_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.1.0-hc4be1a9_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1661,16 +1661,16 @@ package:
   version: 1.0.9
 - category: main
   dependencies:
-    gcc_impl_linux-64: '>=13.1.0,<13.1.1.0a0'
+    gcc_impl_linux-64: '>=12.3.0,<12.3.1.0a0'
   hash:
-    md5: bf50acee3dbe6198ad304538eedd9413
-    sha256: a89b1750b88e5b2d3f3326a1755267dcd20ee1998cef9e961dde1d67890c584c
+    md5: 203fbb799caffdf242ccef5f9879d3a1
+    sha256: b9db23cd4fd2df43c06734b3cdb7491e03472679282a058bca7148455704b6a4
   manager: conda
   name: conda-gcc-specs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-13.1.0-h0612280_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-12.3.0-h83fac38_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=7.5.0'
@@ -1714,16 +1714,16 @@ package:
   version: 2.12.1
 - category: main
   dependencies:
-    gcc_impl_linux-64: 13.1.0.*
+    gcc_impl_linux-64: 12.3.0.*
   hash:
-    md5: 847c6849a2a4ca12e907c17872694d23
-    sha256: b6ee942b1d9b30c2d6eda2a2c36ba05f26a4a8a625d8aa27d5fbaa13045399ab
+    md5: 8da41232e71a99e3ff1cc43350d0f0fb
+    sha256: 1cd58fecd56680f8e8eda18fa3d557231b7016cd3de50c73a0ce8b79303d37b9
   manager: conda
   name: gcc
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-13.1.0-h8e92de4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -1743,18 +1743,18 @@ package:
   version: 3.7.8
 - category: main
   dependencies:
-    gcc_impl_linux-64: 13.1.0 hc4be1a9_0
-    libstdcxx-devel_linux-64: 13.1.0 he3cc6c4_0
+    gcc_impl_linux-64: 12.3.0 he2b93b0_0
+    libstdcxx-devel_linux-64: 12.3.0 h8bca6fd_0
     sysroot_linux-64: ''
   hash:
-    md5: e6591b3c81fc5fb83e342b20a2506e80
-    sha256: a2e154839f057a4fc540c038de13db3c562bccf361a06ed5072e1c74691c4062
+    md5: 3f00aa0a8f8d3924890fecae937cc6bd
+    sha256: 87c7ec85f76aa065c2c991acd7bbf86d25b4724bc283f793400c14f5d5e39aa0
   manager: conda
   name: gxx_impl_linux-64
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-13.1.0-hc4be1a9_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     keyutils: '>=1.6.1,<2.0a0'
@@ -2346,17 +2346,17 @@ package:
   version: 0.7.6
 - category: main
   dependencies:
-    gcc: 13.1.0.*
-    gxx_impl_linux-64: 13.1.0.*
+    gcc: 12.3.0.*
+    gxx_impl_linux-64: 12.3.0.*
   hash:
-    md5: 5592c3280d50f5dc8dc548ba98c6e9ba
-    sha256: 3c99a6df3f0cac1b8730fea9cc32fab07475b1b8a9b1e7a10d3951bdf29a415f
+    md5: c6f5830abf6e0849e32eeaa8feb6af2e
+    sha256: e6734338ae19b90956532cbab5792e57ec0885fd1e36ab95fe0d1f6e5b5959e4
   manager: conda
   name: gxx
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-13.1.0-h8e92de4_0.conda
-  version: 13.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_0.conda
+  version: 12.3.0
 - category: main
   dependencies:
     python: '>=3.10,<3.11.0a0'
@@ -2888,14 +2888,14 @@ package:
   dependencies:
     python: '>=3.6'
   hash:
-    md5: d3ed087d1f7f8f5590e8e87b57a8ce64
-    sha256: 18e3bd52c64f23bbc7c200fd2fc4152dd29423936dc43e8f129cb43f1af0136c
+    md5: e8fbc1b54b25f4b08281467bc13b70cc
+    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
   manager: conda
   name: pyparsing
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.0-pyhd8ed1ab_0.conda
-  version: 3.1.0
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+  version: 3.0.9
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -3698,14 +3698,14 @@ package:
     more-itertools: ''
     python: '>=3.7'
   hash:
-    md5: 31e4a1506968d017229bdb64695013a1
-    sha256: 6a81b67a1de8f761f66a4540bbd07cc27f9fbf2c7d67aa3732ebef379cf62874
+    md5: e9f79248d30e942f7c358ff21a1790f5
+    sha256: 14f5240c3834e1b784dd41a5a14392d9150dff62a74ae851f73e65d2e2bbd891
   manager: conda
   name: jaraco.classes
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.2.3-pyhd8ed1ab_0.tar.bz2
-  version: 3.2.3
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.0-pyhd8ed1ab_0.conda
+  version: 3.3.0
 - category: main
   dependencies:
     markupsafe: '>=2.0'
@@ -4264,20 +4264,20 @@ package:
     numpy: '>=1.21.6,<2.0a0'
     packaging: '>=20.0'
     pillow: '>=6.2.0'
-    pyparsing: '>=2.3.1'
+    pyparsing: '>=2.3.1,<3.1'
     python: '>=3.10,<3.11.0a0'
     python-dateutil: '>=2.7'
     python_abi: 3.10.* *_cp310
     tk: '>=8.6.12,<8.7.0a0'
   hash:
-    md5: 68b2dd34c69d08b05a9db5e3596fe3ee
-    sha256: d2be8ac0a90aa12ba808f8777d1837b5aa983fc3c7c60c600e8fe6bd9352541c
+    md5: 9b55c9041c5a7f80f184a2cb05ec9663
+    sha256: 28ff078d33e18b52a455d58d24ab7b959b4db98411470afd5869f30fbb54250b
   manager: conda
   name: matplotlib-base
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.7.1-py310he60537e_0.conda
-  version: 3.7.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.7.2-py310hf38f957_0.conda
+  version: 3.7.2
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -4898,14 +4898,14 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     urllib3: '>=1.25.4,<1.27'
   hash:
-    md5: 0edc7c1cfd7921df59c922f2b734ff1c
-    sha256: 232a3ad207515d492274b004bf59bacc7254893086ac0d72fe0108cea2834dbf
+    md5: 191ea267121cccd3531e98ea5b869b87
+    sha256: 3172c3714a3c6abc729af5335dfbf2ac02acc01ec64ad1d30413bd49f1bd0497
   manager: conda
   name: botocore
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.1-pyhd8ed1ab_0.conda
-  version: 1.31.1
+  url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.31.2-pyhd8ed1ab_0.conda
+  version: 1.31.2
 - category: main
   dependencies:
     cairo: '>=1.16.0,<2.0a0'
@@ -4973,14 +4973,14 @@ package:
     six: '>=1.11.0'
     typing-extensions: '>=4.0.1'
   hash:
-    md5: 5576496c2743cafa05111ac76267db29
-    sha256: 51951b49a43b7de818ad055d113348f7e438e225fc7a5f8f4c635998239c4c89
+    md5: 3f61696f5c09ca1e7001d042c9968c1d
+    sha256: da22c5d95a9ed937509b696568cd51580f3becec90febf0e5b1aca1096bf4c24
   manager: conda
   name: azure-core
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.27.1-pyhd8ed1ab_0.conda
-  version: 1.27.1
+  url: https://conda.anaconda.org/conda-forge/noarch/azure-core-1.28.0-pyhd8ed1ab_0.conda
+  version: 1.28.0
 - category: main
   dependencies:
     msgpack-python: '>=0.5.2'
@@ -5140,7 +5140,7 @@ package:
   version: 5.1.1
 - category: main
   dependencies:
-    botocore: 1.31.1
+    botocore: 1.31.2
     colorama: '>=0.2.5,<0.4.5'
     docutils: '>=0.10,<0.17'
     python: '>=3.10,<3.11.0a0'
@@ -5149,29 +5149,29 @@ package:
     rsa: '>=3.1.2,<4.8'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 97290e3028c5cdc775e55873dc8e3f03
-    sha256: 8715e45be127be2e25d872137ba27fc27673f354baae2a55c9060bfce701ad57
+    md5: 090abd0e0146575f4a7b5c6cbb71e866
+    sha256: 2b66dc496eae7517bcf85b8ef54bf5512bc4ca7b710fd710b30d22b68ec4477d
   manager: conda
   name: awscli
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.29.1-py310hff52083_0.conda
-  version: 1.29.1
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-1.29.2-py310hff52083_0.conda
+  version: 1.29.2
 - category: main
   dependencies:
-    botocore: '>=1.31.1,<1.32.0'
+    botocore: '>=1.31.2,<1.32.0'
     jmespath: '>=0.7.1,<2.0.0'
     python: '>=3.7'
     s3transfer: '>=0.6.0,<0.7.0'
   hash:
-    md5: 3a0123e890ea210f6468121bdfa6cfc0
-    sha256: 4fea48dc33349ea59efe4f8ddb6c4ec2fbec24c49a7482263893498bc6e506ca
+    md5: 1ebffec127102119aff7a572243464da
+    sha256: 454975a1def5ec1043925403547f9cf938c91a534c62cba509eb108b253bbf89
   manager: conda
   name: boto3
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.28.1-pyhd8ed1ab_0.conda
-  version: 1.28.1
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.28.2-pyhd8ed1ab_0.conda
+  version: 1.28.2
 - category: main
   dependencies:
     cachecontrol: 0.13.0 pyhd8ed1ab_0
@@ -5297,14 +5297,14 @@ package:
     python: ''
     typing_extensions: ''
   hash:
-    md5: e07be93e70ff9affb934ff017a86c722
-    sha256: c3a63fce78c2b080803b2a40cc3f5fe9e5ade617efe278cf09b6b89c8f0ea232
+    md5: 31349469d53ac0877f3a90842023571d
+    sha256: feb48351ca5a328d200a7307d041b05f5d1e476151929951e1a11a1ecede8d4e
   manager: conda
   name: boto3-stubs
   optional: false
   platform: linux-64
-  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.28.1-pyhd8ed1ab_0.conda
-  version: 1.28.1
+  url: https://conda.anaconda.org/conda-forge/noarch/boto3-stubs-1.28.2-pyhd8ed1ab_0.conda
+  version: 1.28.2
 - category: main
   dependencies:
     cachecontrol-with-filecache: '>=0.12.9'

--- a/docs/Chipyard-Basics/Initial-Repo-Setup.rst
+++ b/docs/Chipyard-Basics/Initial-Repo-Setup.rst
@@ -34,6 +34,13 @@ After Conda is installed and is on your ``PATH``, we need to install a version o
 For this you can use the system package manager like ``yum`` or ``apt`` to install ``git``.
 This ``git`` is only used to first checkout the repository, we will later install a newer version of ``git`` with Conda.
 
+Next, we install `libmamba <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`__ for much faster dependency solving when initially setting up the repository.
+
+.. code-block:: shell
+
+    conda install -n base conda-libmamba-solver
+    conda config --set solver libmamba
+
 Finally we need to install ``conda-lock`` into the ``base`` conda environment.
 This is done by the following:
 
@@ -42,7 +49,6 @@ This is done by the following:
     conda install -n base conda-lock=1.4
     conda activate base
 
-.. Note:: We also recommended switching to `libmamba <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`__ for much faster dependency solving.
 
 Setting up the Chipyard Repo
 -------------------------------------------

--- a/scripts/build-setup.sh
+++ b/scripts/build-setup.sh
@@ -123,7 +123,7 @@ if run_step "1"; then
     fi
 
     # use conda-lock to create env
-    conda-lock install -p $CYDIR/.conda-env $LOCKFILE
+    conda-lock install --conda $(which conda) -p $CYDIR/.conda-env $LOCKFILE
 
     source $CYDIR/.conda-env/etc/profile.d/conda.sh
     conda activate $CYDIR/.conda-env

--- a/scripts/generate-conda-lockfiles.sh
+++ b/scripts/generate-conda-lockfiles.sh
@@ -14,5 +14,5 @@ for TOOLCHAIN_TYPE in riscv-tools esp-tools; do
     # note: lock file must end in .conda-lock.yml - see https://github.com/conda-incubator/conda-lock/issues/154
     LOCKFILE=$REQS_DIR/conda-lock-reqs/conda-requirements-$TOOLCHAIN_TYPE-linux-64.conda-lock.yml
 
-    conda-lock -f "$REQS_DIR/chipyard.yaml" -f "$REQS_DIR/$TOOLCHAIN_TYPE.yaml" -p linux-64 --lockfile $LOCKFILE
+    conda-lock --conda $(which conda) -f "$REQS_DIR/chipyard.yaml" -f "$REQS_DIR/$TOOLCHAIN_TYPE.yaml" -p linux-64 --lockfile $LOCKFILE
 done


### PR DESCRIPTION
Testing the following theory:

`conda-lock` under the hood uses `conda` to solve some extra dependencies that are machine-specific in addition to the pre-computed lockfile dependencies. When it does this it uses a non-optimized version (i.e. without libmamba solver) of `conda` which is very slow for many dependencies. This PR forces `conda-lock` to use the `conda` that the user has installed (by doing `which conda` and passing that).

This also bumps the lockfiles, makes the default instructions include installing `libmamba`, and uses the most recent conda version in CI.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [x] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [x] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] (If applicable) Did you mark the PR as `Please Backport`?
