### PR TITLE
Fix IO direction for host Serial-TL port

### DIFF
--- a/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
+++ b/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
@@ -355,7 +355,7 @@ class WithSerialTLPunchthrough extends OverrideIOBinder({
   (system: CanHavePeripheryTLSerial) => {
     val (ports, cells) = system.serial_tl.zipWithIndex.map({ case (s, id) =>
       val sys = system.asInstanceOf[BaseSubsystem]
-      val port = IO(s.getWrappedValue.cloneType)
+      val port = IO(chiselTypeOf(s.getWrappedValue))
       port <> s.getWrappedValue
       (SerialTLPort(port, sys.p(SerialTLKey).get, system.serdesser.get, id), Nil)
     }).unzip


### PR DESCRIPTION
`cloneType` is a Chisel-internal method; use `chiselTypeOf` to construct an IO of the same type and direction.

`cloneType` appears to strip the `Flipped` modifier from types, so attempting to instantiate a bringup host config with a serial-TL clock driven by the DUT results in a connection failure during elaboration since both the ChipTop IO and the DigitalTop port are drivers.

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
