### PR TITLE
Update to use the new CI machines

### DIFF
--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -65,7 +65,7 @@ jobs:
     name: setup-repo
     needs: [change-filters, cancel-prior-workflows]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: jktqos
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -88,7 +88,7 @@ jobs:
   run-cfg-finder:
     name: run-cfg-finder
     needs: [setup-repo]
-    runs-on: jktqos
+    runs-on: as4
     steps:
       - name: Run config finder
         run: |
@@ -101,7 +101,7 @@ jobs:
   run-tutorial:
     name: run-tutorial
     needs: [setup-repo]
-    runs-on: jktqos
+    runs-on: as4
     steps:
       - name: Run smoke test
         run: |
@@ -170,7 +170,7 @@ jobs:
   cleanup:
     name: cleanup
     needs: [run-tutorial]
-    runs-on: jktqos
+    runs-on: as4
     if: ${{ always() }}
     steps:
       - name: Delete repo copy and conda env

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -62,32 +62,11 @@ jobs:
               - '**/.gitignore'
               - '.github/ISSUE_TEMPLATE/**'
 
-  create-conda-env-jktgz:
-    name: create-conda-env-jktgz
+  create-conda-env-as4:
+    name: create-conda-env-as4
     needs: [change-filters, cancel-prior-workflows]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: jktgz
