### PR TITLE
Add support for symmetric serial-tilelink

### DIFF
--- a/.github/scripts/defaults.sh
+++ b/.github/scripts/defaults.sh
@@ -29,7 +29,7 @@ REMOTE_COURSIER_CACHE=$REMOTE_WORK_DIR/.coursier-cache
 # key value store to get the build groups
 declare -A grouping
 grouping["group-cores"]="chipyard-cva6 chipyard-ibex chipyard-rocket chipyard-hetero chipyard-boom chipyard-sodor chipyard-digitaltop chipyard-multiclock-rocket chipyard-nomem-scratchpad chipyard-spike chipyard-clone chipyard-prefetchers chipyard-shuttle"
-grouping["group-peripherals"]="chipyard-dmirocket chipyard-dmiboom chipyard-spiflashwrite chipyard-mmios chipyard-nocores chipyard-manyperipherals chipyard-chiplike chipyard-tethered"
+grouping["group-peripherals"]="chipyard-dmirocket chipyard-dmiboom chipyard-spiflashwrite chipyard-mmios chipyard-nocores chipyard-manyperipherals chipyard-chiplike chipyard-tethered chipyard-symmetric"
 grouping["group-accels"]="chipyard-mempress chipyard-sha3 chipyard-hwacha chipyard-gemmini chipyard-manymmioaccels chipyard-nvdla chipyard-aes256ecb"
 grouping["group-constellation"]="chipyard-constellation"
 grouping["group-tracegen"]="tracegen tracegen-boom"
@@ -58,6 +58,7 @@ mapping["chipyard-spiflashwrite"]=" CONFIG=SmallSPIFlashRocketConfig EXTRA_SIM_F
 mapping["chipyard-manyperipherals"]=" CONFIG=ManyPeripheralsRocketConfig EXTRA_SIM_FLAGS='+spiflash0=${LOCAL_CHIPYARD_DIR}/tests/spiflash.img'"
 mapping["chipyard-chiplike"]=" CONFIG=ChipLikeRocketConfig MODEL=FlatTestHarness MODEL_PACKAGE=chipyard.example verilog"
 mapping["chipyard-tethered"]=" CONFIG=VerilatorCITetheredChipLikeRocketConfig"
+mapping["chipyard-symmetric"]=" CONFIG=MultiSimSymmetricChipletRocketConfig"
 mapping["chipyard-cloneboom"]=" CONFIG=Cloned64MegaBoomConfig verilog"
 mapping["chipyard-nocores"]=" CONFIG=NoCoresConfig verilog"
 mapping["tracegen"]=" CONFIG=NonBlockingTraceGenL2Config"

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -118,6 +118,10 @@ case $1 in
         make -C $LOCAL_CHIPYARD_DIR/tests
         run_binary BINARY=$LOCAL_CHIPYARD_DIR/tests/hello.riscv LOADMEM=1 EXTRA_SIM_FLAGS="+cflush_addr=0x2010200"
         ;;
+    chipyard-symmetric)
+        make -C $LOCAL_CHIPYARD_DIR/tests
+        run_binary BINARY=$LOCAL_CHIPYARD_DIR/tests/symmetric.riscv LOADMEM=1
+        ;;
     tracegen)
         run_tracegen
         ;;

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -708,6 +708,29 @@ jobs:
           group-key: "group-peripherals"
           project-key: "chipyard-tethered"
 
+  chipyard-symmetric-run-tests:
+    name: chipyard-symmetric-run-tests
+    needs: prepare-chipyard-peripherals
+    runs-on: as4
+    steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
+            ls -alh .
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Git workaround
+        uses: ./.github/actions/git-workaround
+      - name: Create conda env
+        uses: ./.github/actions/create-conda-env
+      - name: Run tests
+        uses: ./.github/actions/run-tests
+        with:
+          group-key: "group-peripherals"
+          project-key: "chipyard-symmetric"
+
   chipyard-sha3-run-tests:
     name: chipyard-sha3-run-tests
     needs: prepare-chipyard-accels
