### PR TITLE
Fix submodule recusive cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
-[submodule "rocket-chip"]
+[submodule "generators/rocket-chip"]
 	path = generators/rocket-chip
 	url = https://github.com/chipsalliance/rocket-chip.git
-[submodule "testchipip"]
+[submodule "generators/testchipip"]
 	path = generators/testchipip
 	url = https://github.com/ucb-bar/testchipip.git
-[submodule "barstools"]
+[submodule "tools/barstools"]
 	path = tools/barstools
 	url = https://github.com/ucb-bar/barstools.git
 [submodule "tools/torture"]

--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -106,7 +106,13 @@ cd "$RDIR"
     # Non-recursive clone to exclude cva6 submods
     git submodule update --init generators/cva6
     git -C generators/cva6 submodule update --init src/main/resources/cva6/vsrc/cva6
-
+    git -C generators/cva6/src/main/resources/cva6/vsrc/cva6 submodule update --init src/axi
+    git -C generators/cva6/src/main/resources/cva6/vsrc/cva6 submodule update --init src/axi_riscv_atomics
+    git -C generators/cva6/src/main/resources/cva6/vsrc/cva6 submodule update --init src/common_cells
+    git -C generators/cva6/src/main/resources/cva6/vsrc/cva6 submodule update --init src/fpga-support
+    git -C generators/cva6/src/main/resources/cva6/vsrc/cva6 submodule update --init src/riscv-dbg
+    git -C generators/cva6/src/main/resources/cva6/vsrc/cva6 submodule update --init src/register_interface
+    git -C generators/cva6/src/main/resources/cva6/vsrc/cva6 submodule update --init --recursive src/fpu
     # Non-recursive clone to exclude nvdla submods
     git submodule update --init generators/nvdla
     git -C generators/nvdla submodule update --init src/main/resources/hw

--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -69,6 +69,8 @@ cd "$RDIR"
         # path to temporarily exclude during the recursive update
         for name in \
             toolchains/*-tools/* \
+            generators/cva6 \
+            generators/nvdla \
             toolchains/libgloss \
             generators/sha3 \
             generators/gemmini \
@@ -100,6 +102,14 @@ cd "$RDIR"
 (
     # Non-recursive clone to exclude riscv-linux
     git submodule update --init generators/sha3
+
+    # Non-recursive clone to exclude cva6 submods
+    git submodule update --init generators/cva6
+    git -C generators/cva6 submodule update --init src/main/resources/cva6/vsrc/cva6
+
+    # Non-recursive clone to exclude nvdla submods
+    git submodule update --init generators/nvdla
+    git -C generators/nvdla submodule update --init src/main/resources/hw
 
     # Non-recursive clone to exclude gemmini-software
     git submodule update --init generators/gemmini


### PR DESCRIPTION
- Prevents recursive clones of nvdla/cva6
- Fixes recusive clones of rocket-chip not respecting submodule.update=none

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
