### PR TITLE
vlsi/Makefile: truncate file SRAM_GENERATOR_CONF

### DIFF
--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -100,8 +100,8 @@ $(SMEMS_HAMMER): $(TOP_SMEMS_FILE)
 
 $(SRAM_GENERATOR_CONF): $(SMEMS_HAMMER)
 	mkdir -p $(dir $@)
-	echo "vlsi.inputs.sram_parameters: '$(SMEMS_HAMMER)'" >> $@
-	echo "vlsi.inputs.sram_parameters_meta: [\"transclude\", \"json2list\"]">> $@
+	echo "vlsi.inputs.sram_parameters: '$(SMEMS_HAMMER)'" > $@
+	echo "vlsi.inputs.sram_parameters_meta: [\"transclude\", \"json2list\"]" >> $@
 
 $(SRAM_CONF): $(SRAM_GENERATOR_CONF)
 	cd $(vlsi_dir) && $(HAMMER_EXEC) -e $(ENV_YML) $(foreach x,$(INPUT_CONFS) $(SRAM_GENERATOR_CONF), -p $(x)) --obj_dir $(build_dir) sram_generator


### PR DESCRIPTION
previously the target would append, not truncate
the file, which could lead to duplicate yaml entries in that file when the target was re-run.

**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
