### PR TITLE
vlsi/Makefile: with synflops there is no SRAM_CONF

### DIFF
--- a/vlsi/Makefile
+++ b/vlsi/Makefile
@@ -112,8 +112,10 @@ $(SRAM_CONF): $(SRAM_GENERATOR_CONF)
 #########################################################################################
 SYN_CONF = $(OBJ_DIR)/inputs.yml
 GENERATED_CONFS = $(SYN_CONF)
+ifeq ($(findstring --mode synflops,$(TOP_MACROCOMPILER_MODE)),)
 ifeq ($(CUSTOM_VLOG), )
 	GENERATED_CONFS += $(SRAM_CONF)
+endif
 endif
 
 $(SYN_CONF): $(VLSI_RTL)


### PR DESCRIPTION
I am interested in studying asap7 .sdc files from Hammer and I want to use synflops to bypass the question of SRAMs for now.

Without this change, the following command line fails:

```
make CONFIG=MegaBoomConfig tech_name=asap7 INPUT_CONFS=example-asap7.yml TOP_MACROCOMPILER_MODE='--mode synflops' syn
```

```
[deleted]
FileNotFoundError: [Errno 2] No such file or directory: '/home/oyvind/chipyard/vlsi/build/chipyard.harness.TestHarness.MegaBoomConfig-ChipTop/sram_generator-output.json'
```

