### PR TITLE
FIX: fix conda-lock version, >1.4.0 does not work!

### DIFF
--- a/docs/Chipyard-Basics/Initial-Repo-Setup.rst
+++ b/docs/Chipyard-Basics/Initial-Repo-Setup.rst
@@ -46,7 +46,7 @@ This is done by the following:
 
 .. code-block:: shell
 
-    conda install -n base conda-lock=1.4
+    conda install -n base conda-lock==1.4.0
     conda activate base
 
 


### PR DESCRIPTION
**Related PRs / Issues**:

When using conda-lock=1.4 constraint, it will install version greater than v1.4.**0**. With that version, `build-setup.sh` will halt with the following error:

![image](https://github.com/ucb-bar/chipyard/assets/26409587/c76775ed-6479-4be7-8384-1cac2bbc70ca)


<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Documentation
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
