### PR TITLE
[vlsi][ci skip] Fix tutorial.mk so that INPUT_CONFS override only affects tutorials

### DIFF
--- a/vlsi/tutorial.mk
+++ b/vlsi/tutorial.mk
@@ -12,6 +12,7 @@ ifeq ($(tutorial),asap7)
     TECH_CONF         ?= example-asap7.yml
     DESIGN_CONFS      ?=
     VLSI_OBJ_DIR      ?= build-asap7-commercial
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
 endif
 
 ifeq ($(tutorial),sky130-commercial)
@@ -23,6 +24,7 @@ ifeq ($(tutorial),sky130-commercial)
                         $(if $(filter $(VLSI_TOP),Rocket), \
                             example-designs/sky130-rocket.yml, )
     VLSI_OBJ_DIR      ?= build-sky130-commercial
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
 endif
 
 ifeq ($(tutorial),sky130-openroad)
@@ -36,8 +38,8 @@ ifeq ($(tutorial),sky130-openroad)
                         $(if $(filter $(VLSI_TOP),RocketTile), \
                             example-designs/sky130-openroad-rockettile.yml, )
     VLSI_OBJ_DIR      ?= build-sky130-openroad
+    INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)
     # Yosys compatibility for CIRCT-generated Verilog, at the expense of elaboration time.
     ENABLE_YOSYS_FLOW  = 1
 endif
 
-INPUT_CONFS       ?= $(TOOLS_CONF) $(TECH_CONF) $(DESIGN_CONFS) $(EXTRA_CONFS)


### PR DESCRIPTION
Previously, this unintuitively overrode the `INPUT_CONFS` in `vlsi/Makefile` in all cases.

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
