### PR TITLE
Add configurable ResetShifter

### DIFF
--- a/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
+++ b/generators/chipyard/src/main/scala/clocking/HasChipyardPRCI.scala
@@ -19,6 +19,7 @@ import testchipip.{TLTileResetCtrl, ClockGroupFakeResetSynchronizer}
 case class ChipyardPRCIControlParams(
   slaveWhere: TLBusWrapperLocation = CBUS,
   baseAddress: BigInt = 0x100000,
+  syncResetShiftN: Int = 4,
   enableTileClockGating: Boolean = true,
   enableTileResetSetting: Boolean = true,
   enableResetSynchronizers: Boolean = true // this should only be disabled to work around verilator async-reset initialization problems
@@ -81,6 +82,7 @@ trait HasChipyardPRCI { this: BaseSubsystem with InstantiatesTiles =>
   // diplomatic IOBinder should drive
   val frequencySpecifier = ClockGroupFrequencySpecifier(p(ClockFrequencyAssignersKey))
   val clockGroupCombiner = ClockGroupCombiner()
+  val resetShifter       = ClockGroupResetShifter(prciParams.syncResetShiftN)
   val resetSynchronizer  = prci_ctrl_domain {
     if (prciParams.enableResetSynchronizers) ClockGroupResetSynchronizer() else ClockGroupFakeResetSynchronizer()
   }
@@ -118,6 +120,7 @@ RTL SIMULATORS, NAMELY VERILATOR.
   (aggregator
     := frequencySpecifier
     := clockGroupCombiner
+    := resetShifter
     := resetSynchronizer
     := tileClockGater.map(_.clockNode).getOrElse(ClockGroupEphemeralNode()(ValName("temp")))
     := tileResetSetter.map(_.clockNode).getOrElse(ClockGroupEphemeralNode()(ValName("temp")))

--- a/generators/chipyard/src/main/scala/clocking/ResetShifter.scala
+++ b/generators/chipyard/src/main/scala/clocking/ResetShifter.scala
@@ -1,0 +1,26 @@
+package chipyard.clocking
+
+import org.chipsalliance.cde.config.{Parameters}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.util.{ResetCatchAndSync}
+import freechips.rocketchip.prci._
+import chisel3._
+import chisel3.util._
+
+// Adds shift registers to a synchronous reset path
+class ClockGroupResetShifter(shiftN: Int)(implicit p: Parameters) extends LazyModule {
+  val node = ClockGroupAdapterNode()
+  lazy val module = new Impl
+  class Impl extends LazyRawModuleImp(this) {
+    (node.out zip node.in).map { case ((oG, _), (iG, _)) =>
+      (oG.member.data zip iG.member.data).foreach { case (o, i) =>
+        o.clock := i.clock
+        o.reset := withClock(i.clock) { ShiftRegister(i.reset, shiftN) }
+      }
+    }
+  }
+}
+
+object ClockGroupResetShifter {
+  def apply(shiftN: Int)(implicit p: Parameters, valName: ValName) = LazyModule(new ClockGroupResetShifter(shiftN)).node
+}


### PR DESCRIPTION
In large designs, achieving synchronous reset deassertion is challenging.
Adding a synchronous reset shifter should make it easier to close timing.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
