### PR TITLE
Fix FIFO-fixing for PRCI bus

### DIFF
--- a/generators/chipyard/src/main/scala/clocking/ClockBinders.scala
+++ b/generators/chipyard/src/main/scala/clocking/ClockBinders.scala
@@ -38,9 +38,9 @@ class WithPLLSelectorDividerClockGenerator extends OverrideLazyIOBinder({
     val clockSelector = system.prci_ctrl_domain { LazyModule(new TLClockSelector(baseAddress + 0x30000, tlbus.beatBytes)) }
     val pllCtrl       = system.prci_ctrl_domain { LazyModule(new FakePLLCtrl    (baseAddress + 0x40000, tlbus.beatBytes)) }
 
-    clockDivider.tlNode  := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get
-    clockSelector.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get
-    pllCtrl.tlNode       := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get
+    clockDivider.tlNode  := system.prci_ctrl_domain { TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get }
+    clockSelector.tlNode := system.prci_ctrl_domain { TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get }
+    pllCtrl.tlNode       := system.prci_ctrl_domain { TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get }
 
     system.allClockGroupsNode := clockDivider.clockNode := clockSelector.clockNode
 

--- a/generators/chipyard/src/main/scala/clocking/ClockBinders.scala
+++ b/generators/chipyard/src/main/scala/clocking/ClockBinders.scala
@@ -38,9 +38,9 @@ class WithPLLSelectorDividerClockGenerator extends OverrideLazyIOBinder({
     val clockSelector = system.prci_ctrl_domain { LazyModule(new TLClockSelector(baseAddress + 0x30000, tlbus.beatBytes)) }
     val pllCtrl       = system.prci_ctrl_domain { LazyModule(new FakePLLCtrl    (baseAddress + 0x40000, tlbus.beatBytes)) }
 
-    clockDivider.tlNode  := system.prci_ctrl_bus.get
-    clockSelector.tlNode := system.prci_ctrl_bus.get
-    pllCtrl.tlNode       := system.prci_ctrl_bus.get
+    clockDivider.tlNode  := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get
+    clockSelector.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get
+    pllCtrl.tlNode       := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := system.prci_ctrl_bus.get
 
     system.allClockGroupsNode := clockDivider.clockNode := clockSelector.clockNode
 

--- a/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
+++ b/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
@@ -42,7 +42,6 @@ trait HasChipyardPRCI { this: BaseSubsystem with InstantiatesTiles =>
   val prci_ctrl_bus = Option.when(prciParams.generatePRCIXBar) { prci_ctrl_domain { TLXbar() } }
   prci_ctrl_bus.foreach(xbar => tlbus.coupleTo("prci_ctrl") { (xbar
     := TLFIFOFixer(TLFIFOFixer.all)
-    := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes)
     := TLBuffer()
     := _)
   })
@@ -87,13 +86,13 @@ trait HasChipyardPRCI { this: BaseSubsystem with InstantiatesTiles =>
   }
   val tileClockGater     = Option.when(prciParams.enableTileClockGating) { prci_ctrl_domain {
     val clock_gater = LazyModule(new TileClockGater(prciParams.baseAddress + 0x00000, tlbus.beatBytes))
-    clock_gater.tlNode := prci_ctrl_bus.get
+    clock_gater.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := prci_ctrl_bus.get
     clock_gater
   } }
   val tileResetSetter    = Option.when(prciParams.enableTileResetSetting) { prci_ctrl_domain {
     val reset_setter = LazyModule(new TileResetSetter(prciParams.baseAddress + 0x10000, tlbus.beatBytes,
       tile_prci_domains.map(_.tile_reset_domain.clockNode.portParams(0).name.get), Nil))
-    reset_setter.tlNode := prci_ctrl_bus.get
+    reset_setter.tlNode := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := prci_ctrl_bus.get
     reset_setter
   } }
 


### PR DESCRIPTION
Fragmenter infront of FIFO-fixer needs to track way too many source-Ids

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
