### PR TITLE
Add Caliptra AES256 ECB engine as RoCC accelerator

### DIFF
--- a/.github/scripts/check-commit.sh
+++ b/.github/scripts/check-commit.sh
@@ -45,7 +45,7 @@ search () {
     done
 }
 
-submodules=("cva6" "boom" "ibex" "gemmini" "hwacha" "icenet" "nvdla" "rocket-chip" "sha3" "sifive-blocks" "sifive-cache" "testchipip" "riscv-sodor" "mempress" "bar-fetchers" "shuttle")
+submodules=("cva6" "boom" "ibex" "gemmini" "hwacha" "icenet" "nvdla" "rocket-chip" "sha3" "sifive-blocks" "sifive-cache" "testchipip" "riscv-sodor" "mempress" "bar-fetchers" "shuttle" "caliptra-aes-acc" "rocc-acc-utils")
 dir="generators"
 branches=("master" "main" "dev")
 search

--- a/.github/scripts/defaults.sh
+++ b/.github/scripts/defaults.sh
@@ -30,7 +30,7 @@ REMOTE_COURSIER_CACHE=$REMOTE_WORK_DIR/.coursier-cache
 declare -A grouping
 grouping["group-cores"]="chipyard-cva6 chipyard-ibex chipyard-rocket chipyard-hetero chipyard-boom chipyard-sodor chipyard-digitaltop chipyard-multiclock-rocket chipyard-nomem-scratchpad chipyard-spike chipyard-clone chipyard-prefetchers chipyard-shuttle"
 grouping["group-peripherals"]="chipyard-dmirocket chipyard-dmiboom chipyard-spiflashwrite chipyard-mmios chipyard-nocores chipyard-manyperipherals chipyard-chiplike chipyard-tethered"
-grouping["group-accels"]="chipyard-mempress chipyard-sha3 chipyard-hwacha chipyard-gemmini chipyard-manymmioaccels chipyard-nvdla"
+grouping["group-accels"]="chipyard-mempress chipyard-sha3 chipyard-hwacha chipyard-gemmini chipyard-manymmioaccels chipyard-nvdla chipyard-aes256ecb"
 grouping["group-constellation"]="chipyard-constellation"
 grouping["group-tracegen"]="tracegen tracegen-boom"
 grouping["group-other"]="icenet testchipip constellation rocketchip-amba rocketchip-tlsimple rocketchip-tlwidth rocketchip-tlxbar"
@@ -67,6 +67,7 @@ mapping["chipyard-shuttle"]=" CONFIG=ShuttleConfig"
 mapping["chipyard-multiclock-rocket"]=" CONFIG=MulticlockRocketConfig"
 mapping["chipyard-nomem-scratchpad"]=" CONFIG=MMIOScratchpadOnlyRocketConfig"
 mapping["chipyard-constellation"]=" CONFIG=SharedNoCConfig"
+mapping["chipyard-aes256ecb"]=" CONFIG=AES256ECBRocketConfig verilog"
 
 mapping["constellation"]=" SUB_PROJECT=constellation"
 mapping["firesim"]="SCALA_TEST=firesim.firesim.RocketNICF1Tests"

--- a/.github/scripts/defaults.sh
+++ b/.github/scripts/defaults.sh
@@ -67,7 +67,7 @@ mapping["chipyard-shuttle"]=" CONFIG=ShuttleConfig"
 mapping["chipyard-multiclock-rocket"]=" CONFIG=MulticlockRocketConfig"
 mapping["chipyard-nomem-scratchpad"]=" CONFIG=MMIOScratchpadOnlyRocketConfig"
 mapping["chipyard-constellation"]=" CONFIG=SharedNoCConfig"
-mapping["chipyard-aes256ecb"]=" CONFIG=AES256ECBRocketConfig verilog"
+mapping["chipyard-aes256ecb"]=" CONFIG=AES256ECBRocketConfig"
 
 mapping["constellation"]=" SUB_PROJECT=constellation"
 mapping["firesim"]="SCALA_TEST=firesim.firesim.RocketNICF1Tests"

--- a/.gitmodules
+++ b/.gitmodules
@@ -133,3 +133,9 @@
 [submodule "generators/hardfloat"]
 	path = generators/hardfloat
 	url = https://github.com/ucb-bar/berkeley-hardfloat.git
