### PR TITLE
Fix regex for similar module names that are uniquified

### DIFF
--- a/scripts/uniquify-module-names.py
+++ b/scripts/uniquify-module-names.py
@@ -109,7 +109,7 @@ def generate_copy(c, sfx):
   new_file = os.path.join(args.gcpath, new_file)
 
   shutil.copy(cur_file, new_file)
- bash(f"sed -i 's/module\( \+\){cur_name}/module\\1{new_name}/' {new_file}")
+  bash(f"sed -i 's/module\( \+\){cur_name}/module\\1{new_name}/' {new_file}")
   return new_file
 
 def bfs_uniquify_modules(tree, common_fnames, verilog_module_filename):

--- a/scripts/uniquify-module-names.py
+++ b/scripts/uniquify-module-names.py
@@ -109,7 +109,7 @@ def generate_copy(c, sfx):
   new_file = os.path.join(args.gcpath, new_file)
 
   shutil.copy(cur_file, new_file)
-  bash(f"sed -i s/\"module {cur_name}\"/\"module {new_name}\"/ {new_file}")
+ bash(f"sed -i 's/module\( \+\){cur_name}/module\\1{new_name}/' {new_file}")
   return new_file
 
 def bfs_uniquify_modules(tree, common_fnames, verilog_module_filename):
@@ -136,7 +136,7 @@ def bfs_uniquify_modules(tree, common_fnames, verilog_module_filename):
         new_file = generate_copy(cur_file, MODEL_SFX)
         if parent is not None and ((parent, mod) not in updated_submodule):
           parent_file = os.path.join(args.gcpath, verilog_module_filename[parent])
-          bash(f"sed -i s/\"{mod} \"/\"{mod}_{MODEL_SFX} \"/ {parent_file}")
+          bash(f"sed -i 's/\( \*\){mod}\( \+\)/\\1{mod}_{MODEL_SFX}\\2/' {parent_file}")
           updated_submodule.add((parent, mod))
 
         # add the uniquified module to the verilog_modul_filename dict


### PR DESCRIPTION
When there is a module that is uniquified between the model and top, the regex in this file will improperly over-rename things. Ex: `MemLoader` is renamed to `MemLoader_UNIQUE`... however `ReverseMemLoader` would also be renamed. This PR fixes this issue by fixing the regex and adding more capture groups to properly capture spaces.

Fixes #1624 

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