-    steps:
-      - name: Delete old checkout
-        run: |
-            ls -alh .
-            rm -rf ${{ github.workspace }}/* || true
-            rm -rf ${{ github.workspace }}/.* || true
-            ls -alh .
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Git workaround
-        uses: ./.github/actions/git-workaround
-      - name: Cleanup conda
-        uses: ./.github/actions/cleanup-conda
-      - name: Create conda env
-        uses: ./.github/actions/create-conda-env
-
-  create-conda-env-jktqos:
-    name: create-conda-env-jktqos
-    needs: [change-filters, cancel-prior-workflows]
-    if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: jktqos
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -109,7 +88,7 @@ jobs:
   # When adding new prep jobs, please add them to `needs` below
   setup-complete:
     name: setup-complete
-    needs: [create-conda-env-jktgz, create-conda-env-jktqos]
+    needs: [create-conda-env-as4]
     runs-on: ubuntu-latest
     steps:
       - name: Set up complete
@@ -121,7 +100,7 @@ jobs:
     name: commit-on-master-check
     needs: [setup-complete]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -144,7 +123,7 @@ jobs:
     name: tutorial-setup-check
     needs: [setup-complete]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -166,7 +145,7 @@ jobs:
   documentation-check:
     name: documentation-check
     needs: [setup-complete]
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -192,7 +171,7 @@ jobs:
     name: build-extra-tests
     needs: [setup-complete]
     if: needs.change-filters.outputs.needs-rtl == 'true'
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -224,7 +203,7 @@ jobs:
   prepare-chipyard-cores:
     name: prepare-chipyard-cores
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -246,7 +225,7 @@ jobs:
   prepare-chipyard-constellation:
     name: prepare-chipyard-constellation
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -268,7 +247,7 @@ jobs:
   prepare-chipyard-peripherals:
     name: prepare-chipyard-peripherals
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -290,7 +269,7 @@ jobs:
   prepare-chipyard-accels:
     name: prepare-chipyard-accels
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -312,7 +291,7 @@ jobs:
   prepare-chipyard-tracegen:
     name: prepare-chipyard-tracegen
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -334,7 +313,7 @@ jobs:
   prepare-chipyard-other:
     name: prepare-chipyard-other
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -356,7 +335,7 @@ jobs:
   prepare-chipyard-fpga:
     name: prepare-chipyard-fpga
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -381,7 +360,7 @@ jobs:
   chipyard-spike-gemmini-run-tests:
     name: chipyard-spike-gemmini-run-tests
     needs: prepare-chipyard-accels # technically doesn't depend on RTL but should be after the build.sh for Gemmini
-    runs-on: jktqos
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -410,7 +389,7 @@ jobs:
   chipyard-rocket-run-tests:
     name: chipyard-rocket-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -433,7 +412,7 @@ jobs:
   chipyard-prefetchers-run-tests:
     name: chipyard-prefetchers-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -456,7 +435,7 @@ jobs:
   chipyard-hetero-run-tests:
     name: chipyard-hetero-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -479,7 +458,7 @@ jobs:
   chipyard-boom-run-tests:
     name: chipyard-boom-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -502,7 +481,7 @@ jobs:
   chipyard-shuttle-run-tests:
     name: chipyard-shuttle-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -525,7 +504,7 @@ jobs:
   chipyard-cva6-run-tests:
     name: chipyard-cva6-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -548,7 +527,7 @@ jobs:
   chipyard-ibex-run-tests:
     name: chipyard-ibex-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -571,7 +550,7 @@ jobs:
   chipyard-sodor-run-tests:
     name: chipyard-sodor-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -594,7 +573,7 @@ jobs:
   chipyard-spike-run-tests:
     name: chipyard-spike-run-tests
     needs: prepare-chipyard-cores
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -617,7 +596,7 @@ jobs:
   chipyard-dmirocket-run-tests:
     name: chipyard-dmirocket-run-tests
     needs: prepare-chipyard-peripherals
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -640,7 +619,7 @@ jobs:
   chipyard-dmiboom-run-tests:
     name: chipyard-dmiboom-run-tests
     needs: prepare-chipyard-peripherals
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -663,7 +642,7 @@ jobs:
   chipyard-spiflashwrite-run-tests:
     name: chipyard-spiflashwrite-run-tests
     needs: prepare-chipyard-peripherals
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -686,7 +665,7 @@ jobs:
   chipyard-manyperipherals-run-tests:
     name: chipyard-manyperipherals-run-tests
     needs: prepare-chipyard-peripherals
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -709,7 +688,7 @@ jobs:
   chipyard-tethered-run-tests:
     name: chipyard-tethered-run-tests
     needs: prepare-chipyard-peripherals
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -732,7 +711,7 @@ jobs:
   chipyard-sha3-run-tests:
     name: chipyard-sha3-run-tests
     needs: prepare-chipyard-accels
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -755,7 +734,7 @@ jobs:
   chipyard-gemmini-run-tests:
     name: chipyard-gemmini-run-tests
     needs: prepare-chipyard-accels
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -778,7 +757,7 @@ jobs:
   chipyard-manymmioaccels-run-tests:
     name: chipyard-manymmioaccels-run-tests
     needs: prepare-chipyard-accels
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -801,7 +780,7 @@ jobs:
   # chipyard-nvdla-run-tests:
   #   name: chipyard-nvdla-run-tests
   #   needs: prepare-chipyard-accels
-  #   runs-on: self-hosted
+  #   runs-on: as4
   #   steps:
   #     - name: Delete old checkout
   #       run: |
@@ -824,7 +803,7 @@ jobs:
   chipyard-mempress-run-tests:
     name: chipyard-mempress-run-tests
     needs: prepare-chipyard-accels
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -848,7 +827,7 @@ jobs:
   tracegen-boom-run-tests:
     name: tracegen-boom-run-tests
     needs: prepare-chipyard-tracegen
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -871,7 +850,7 @@ jobs:
   tracegen-run-tests:
     name: tracegen-run-tests
     needs: prepare-chipyard-tracegen
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -894,7 +873,7 @@ jobs:
   icenet-run-tests:
     name: icenet-run-tests
     needs: prepare-chipyard-other
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -917,7 +896,7 @@ jobs:
   testchipip-run-tests:
     name: testchipip-run-tests
     needs: prepare-chipyard-other
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -940,7 +919,7 @@ jobs:
   rocketchip-run-tests:
     name: rocketchip-run-tests
     needs: prepare-chipyard-other
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -979,7 +958,7 @@ jobs:
   constellation-run-tests:
     name: constellation-run-tests
     needs: prepare-chipyard-other
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -1002,7 +981,7 @@ jobs:
   chipyard-constellation-run-tests:
     name: chipyard-constellation-run-tests
     needs: prepare-chipyard-constellation
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -1026,7 +1005,7 @@ jobs:
   firesim-run-tests:
     name: firesim-run-tests
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |
@@ -1050,7 +1029,7 @@ jobs:
   fireboom-run-tests:
     name: fireboom-run-tests
     needs: setup-complete
-    runs-on: self-hosted
+    runs-on: as4
     steps:
       - name: Delete old checkout
         run: |


### PR DESCRIPTION
Updates the CI labels to use the new CI machine (`as4`). There are 8 runners on that single machine instead of 12 spread over 2.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
