### PR TITLE
REFACTOR: rename arty35t explicitly

### DIFF
--- a/.github/scripts/defaults.sh
+++ b/.github/scripts/defaults.sh
@@ -34,7 +34,7 @@ grouping["group-accels"]="chipyard-mempress chipyard-sha3 chipyard-hwacha chipya
 grouping["group-constellation"]="chipyard-constellation"
 grouping["group-tracegen"]="tracegen tracegen-boom"
 grouping["group-other"]="icenet testchipip constellation rocketchip-amba rocketchip-tlsimple rocketchip-tlwidth rocketchip-tlxbar"
-grouping["group-fpga"]="arty arty100t nexysvideo vc707 vcu118"
+grouping["group-fpga"]="arty35t arty100t nexysvideo vc707 vcu118"
 
 # key value store to get the build strings
 declare -A mapping
@@ -79,7 +79,7 @@ mapping["rocketchip-tlsimple"]="SUB_PROJECT=rocketchip CONFIG=TLSimpleUnitTestCo
 mapping["rocketchip-tlwidth"]="SUB_PROJECT=rocketchip CONFIG=TLWidthUnitTestConfig"
 mapping["rocketchip-tlxbar"]="SUB_PROJECT=rocketchip CONFIG=TLXbarUnitTestConfig"
 
-mapping["arty"]="SUB_PROJECT=arty verilog"
+mapping["arty35t"]="SUB_PROJECT=arty35t verilog"
 mapping["arty100t"]="SUB_PROJECT=arty100t verilog"
 mapping["nexysvideo"]="SUB_PROJECT=nexysvideo verilog"
 mapping["vc707"]="SUB_PROJECT=vc707 verilog"

--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -72,11 +72,11 @@ ifeq ($(SUB_PROJECT),nexysvideo)
 	FPGA_BRAND        ?= xilinx
 endif
 
-ifeq ($(SUB_PROJECT),arty)
+ifeq ($(SUB_PROJECT),arty35t)
 	# TODO: Fix with Arty
 	SBT_PROJECT       ?= fpga_platforms
-	MODEL             ?= ArtyFPGATestHarness
-	VLOG_MODEL        ?= ArtyFPGATestHarness
+	MODEL             ?= Arty35THarness
+	VLOG_MODEL        ?= Arty35THarness
 	MODEL_PACKAGE     ?= chipyard.fpga.arty
 	CONFIG            ?= TinyRocketArtyConfig
 	CONFIG_PACKAGE    ?= chipyard.fpga.arty

--- a/fpga/src/main/scala/arty/HarnessBinders.scala
+++ b/fpga/src/main/scala/arty/HarnessBinders.scala
@@ -15,19 +15,19 @@ import chipyard.harness.{HarnessBinder}
 import chipyard.iobinders._
 
 class WithArtyDebugResetHarnessBinder extends HarnessBinder({
-  case (th: ArtyFPGATestHarness, port: DebugResetPort) => {
+  case (th: Arty35THarness, port: DebugResetPort) => {
     th.dut_ndreset := port.io // Debug module reset
   }
 })
 
 class WithArtyJTAGResetHarnessBinder extends HarnessBinder({
-  case (th: ArtyFPGATestHarness, port: JTAGResetPort) => {
+  case (th: Arty35THarness, port: JTAGResetPort) => {
     port.io := PowerOnResetFPGAOnly(th.clock_32MHz) // JTAG module reset
   }
 })
 
 class WithArtyJTAGHarnessBinder extends HarnessBinder({
-  case (th: ArtyFPGATestHarness, port: JTAGPort) => {
+  case (th: Arty35THarness, port: JTAGPort) => {
     val jtag_wire = Wire(new JTAGIO)
     jtag_wire.TDO.data := port.io.TDO
     jtag_wire.TDO.driven := true.B
@@ -62,7 +62,7 @@ class WithArtyJTAGHarnessBinder extends HarnessBinder({
 })
 
 class WithArtyUARTHarnessBinder extends HarnessBinder({
-  case (th: ArtyFPGATestHarness, port: UARTPort) => {
+  case (th: Arty35THarness, port: UARTPort) => {
     withClockAndReset(th.clock_32MHz, th.ck_rst) {
       IOBUF(th.uart_rxd_out,  port.io.txd)
       port.io.rxd := IOBUF(th.uart_txd_in)

--- a/fpga/src/main/scala/arty/TestHarness.scala
+++ b/fpga/src/main/scala/arty/TestHarness.scala
@@ -10,7 +10,7 @@ import sifive.fpgashells.shell.xilinx.artyshell.{ArtyShell}
 
 import chipyard.harness.{HasHarnessInstantiators}
 
-class ArtyFPGATestHarness(override implicit val p: Parameters) extends ArtyShell with HasHarnessInstantiators {
+class Arty35THarness(override implicit val p: Parameters) extends ArtyShell with HasHarnessInstantiators {
   // Convert harness resets from Bool to Reset type.
   val hReset = Wire(Reset())
   hReset := ~ck_rst


### PR DESCRIPTION
Rename the arty config to arty35t config to avoid confusion.

Now, instead of 

```bash
make SUB_PROJECT=arty bitstream
```

the command for making 35T configuration becomes

```bash
make SUB_PROJECT=arty35t bitstream
```

This change is made to keep Arty 35t configuration with the same naming convention as the Arty 100t configuration.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [x] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
