### PR TITLE
Always generate MFC Blackbox filelist

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -261,6 +261,7 @@ $(SFC_MFC_TARGETS) &: $(TAPEOUT_CLASSPATH_TARGETS) $(FIRRTL_FILE) $(FINAL_ANNO_F
 		$(SFC_FIRRTL_FILE)
 	-mv $(SFC_SMEMS_CONF) $(MFC_SMEMS_CONF) 2> /dev/null
 	$(SED) -i 's/.*/& /' $(MFC_SMEMS_CONF) # need trailing space for SFC macrocompiler
+	touch $(MFC_BB_MODS_FILELIST) # if there are no BB's then the file might not be generated, instead always generate it
 # DOC include end: FirrtlCompiler
 
 $(TOP_MODS_FILELIST) $(MODEL_MODS_FILELIST) $(ALL_MODS_FILELIST) $(BB_MODS_FILELIST) $(MFC_MODEL_HRCHY_JSON_UNIQUIFIED) &: $(MFC_MODEL_HRCHY_JSON) $(MFC_TOP_HRCHY_JSON) $(MFC_FILELIST) $(MFC_BB_MODS_FILELIST)


### PR DESCRIPTION
If a design has no blackboxes it might not generate a black-box filelist (`MFC...BB_FILELIST`). This breaks the flow (since a `sed` needs it downstream). Instead always generate it.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