@@ -1071,6 +1094,7 @@ jobs:
             chipyard-spiflashwrite-run-tests,
             chipyard-manyperipherals-run-tests,
             chipyard-tethered-run-tests,
+            chipyard-symmetric-run-tests,
             chipyard-sha3-run-tests,
             chipyard-gemmini-run-tests,
             chipyard-manymmioaccels-run-tests, # chipyard-nvdla-run-tests,

--- a/fpga/src/main/scala/arty100t/Configs.scala
+++ b/fpga/src/main/scala/arty100t/Configs.scala
@@ -56,5 +56,5 @@ class NoCoresArty100TConfig extends Config(
 class BringupArty100TConfig extends Config(
   new WithArty100TSerialTLToGPIO ++
   new WithArty100TTweaks(freqMHz = 50) ++
-  new testchipip.serdes.WithSerialTLClockDirection(provideClockFreqMHz = Some(50)) ++
+  new testchipip.serdes.WithSerialTLPHYParams(testchipip.serdes.InternalSyncSerialParams(freqMHz=50)) ++
   new chipyard.ChipBringupHostConfig)

--- a/fpga/src/main/scala/arty100t/HarnessBinders.scala
+++ b/fpga/src/main/scala/arty100t/HarnessBinders.scala
@@ -53,8 +53,8 @@ class WithArty100TSerialTLToGPIO extends HarnessBinder({
     harnessIO match {
       case io: DecoupledSerialIO => {
         val clkIO = io match {
-          case io: LocallySyncSerialIO => IOPin(io.clock_out)
-          case io: ExternallySyncSerialIO => IOPin(io.clock_in)
+          case io: InternalSyncSerialIO => IOPin(io.clock_out)
+          case io: ExternalSyncSerialIO => IOPin(io.clock_in)
         }
         val packagePinsWithPackageIOs = Seq(
           ("G13", clkIO),
@@ -78,10 +78,10 @@ class WithArty100TSerialTLToGPIO extends HarnessBinder({
 
         // Don't add IOB to the clock, if its an input
         io match {
-          case io: LocallySyncSerialIO => packagePinsWithPackageIOs foreach { case (pin, io) => {
+          case io: InternalSyncSerialIO => packagePinsWithPackageIOs foreach { case (pin, io) => {
             artyTh.xdc.addIOB(io)
           }}
-          case io: ExternallySyncSerialIO => packagePinsWithPackageIOs.drop(1).foreach { case (pin, io) => {
+          case io: ExternalSyncSerialIO => packagePinsWithPackageIOs.drop(1).foreach { case (pin, io) => {
             artyTh.xdc.addIOB(io)
           }}
         }

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -65,8 +65,8 @@ class AbstractConfig extends Config(
   new testchipip.boot.WithBootAddrReg ++                            // add a boot-addr-reg for configurable boot address
   new testchipip.serdes.WithSerialTL(Seq(                           // add a serial-tilelink interface
     testchipip.serdes.SerialTLParams(
-      client = Some(testchipip.serdes.SerialTLClientParams(idBits=4)), // serial-tilelink interface will master the FBUS, and support 4 idBits
-      width = 32                                                    // serial-tilelink interface with 32 lanes
+      client = Some(testchipip.serdes.SerialTLClientParams()),      // serial-tilelink interface will master the FBUS, and support 4 idBits
+      phyParams = testchipip.serdes.ExternalSyncSerialParams(width=32) // serial-tilelink interface with 32 lanes
     )
   )) ++
   new chipyard.config.WithDebugModuleAbstractDataWords(8) ++        // increase debug module data capacity

--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -22,8 +22,18 @@ class ChipLikeRocketConfig extends Config(
   //==================================
   // Set up I/O
   //==================================
-  new testchipip.serdes.WithSerialTLWidth(4) ++                                         // 4bit wide Serialized TL interface to minimize IO
-  new testchipip.serdes.WithSerialTLMem(size = (1 << 30) * 4L) ++                       // Configure the off-chip memory accessible over serial-tl as backing memory
+  new testchipip.serdes.WithSerialTL(Seq(testchipip.serdes.SerialTLParams(              // 1 serial tilelink port
+    manager = Some(testchipip.serdes.SerialTLManagerParams(                             // port acts as a manager of offchip memory
+      memParams = Seq(testchipip.serdes.ManagerRAMParams(                               // 4 GB of off-chip memory
+        address = BigInt("80000000", 16),
+        size    = BigInt("100000000", 16)
+      )),
+      isMemoryDevice = true
+    )),
+    client = Some(testchipip.serdes.SerialTLClientParams()),                            // Allow an external manager to probe this chip
+    phyParams = testchipip.serdes.ExternalSyncSerialParams(width=4)                     // 4-bit bidir interface, sync'd to an external clock
+  ))) ++
+
   new freechips.rocketchip.subsystem.WithNoMemPort ++                                   // Remove axi4 mem port
   new freechips.rocketchip.subsystem.WithNMemoryChannels(1) ++                          // 1 memory channel
 
@@ -60,10 +70,16 @@ class ChipBringupHostConfig extends Config(
   //=============================
   // Setup the SerialTL side on the bringup device
   //=============================
-  new testchipip.serdes.WithSerialTLWidth(4) ++                                // match width with the chip
-  new testchipip.serdes.WithSerialTLMem(base = 0x0, size = 0x80000000L,        // accessible memory of the chip that doesn't come from the tethered host
-                                        idBits = 4, isMainMemory = false) ++   // This assumes off-chip mem starts at 0x8000_0000
-  new testchipip.serdes.WithSerialTLClockDirection(provideClockFreqMHz = Some(75)) ++ // bringup board drives the clock for the serial-tl receiver on the chip, use 75MHz clock
+  new testchipip.serdes.WithSerialTL(Seq(testchipip.serdes.SerialTLParams(
+    manager = Some(testchipip.serdes.SerialTLManagerParams(
+      memParams = Seq(testchipip.serdes.ManagerRAMParams(                            // Bringup platform can access all memory from 0 to DRAM_BASE
+        address = BigInt("00000000", 16),
+        size    = BigInt("80000000", 16)
+      ))
+    )),
+    client = Some(testchipip.serdes.SerialTLClientParams()),                         // Allow chip to access this device's memory (DRAM)
+    phyParams = testchipip.serdes.InternalSyncSerialParams(width=4, freqMHz = 75)    // bringup platform provides the clock
+  ))) ++
 
   //============================
   // Setup bus topology on the bringup system

--- a/generators/chipyard/src/main/scala/config/ChipletConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipletConfigs.scala
@@ -36,3 +36,11 @@ class SymmetricChipletRocketConfig extends Config(
   new testchipip.soc.WithOffchipBus ++
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.AbstractConfig)
+
+// Simulates 2X of the SymmetricChipletRocketConfig in a multi-sim config
+class MultiSimSymmetricChipletRocketConfig extends Config(
+  new chipyard.harness.WithAbsoluteFreqHarnessClockInstantiator ++
+  new chipyard.harness.WithMultiChipSerialTL(chip0=0, chip1=1, chip0portId=1, chip1portId=1) ++
+  new chipyard.harness.WithMultiChip(0, new SymmetricChipletRocketConfig) ++
+  new chipyard.harness.WithMultiChip(1, new SymmetricChipletRocketConfig)
+)

--- a/generators/chipyard/src/main/scala/config/ChipletConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipletConfigs.scala
@@ -1,0 +1,38 @@
+package chipyard
+
+import org.chipsalliance.cde.config.{Config}
+import freechips.rocketchip.diplomacy.{AddressSet}
+import freechips.rocketchip.subsystem.{SBUS}
+import testchipip.soc.{OBUS}
+
+// ------------------------------------------------
+// Configs demonstrating chip-to-chip communication
+// ------------------------------------------------
+
+// Simple design which exposes a second serial-tl port that can connect to another instance of itself
+class SymmetricChipletRocketConfig extends Config(
+  new chipyard.harness.WithSerialTLTiedOff(tieoffs=Some(Seq(1))) ++ // Tie-off the chip-to-chip link in single-chip sims
+  new testchipip.serdes.WithSerialTL(Seq(
+    testchipip.serdes.SerialTLParams(                               // 0th serial-tl is chip-to-bringup-fpga
+      client = Some(testchipip.serdes.SerialTLClientParams()),      // bringup serial-tl acts only as a client
+      phyParams = testchipip.serdes.ExternalSyncSerialParams()      // bringup serial-tl is sync'd to external clock
+    ),
+    testchipip.serdes.SerialTLParams(                               // 1st serial-tl is chip-to-chip
+      client = Some(testchipip.serdes.SerialTLClientParams()),      // chip-to-chip serial-tl acts as a client
+      manager = Some(testchipip.serdes.SerialTLManagerParams(       // chip-to-chip serial-tl managers other chip's memory
+        memParams = Seq(testchipip.serdes.ManagerRAMParams(
+          address = 0,
+          size = 1L << 32,
+        )),
+        slaveWhere = OBUS
+      )),
+      phyParams = testchipip.serdes.SourceSyncSerialParams()        // chip-to-chip serial-tl is symmetric source-sync'd
+    ))
+  ) ++
+  new testchipip.soc.WithOffchipBusClient(SBUS,                     // obus provides path to other chip's memory
+    blockRange = Seq(AddressSet(0, (1L << 32) - 1)),                // The lower 4GB is mapped to this chip
+    replicationBase = Some(1L << 32)                                // The upper 4GB goes off-chip
+  ) ++
+  new testchipip.soc.WithOffchipBus ++
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
+++ b/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
@@ -11,10 +11,10 @@ import freechips.rocketchip.util.{PlusArg}
 import freechips.rocketchip.subsystem.{CacheBlockBytes}
 import freechips.rocketchip.devices.debug.{SimJTAG}
 import freechips.rocketchip.jtag.{JTAGIO}
-import testchipip.serdes.{SerialTLKey}
+import testchipip.serdes.{SerialTLKey, LocallySyncSerialIO, ExternallySyncSerialIO}
 import testchipip.uart.{UARTAdapter}
 import testchipip.dram.{SimDRAM}
-import testchipip.tsi.{TSIHarness, SimTSI}
+import testchipip.tsi.{TSIHarness, SimTSI, SerialRAM}
 import chipyard.harness.{BuildTop}
 
 // A "flat" TestHarness that doesn't use IOBinders
@@ -46,18 +46,25 @@ class FlatTestHarness(implicit val p: Parameters) extends Module {
   val serialTLManagerParams = sVal.manager.get
   require(serialTLManagerParams.isMemoryDevice)
 
-  withClockAndReset(clock, reset) {
-    val serial_bits = dut.serial_tl_pad.bits
-    if (DataMirror.directionOf(dut.serial_tl_pad.clock) == Direction.Input) {
-      dut.serial_tl_pad.clock := clock
-    }
-    val harnessRAM = TSIHarness.connectRAM(
-      p(SerialTLKey)(0),
-      lazyDut.system.serdessers(0),
-      serial_bits,
-      reset)
-    io.success := SimTSI.connect(harnessRAM.module.io.tsi, clock, reset)
+  // Figure out which clock drives the harness TLSerdes, based on the port type
+  val serial_ram_clock = dut.serial_tl_pad match {
+    case io: LocallySyncSerialIO => io.clock_out
+    case io: ExternallySyncSerialIO => clock
+  }
 
+  withClockAndReset(serial_ram_clock, reset) {
+    dut.serial_tl_pad match {
+      case io: ExternallySyncSerialIO => io.clock_in := clock
+      case io: LocallySyncSerialIO =>
+    }
+
+    // SerialRAM implements the memory regions the chip expects
+    val ram = Module(LazyModule(new SerialRAM(lazyDut.system.serdessers(0), p(SerialTLKey)(0))).module)
+    ram.io.ser.in <> dut.serial_tl_pad.out
+    dut.serial_tl_pad.in <> ram.io.ser.out
+
+    // Allow TSI to master the chip
+    io.success := SimTSI.connect(ram.io.tsi, serial_ram_clock, reset)
   }
 
   // JTAG

--- a/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
@@ -211,8 +211,8 @@ class WithSerialTLTiedOff extends HarnessBinder({
       case io: DecoupledSerialIO => io.out.ready := false.B; io.in.valid := false.B; io.in.bits := DontCare;
     }
     port.io match {
-      case io: LocallySyncSerialIO =>
-      case io: ExternallySyncSerialIO => io.clock_in := false.B.asClock
+      case io: InternalSyncSerialIO =>
+      case io: ExternalSyncSerialIO => io.clock_in := false.B.asClock
     }
   }
 })
@@ -220,8 +220,8 @@ class WithSerialTLTiedOff extends HarnessBinder({
 class WithSimTSIOverSerialTL extends HarnessBinder({
   case (th: HasHarnessInstantiators, port: SerialTLPort) => {
     port.io match {
-      case io: LocallySyncSerialIO =>
-      case io: ExternallySyncSerialIO => io.clock_in := false.B.asClock
+      case io: InternalSyncSerialIO =>
+      case io: ExternalSyncSerialIO => io.clock_in := false.B.asClock
     }
 
     port.io match {
@@ -229,8 +229,8 @@ class WithSimTSIOverSerialTL extends HarnessBinder({
         // If the port is locally synchronous (provides a clock), drive everything with that clock
         // Else, drive everything with the harnes clock
         val clock = port.io match {
-          case io: LocallySyncSerialIO => io.clock_out
-          case io: ExternallySyncSerialIO => th.harnessBinderClock
+          case io: InternalSyncSerialIO => io.clock_out
+          case io: ExternalSyncSerialIO => th.harnessBinderClock
         }
         withClock(clock) {
           val ram = Module(LazyModule(new SerialRAM(port.serdesser, port.params)(port.serdesser.p)).module)

--- a/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
@@ -10,7 +10,7 @@ import freechips.rocketchip.devices.debug._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.util._
 
-import testchipip._
+import testchipip.serdes._
 
 import chipyard._
 import chipyard.iobinders.{GetSystemParameters, JTAGChipIO, HasChipyardPorts, Port, SerialTLPort}
@@ -60,11 +60,14 @@ class WithMultiChipSerialTL(chip0: Int, chip1: Int, chip0portId: Int = 0, chip1p
   (p0: SerialTLPort) => p0.portId == chip0portId,
   (p1: SerialTLPort) => p1.portId == chip1portId,
   (th: HasHarnessInstantiators, p0: SerialTLPort, p1: SerialTLPort) => {
-    (DataMirror.directionOf(p0.io.clock), DataMirror.directionOf(p1.io.clock)) match {
-      case (Direction.Input, Direction.Output) => p0.io.clock := p1.io.clock
-      case (Direction.Output, Direction.Input) => p1.io.clock := p0.io.clock
+    def connectDecoupledSyncSerialIO(clkSource: LocallySyncSerialIO, clkSink: ExternallySyncSerialIO) = {
+      clkSink.clock_in := clkSource.clock_out
+      clkSink.in <> clkSource.out
+      clkSource.in <> clkSink.out
     }
-    p0.io.bits.in <> p1.io.bits.out
-    p1.io.bits.in <> p0.io.bits.out
+    (p0.io, p1.io) match {
+      case (io0: LocallySyncSerialIO   , io1: ExternallySyncSerialIO) => connectDecoupledSyncSerialIO(io0, io1)
+      case (io0: ExternallySyncSerialIO, io1: LocallySyncSerialIO)    => connectDecoupledSyncSerialIO(io1, io0)
+    }
   }
 )

--- a/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
@@ -65,9 +65,20 @@ class WithMultiChipSerialTL(chip0: Int, chip1: Int, chip0portId: Int = 0, chip1p
       clkSink.in <> clkSource.out
       clkSource.in <> clkSink.out
     }
+    def connectSourceSyncSerialIO(a: SourceSyncSerialIO, b: SourceSyncSerialIO) = {
+      a.clock_in := b.clock_out
+      b.clock_in := a.clock_out
+      a.reset_in := b.reset_out
+      b.reset_in := a.reset_out
+      a.in := b.out
+      b.in := a.out
+      a.credit_in := b.credit_out
+      b.credit_in := a.credit_out
+    }
     (p0.io, p1.io) match {
       case (io0: InternalSyncSerialIO, io1: ExternalSyncSerialIO) => connectDecoupledSyncSerialIO(io0, io1)
       case (io0: ExternalSyncSerialIO, io1: InternalSyncSerialIO) => connectDecoupledSyncSerialIO(io1, io0)
+      case (io0: SourceSyncSerialIO  , io1: SourceSyncSerialIO  ) => connectSourceSyncSerialIO   (io0, io1)
     }
   }
 )

--- a/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
@@ -60,14 +60,14 @@ class WithMultiChipSerialTL(chip0: Int, chip1: Int, chip0portId: Int = 0, chip1p
   (p0: SerialTLPort) => p0.portId == chip0portId,
   (p1: SerialTLPort) => p1.portId == chip1portId,
   (th: HasHarnessInstantiators, p0: SerialTLPort, p1: SerialTLPort) => {
-    def connectDecoupledSyncSerialIO(clkSource: LocallySyncSerialIO, clkSink: ExternallySyncSerialIO) = {
+    def connectDecoupledSyncSerialIO(clkSource: InternalSyncSerialIO, clkSink: ExternalSyncSerialIO) = {
       clkSink.clock_in := clkSource.clock_out
       clkSink.in <> clkSource.out
       clkSource.in <> clkSink.out
     }
     (p0.io, p1.io) match {
-      case (io0: LocallySyncSerialIO   , io1: ExternallySyncSerialIO) => connectDecoupledSyncSerialIO(io0, io1)
-      case (io0: ExternallySyncSerialIO, io1: LocallySyncSerialIO)    => connectDecoupledSyncSerialIO(io1, io0)
+      case (io0: InternalSyncSerialIO, io1: ExternalSyncSerialIO) => connectDecoupledSyncSerialIO(io0, io1)
+      case (io0: ExternalSyncSerialIO, io1: InternalSyncSerialIO) => connectDecoupledSyncSerialIO(io1, io0)
     }
   }
 )

--- a/generators/chipyard/src/main/scala/iobinders/Ports.scala
+++ b/generators/chipyard/src/main/scala/iobinders/Ports.scala
@@ -72,8 +72,9 @@ case class DMIPort         (val getIO: () => ClockedDMIIO)
 case class JTAGPort        (val getIO: () => JTAGChipIO)
     extends Port[JTAGChipIO]
 
-case class SerialTLPort    (val getIO: () => ClockedIO[SerialIO], val params: SerialTLParams, val serdesser: TLSerdesser, val portId: Int)
-    extends Port[ClockedIO[SerialIO]]
+// Lack of nice union types in scala-2 means we have to set this type as Data
+case class SerialTLPort    (val getIO: () => Data, val params: SerialTLParams, val serdesser: TLSerdesser, val portId: Int)
+    extends Port[Data]
 
 case class UARTTSIPort     (val getIO: () => UARTTSIIO)
     extends Port[UARTTSIIO]

--- a/generators/firechip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/src/main/scala/BridgeBinders.scala
@@ -15,7 +15,7 @@ import freechips.rocketchip.prci.{ClockBundle, ClockBundleParameters}
 import freechips.rocketchip.util.{ResetCatchAndSync}
 import sifive.blocks.devices.uart._
 
-import testchipip.serdes.{ExternallySyncSerialIO}
+import testchipip.serdes.{ExternalSyncSerialIO}
 import testchipip.tsi.{SerialRAM}
 import icenet.{CanHavePeripheryIceNIC, SimNetwork, NicLoopback, NICKey, NICIOvonly}
 
@@ -69,7 +69,7 @@ class WithFireSimIOCellModels extends Config((site, here, up) => {
 class WithTSIBridgeAndHarnessRAMOverSerialTL extends HarnessBinder({
   case (th: FireSim, port: SerialTLPort) => {
     port.io match {
-      case io: ExternallySyncSerialIO => {
+      case io: ExternalSyncSerialIO => {
         io.clock_in := th.harnessBinderClock
         val ram = Module(LazyModule(new SerialRAM(port.serdesser, port.params)(port.serdesser.p)).module)
         ram.io.ser.in <> io.out

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -260,7 +260,7 @@ class FireSimSmallSystemConfig extends Config(
   new freechips.rocketchip.subsystem.WithExtMemSize(1 << 28) ++
   new testchipip.serdes.WithSerialTL(Seq(testchipip.serdes.SerialTLParams(
     client = Some(testchipip.serdes.SerialTLClientParams(idBits = 4)),
-    width = 32
+    phyParams = testchipip.serdes.ExternalSyncSerialParams(width=32)
   ))) ++
   new testchipip.iceblk.WithBlockDevice ++
   new chipyard.config.WithUARTInitBaudRate(BigInt(3686400L)) ++

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -29,7 +29,7 @@ include libgloss.mk
 
 PROGRAMS = pwm blkdev accum charcount nic-loopback big-blkdev pingd \
            streaming-passthrough streaming-fir nvdla spiflashread spiflashwrite fft gcd \
-           hello mt-hello
+           hello mt-hello symmetric
 
 
 .DEFAULT_GOAL := default

--- a/tests/symmetric.c
+++ b/tests/symmetric.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <string.h>
+#include <riscv-pk/encoding.h>
+#include "marchid.h"
+
+#define OBUS_OFFSET (0x1L << 32)
+
+char src[] = "This is a test string. It will be written into the off-chip memory address, then copied back.";
+char dest[4096];
+char test[4096];
+
+int main(void) {
+  size_t write_start = rdcycle();
+  memcpy(dest + OBUS_OFFSET, src, sizeof(src));
+  size_t write_end = rdcycle();
+
+  printf("Wrote %ld bytes in %ld cycles\n", sizeof(src), write_end - write_start);
+
+  size_t read_start = rdcycle();
+  memcpy(test, dest + OBUS_OFFSET, sizeof(src));
+  size_t read_end = rdcycle();
+
+  if (memcmp(src, test, sizeof(src))) {
+    printf("Remote write/read failed\n");
+    exit(1);
+  }
+  printf("Read %ld bytes in %ld cycles\n", sizeof(src), read_end - read_start);
+
+  return 0;
+}


### PR DESCRIPTION
Updated APIs:
 - `ClockedIO[SerialIO]` and variants are now `InternalSyncSerialIO/ExternalSyncSerialIO`, for clarity
 - `SimDRAM`/`SimTSI` now can take a `chipId` parameter, allowing simulating multiple SimTSI interfaces, as well as multiple DRAM interfaces across multiple chips
 
 New:
  - `SourceSyncSerialIO`, configuration option for testchipip's serial-TL generator that generates a symmetric credited source-synchronous interface
  - `SymmetricRocketChipletConfig`, demonstrates a RocketConfig that exposes a second symmetric serial-TL port, that can be connected to an instance of itself

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
