### PR TITLE
Reduce CDE lookups for IOBinders

### DIFF
--- a/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
+++ b/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
@@ -116,7 +116,10 @@ object GetSystemParameters {
 }
 
 class IOBinder[T](composer: Seq[IOBinderFunction] => Seq[IOBinderFunction])(implicit tag: ClassTag[T]) extends Config((site, here, up) => {
-  case IOBinders => up(IOBinders, site) + (tag.runtimeClass.toString -> composer(up(IOBinders, site)(tag.runtimeClass.toString)))
+  case IOBinders => {
+    val upMap = up(IOBinders)
+    upMap + (tag.runtimeClass.toString -> composer(upMap(tag.runtimeClass.toString)))
+  }
 })
 
 class ConcreteIOBinder[T](composes: Boolean, fn: T => IOBinderTuple)(implicit tag: ClassTag[T]) extends IOBinder[T](


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

I recently noticed a performance degradation when emitting FIRRTL for a private SoC project, and tracked the issue down to this bit of IOBinders code. If you add a `println` statement to the `IOBinder` class, like this:

```diff
diff --git a/generators/chipyard/src/main/scala/iobinders/IOBinders.scala b/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
index 45f72641..f67e7bf3 100644
--- a/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
+++ b/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
@@ -116,7 +116,10 @@ object GetSystemParameters {
 }

 class IOBinder[T](composer: Seq[IOBinderFunction] => Seq[IOBinderFunction])(implicit tag: ClassTag[T]) extends Config((site, here, up) => {
-  case IOBinders => up(IOBinders, site) + (tag.runtimeClass.toString -> composer(up(IOBinders, site)(tag.runtimeClass.toString)))
+  case IOBinders => {
+    println(s"Checking IOBinder ${tag.runtimeClass.toString}")
+    up(IOBinders, site) + (tag.runtimeClass.toString -> composer(up(IOBinders, site)(tag.runtimeClass.toString)))
+  }
 })

 class ConcreteIOBinder[T](composes: Boolean, fn: T => IOBinderTuple)(implicit tag: ClassTag[T]) extends IOBinder[T](
```

... and then build `RocketConfig` with:

```
make -C sims/vcs firrtl
```

Then you will see 524287 instances of that `println` message, with many duplicate checks of the same `IOBinder` classes. Seems that the extra CDE lookup call to `up` is causing a lot of issues. If you just make a single call to `up`, as in this PR, you'll only see 19 instances of that `println` message.

This performance hiccup isn't that noticeable for Rocket, but for my project, it's the difference between the `make firrtl` step taking 1 minute vs 8 minutes. I'm not adding _that_ many extra IOBinders (maybe about 10), but there seems to be some greater-than-linear blowup in the CDE lookups with the two calls to `up`.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