+[submodule "generators/caliptra-aes-acc"]
+	path = generators/caliptra-aes-acc
+	url = https://github.com/ucb-bar/caliptra-aes-acc
+[submodule "generators/rocc-acc-utils"]
+	path = generators/rocc-acc-utils
+	url = https://github.com/ucb-bar/rocc-acc-utils

--- a/build.sbt
+++ b/build.sbt
@@ -235,11 +235,11 @@ lazy val nvdla = (project in file("generators/nvdla"))
   .settings(commonSettings)
 
 lazy val caliptra_aes = (project in file("generators/caliptra-aes-acc"))
-  .dependsOn(rocketchip, rocc_acc_utils, midasTargetUtils)
+  .dependsOn(rocketchip, rocc_acc_utils, testchipip, midasTargetUtils)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)
 
-llazy val rocc_acc_utils = (project in file("generators/rocc-acc-utils"))
+lazy val rocc_acc_utils = (project in file("generators/rocc-acc-utils"))
   .dependsOn(rocketchip)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ lazy val chipyard = (project in file("generators/chipyard"))
     sha3, // On separate line to allow for cleaner tutorial-setup patches
     dsptools, rocket_dsp_utils,
     gemmini, icenet, tracegen, cva6, nvdla, sodor, ibex, fft_generator,
