### PR TITLE
Add HasHarnessInstantiators into MultiHarnessBinder

### DIFF
--- a/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
@@ -24,18 +24,18 @@ object ApplyMultiHarnessBinders {
     Seq.tabulate(chips.size, chips.size) { case (i, j) => if (i != j) {
       (chips(i), chips(j)) match {
         case (l0: HasChipyardPorts, l1: HasChipyardPorts) => p(MultiHarnessBinders(i, j)).foreach { f =>
-          f(l0.ports, l1.ports)
+          f(th, l0.ports, l1.ports)
         }
       }
     }}
   }
 }
 
-class MultiHarnessBinder[T <: Port[_]](
+class MultiHarnessBinder[T <: Port[_], S <: HasHarnessInstantiators](
   chip0: Int, chip1: Int,
   chip0portFn: T => Boolean, chip1portFn: T => Boolean,
-  connectFn: (T, T) => Unit
-)(implicit tag: ClassTag[T]) extends Config((site, here, up) => {
+  connectFn: (S, T, T) => Unit
+)(implicit tag0: ClassTag[T], tag1: ClassTag[S]) extends Config((site, here, up) => {
     // Override any HarnessBinders for chip0/chip1
     case MultiChipParameters(`chip0`) => new Config(
       new HarnessBinder({case (th, port: T) if chip0portFn(port) => }) ++ up(MultiChipParameters(chip0))
@@ -45,21 +45,21 @@ class MultiHarnessBinder[T <: Port[_]](
     )
     // Set the multiharnessbinder key
     case MultiHarnessBinders(`chip0`, `chip1`) => up(MultiHarnessBinders(chip0, chip1)) :+ {
-      ((chip0Ports: Seq[Port[_]], chip1Ports: Seq[Port[_]]) => {
+      ((th: S, chip0Ports: Seq[Port[_]], chip1Ports: Seq[Port[_]]) => {
         val chip0Port: Seq[T] = chip0Ports.collect { case (p: T) if chip0portFn(p) => p }
         val chip1Port: Seq[T] = chip1Ports.collect { case (p: T) if chip1portFn(p) => p }
         require(chip0Port.size == 1 && chip1Port.size == 1)
-        connectFn(chip0Port(0), chip1Port(0))
+        connectFn(th, chip0Port(0), chip1Port(0))
       })
     }
   })
 
 
-class WithMultiChipSerialTL(chip0: Int, chip1: Int, chip0portId: Int = 0, chip1portId: Int = 0) extends MultiHarnessBinder[SerialTLPort](
+class WithMultiChipSerialTL(chip0: Int, chip1: Int, chip0portId: Int = 0, chip1portId: Int = 0) extends MultiHarnessBinder(
   chip0, chip1,
   (p0: SerialTLPort) => p0.portId == chip0portId,
   (p1: SerialTLPort) => p1.portId == chip1portId,
-  (p0: SerialTLPort, p1: SerialTLPort) => {
+  (th: HasHarnessInstantiators, p0: SerialTLPort, p1: SerialTLPort) => {
     (DataMirror.directionOf(p0.io.clock), DataMirror.directionOf(p1.io.clock)) match {
       case (Direction.Input, Direction.Output) => p0.io.clock := p1.io.clock
       case (Direction.Output, Direction.Input) => p1.io.clock := p0.io.clock

--- a/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
@@ -41,7 +41,7 @@ class MultiHarnessBinder[T <: Port[_], S <: HasHarnessInstantiators](
       new HarnessBinder({case (th: S, port: T) if chip0portFn(port) => }) ++ up(MultiChipParameters(chip0))
     )
     case MultiChipParameters(`chip1`) => new Config(
-      new HarnessBinder({case (th, port: T) if chip1portFn(port) => }) ++ up(MultiChipParameters(chip1))
+      new HarnessBinder({case (th: S, port: T) if chip1portFn(port) => }) ++ up(MultiChipParameters(chip1))
     )
     // Set the multiharnessbinder key
     case MultiHarnessBinders(`chip0`, `chip1`) => up(MultiHarnessBinders(chip0, chip1)) :+ {

--- a/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
@@ -38,7 +38,7 @@ class MultiHarnessBinder[T <: Port[_], S <: HasHarnessInstantiators](
 )(implicit tag0: ClassTag[T], tag1: ClassTag[S]) extends Config((site, here, up) => {
     // Override any HarnessBinders for chip0/chip1
     case MultiChipParameters(`chip0`) => new Config(
-      new HarnessBinder({case (th, port: T) if chip0portFn(port) => }) ++ up(MultiChipParameters(chip0))
+      new HarnessBinder({case (th: S, port: T) if chip0portFn(port) => }) ++ up(MultiChipParameters(chip0))
     )
     case MultiChipParameters(`chip1`) => new Config(
       new HarnessBinder({case (th, port: T) if chip1portFn(port) => }) ++ up(MultiChipParameters(chip1))

--- a/generators/chipyard/src/main/scala/harness/package.scala
+++ b/generators/chipyard/src/main/scala/harness/package.scala
@@ -7,5 +7,5 @@ package object harness
 {
   import chipyard.iobinders.Port
   type HarnessBinderFunction = PartialFunction[(HasHarnessInstantiators, Port[_]), Unit]
-  type MultiHarnessBinderFunction = (Seq[Port[_]], Seq[Port[_]]) => Unit
+  type MultiHarnessBinderFunction = (HasHarnessInstantiator, Seq[Port[_]], Seq[Port[_]]) => Unit
 }

--- a/generators/chipyard/src/main/scala/harness/package.scala
+++ b/generators/chipyard/src/main/scala/harness/package.scala
@@ -7,5 +7,5 @@ package object harness
 {
   import chipyard.iobinders.Port
   type HarnessBinderFunction = PartialFunction[(HasHarnessInstantiators, Port[_]), Unit]
-  type MultiHarnessBinderFunction = (HasHarnessInstantiator, Seq[Port[_]], Seq[Port[_]]) => Unit
+  type MultiHarnessBinderFunction = (HasHarnessInstantiators, Seq[Port[_]], Seq[Port[_]]) => Unit
 }


### PR DESCRIPTION
In general, users should be able to generate arb. RTL in the harness and connect up any clock they want to it (for example to connect up a queue between IOs, debugging loggers, etc). This is supported with current `HarnessBinders` but not with `MultiHarnessBinders` specifically because the `Multi*` version doesn't have access to `th: HasHarnessInstantiators`. This adds this back to the `MultiHarnessBinder` when it was dropped on the PortAPI changes.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
