### PR TITLE
Fix icenet-loopback clock and reset domain

### DIFF
--- a/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
@@ -106,7 +106,7 @@ class WithBlockDeviceModel extends OverrideHarnessBinder({
 class WithLoopbackNIC extends OverrideHarnessBinder({
   (system: CanHavePeripheryIceNIC, th: HasHarnessInstantiators, ports: Seq[ClockedIO[NICIOvonly]]) => {
     implicit val p: Parameters = GetSystemParameters(system)
-    ports.map { n => NicLoopback.connect(Some(n.bits), p(NICKey)) }
+    ports.map { n => NicLoopback.connect(Some(n.bits), p(NICKey), n.clock, th.harnessBinderReset.asBool) }
   }
 })
 

--- a/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
@@ -106,7 +106,11 @@ class WithBlockDeviceModel extends OverrideHarnessBinder({
 class WithLoopbackNIC extends OverrideHarnessBinder({
   (system: CanHavePeripheryIceNIC, th: HasHarnessInstantiators, ports: Seq[ClockedIO[NICIOvonly]]) => {
     implicit val p: Parameters = GetSystemParameters(system)
-    ports.map { n => NicLoopback.connect(Some(n.bits), p(NICKey), n.clock, th.harnessBinderReset.asBool) }
+    ports.map { n =>
+      withClockAndReset(n.clock, th.harnessBinderReset.asBool) {
+        NicLoopback.connect(Some(n.bits), p(NICKey))
+      }
+    }
   }
 })
 


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

`Pipe` in https://github.com/firesim/icenet/blob/bbce029e3d3e4b11578f380ad48012fc49247d60/src/main/scala/NIC.scala#L603 is set on a different clock & reset domain than external ports of the NIC, causing the `nic-loopback` test to fail.

This PR fixes this by explicitly setting the clock & reset domain in the testharness for NIC loopbacks.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->
Related PR
- https://github.com/firesim/icenet/pull/40

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