-    constellation, mempress, barf, shuttle)
+    constellation, mempress, barf, shuttle, caliptra_aes)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(
     libraryDependencies ++= Seq(
@@ -230,6 +230,16 @@ lazy val gemmini = (project in file("generators/gemmini"))
   .settings(commonSettings)
 
 lazy val nvdla = (project in file("generators/nvdla"))
+  .dependsOn(rocketchip)
+  .settings(libraryDependencies ++= rocketLibDeps.value)
+  .settings(commonSettings)
+
+lazy val caliptra_aes = (project in file("generators/caliptra-aes-acc"))
+  .dependsOn(rocketchip, rocc-acc-utils, midasTargetUtils)
+  .settings(libraryDependencies ++= rocketLibDeps.value)
+  .settings(commonSettings)
+
+llazy val rocc_acc_utils = (project in file("generators/rocc-acc-utils"))
   .dependsOn(rocketchip)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,7 @@ lazy val nvdla = (project in file("generators/nvdla"))
   .settings(commonSettings)
 
 lazy val caliptra_aes = (project in file("generators/caliptra-aes-acc"))
-  .dependsOn(rocketchip, rocc-acc-utils, midasTargetUtils)
+  .dependsOn(rocketchip, rocc_acc_utils, midasTargetUtils)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)
 

--- a/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
@@ -56,3 +56,9 @@ class HwachaLargeBoomConfig extends Config(
   new boom.common.WithNLargeBooms(1) ++
   new chipyard.config.WithSystemBusWidth(128) ++
   new chipyard.config.AbstractConfig)
+
+class AES256ECBRocketConfig extends Config(
+  new aes.WithAES256ECBAccel ++                                   // use Caliptra AES 256 ECB accelerator
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
@@ -60,5 +60,5 @@ class HwachaLargeBoomConfig extends Config(
 class AES256ECBRocketConfig extends Config(
   new aes.WithAES256ECBAccel ++                                   // use Caliptra AES 256 ECB accelerator
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
-  new chipyard.config.WithSystemBusWidth(128) ++
+  new chipyard.config.WithSystemBusWidth(256) ++
   new chipyard.config.AbstractConfig)

--- a/scripts/insert-includes.py
+++ b/scripts/insert-includes.py
@@ -12,6 +12,8 @@
 import sys
 import re
 import os
+import tempfile
+import shutil
 
 inVlog = sys.argv[1]
 outVlog = sys.argv[2]
@@ -24,28 +26,52 @@ if inVlog == outVlog:
 incDirs = sys.argv[3:]
 print("[INFO] Searching following dirs for includes: " + str(incDirs))
 
-# open file
-with open(inVlog, 'r') as inFile:
-    with open(outVlog, 'w') as outFile:
-        # for each include found, search through all dirs and replace if found, error if not
-        for num, line in enumerate(inFile, 1):
+def process(inF, outF):
+    # open file
+    with open(inF, 'r') as inFile:
+        with open(outF, 'w') as outFile:
+            # for each include found, search through all dirs and replace if found, error if not
+            for num, line in enumerate(inFile, 1):
+                match = re.match(r"^ *`include +\"(.*)\"", line)
+                if match:
+                    # search for include and replace
+                    found = False
+                    for d in incDirs:
+                        potentialIncFileName = d + "/" + match.group(1)
+                        if os.path.exists(potentialIncFileName):
+                            found = True
+                            with open(potentialIncFileName, 'r') as incFile:
+                                for iline in incFile:
+                                    outFile.write(iline)
+                            break
+
+                    # must find something to include with
+                    if not found:
+                        sys.exit("[ERROR] Couldn't replace include \"" + str(match.group(1)) + "\" found on line " + str(num))
+                else:
+                    outFile.write(line)
+
+inF = inVlog
+
+while True:
+    # create a copy of the input
+    fd, temp_path = tempfile.mkstemp()
+    shutil.copy2(inF, temp_path)
+
+    with open(temp_path, 'r') as inFile:
+        anyIncludes = False
+        for line in inFile:
             match = re.match(r"^ *`include +\"(.*)\"", line)
             if match:
-                # search for include and replace
-                found = False
-                for d in incDirs:
-                    potentialIncFileName = d + "/" + match.group(1)
-                    if os.path.exists(potentialIncFileName):
-                        found = True
-                        with open(potentialIncFileName, 'r') as incFile:
-                            for iline in incFile:
-                                outFile.write(iline)
-                        break
+                anyIncludes = True
+                break
 
-                # must find something to include with
-                if not found:
-                    sys.exit("[ERROR] Couldn't replace include \"" + str(match.group(1)) + "\" found on line " + str(num))
-            else:
-                outFile.write(line)
+        if anyIncludes:
+            process(temp_path, outVlog)
+            inF = outVlog
+            os.remove(temp_path)
+        else:
+            os.remove(temp_path)
+            break
 
 print("[INFO] Success. Writing output to: " + str(outVlog))

--- a/scripts/tutorial-patches/build.sbt.patch
+++ b/scripts/tutorial-patches/build.sbt.patch
@@ -1,20 +1,20 @@
 diff --git a/build.sbt b/build.sbt
-index 302d99e6..0aa0fcb4 100644
+index c3be6161..2a6d7160 100644
 --- a/build.sbt
 +++ b/build.sbt
-@@ -148,7 +148,7 @@ lazy val testchipip = (project in file("generators/testchipip"))
-
+@@ -147,7 +147,7 @@ lazy val testchipip = (project in file("generators/testchipip"))
+ 
  lazy val chipyard = (project in file("generators/chipyard"))
    .dependsOn(testchipip, rocketchip, boom, hwacha, sifive_blocks, sifive_cache, iocell,
 -    sha3, // On separate line to allow for cleaner tutorial-setup patches
 +    //sha3, // On separate line to allow for cleaner tutorial-setup patches
      dsptools, rocket_dsp_utils,
      gemmini, icenet, tracegen, cva6, nvdla, sodor, ibex, fft_generator,
-     constellation, mempress, barf, shuttle)
-@@ -220,10 +220,10 @@ lazy val sodor = (project in file("generators/riscv-sodor"))
+     constellation, mempress, barf, shuttle, caliptra_aes)
+@@ -219,10 +219,10 @@ lazy val sodor = (project in file("generators/riscv-sodor"))
    .settings(libraryDependencies ++= rocketLibDeps.value)
    .settings(commonSettings)
-
+ 
 -lazy val sha3 = (project in file("generators/sha3"))
 -  .dependsOn(rocketchip, midasTargetUtils)
 -  .settings(libraryDependencies ++= rocketLibDeps.value)
@@ -23,6 +23,6 @@ index 302d99e6..0aa0fcb4 100644
 +//   .dependsOn(rocketchip, midasTargetUtils)
 +//   .settings(libraryDependencies ++= rocketLibDeps.value)
 +//   .settings(commonSettings)
-
+ 
  lazy val gemmini = (project in file("generators/gemmini"))
    .dependsOn(rocketchip)


### PR DESCRIPTION
Adds https://github.com/chipsalliance/Caliptra 's AES 256 ECB cryptography core as a RoCC accelerator. Also adds a repo to help users create RoCC memory streaming accelerators (i.e. extend the classes/traits to quickly create a streaming accel). 

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [x] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [x] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [x] (If applicable) Did you mark the PR as `Please Backport`?
