### PR TITLE
Integrate ReRoCC

### DIFF
--- a/.github/scripts/check-commit.sh
+++ b/.github/scripts/check-commit.sh
@@ -45,7 +45,8 @@ search () {
     done
 }
 
-submodules=("cva6" "boom" "ibex" "gemmini" "icenet" "nvdla" "rocket-chip" "rocket-chip-blocks" "rocket-chip-inclusive-cache" "testchipip" "riscv-sodor" "mempress" "bar-fetchers" "shuttle" "constellation" "fft-generator" "hardfloat" "caliptra-aes-acc" "rocc-acc-utils" "diplomacy")
+
+submodules=("cva6" "boom" "ibex" "gemmini" "icenet" "nvdla" "rocket-chip" "rocket-chip-blocks" "rocket-chip-inclusive-cache" "testchipip" "riscv-sodor" "mempress" "bar-fetchers" "shuttle" "constellation" "fft-generator" "hardfloat" "caliptra-aes-acc" "rocc-acc-utils" "diplomacy" "rerocc")
 dir="generators"
 branches=("master" "main" "dev")
 search

--- a/.github/scripts/defaults.sh
+++ b/.github/scripts/defaults.sh
@@ -30,7 +30,7 @@ REMOTE_COURSIER_CACHE=$REMOTE_WORK_DIR/.coursier-cache
 declare -A grouping
 grouping["group-cores"]="chipyard-cva6 chipyard-ibex chipyard-rocket chipyard-hetero chipyard-boomv3 chipyard-boomv4 chipyard-sodor chipyard-digitaltop chipyard-multiclock-rocket chipyard-nomem-scratchpad chipyard-spike chipyard-clone chipyard-prefetchers chipyard-shuttle"
 grouping["group-peripherals"]="chipyard-dmirocket chipyard-dmiboomv3 chipyard-dmiboomv4 chipyard-spiflashwrite chipyard-mmios chipyard-nocores chipyard-manyperipherals chipyard-chiplike chipyard-tethered chipyard-symmetric chipyard-llcchiplet"
-grouping["group-accels"]="chipyard-mempress chipyard-gemmini chipyard-manymmioaccels chipyard-nvdla chipyard-aes256ecb"
+grouping["group-accels"]="chipyard-mempress chipyard-gemmini chipyard-manymmioaccels chipyard-nvdla chipyard-aes256ecb chipyard-rerocc"
 grouping["group-constellation"]="chipyard-constellation"
 grouping["group-tracegen"]="tracegen tracegen-boomv3 tracegen-boomv4"
 grouping["group-other"]="icenet testchipip constellation rocketchip-amba rocketchip-tlsimple rocketchip-tlwidth rocketchip-tlxbar chipyard-clusters"
@@ -72,6 +72,7 @@ mapping["chipyard-nomem-scratchpad"]=" CONFIG=MMIOScratchpadOnlyRocketConfig"
 mapping["chipyard-constellation"]=" CONFIG=SharedNoCConfig"
 mapping["chipyard-clusters"]=" CONFIG=ClusteredRocketConfig verilog"
 mapping["chipyard-aes256ecb"]=" CONFIG=AES256ECBRocketConfig"
+mapping["chipyard-rerocc"]=" CONFIG=ReRoCCTestConfig"
 
 mapping["constellation"]=" SUB_PROJECT=constellation"
 mapping["firesim"]="TARGET_CONFIG=WithNIC_DDR3FRFCFSLLC4MB_FireSimRocketConfig"

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -127,6 +127,10 @@ case $1 in
         make -C $LOCAL_CHIPYARD_DIR/tests
         run_binary BINARY=$LOCAL_CHIPYARD_DIR/tests/hello.riscv LOADMEM=1
         ;;
+    chipyard-rerocc)
+        make -C $LOCAL_CHIPYARD_DIR/generators/rerocc/tests
+        run_binary BINARY=$LOCAL_CHIPYARD_DIR/generators/rerocc/tests/rerocc.riscv LOADMEM=1
+        ;;
     tracegen)
         run_tracegen
         ;;

--- a/.github/workflows/chipyard-run-tests.yml
+++ b/.github/workflows/chipyard-run-tests.yml
@@ -777,6 +777,29 @@ jobs:
           group-key: "group-peripherals"
           project-key: "chipyard-llcchiplet"
 
+  chipyard-rerocc-run-tests:
+    name: chipyard-rerocc-run-tests
+    needs: prepare-chipyard-accels
+    runs-on: as4
+    steps:
+      - name: Delete old checkout
+        run: |
+            ls -alh .
+            rm -rf ${{ github.workspace }}/* || true
+            rm -rf ${{ github.workspace }}/.* || true
+            ls -alh .
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Git workaround
+        uses: ./.github/actions/git-workaround
+      - name: Create conda env
+        uses: ./.github/actions/create-conda-env
+      - name: Run tests
+        uses: ./.github/actions/run-tests
+        with:
+          group-key: "group-accels"
+          project-key: "chipyard-rerocc"
+
   chipyard-gemmini-run-tests:
     name: chipyard-gemmini-run-tests
     needs: prepare-chipyard-accels
@@ -1143,6 +1166,7 @@ jobs:
             chipyard-tethered-run-tests,
             chipyard-symmetric-run-tests,
             chipyard-llcchiplet-run-tests,
+            chipyard-rerocc-run-tests,
             chipyard-gemmini-run-tests,
             chipyard-manymmioaccels-run-tests, # chipyard-nvdla-run-tests,
             chipyard-prefetchers-run-tests,

--- a/.gitmodules
+++ b/.gitmodules
@@ -142,4 +142,6 @@
 [submodule "tools/midas-targetutils"]
 	path = tools/midas-targetutils
 	url = https://github.com/firesim/midas-targetutils.git
-
+[submodule "generators/rerocc"]
+	path = generators/rerocc
+	url = https://github.com/ucb-bar/rerocc.git

--- a/build.sbt
+++ b/build.sbt
@@ -254,7 +254,7 @@ lazy val caliptra_aes = (project in file("generators/caliptra-aes-acc"))
   .settings(commonSettings)
 
 lazy val rerocc = (project in file("generators/rerocc"))
-  .dependsOn(rocketchip)
+  .dependsOn(rocketchip, constellation, boom)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)
 

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val chipyard = (project in file("generators/chipyard"))
   .dependsOn(testchipip, rocketchip, boom, rocketchip_blocks, rocketchip_inclusive_cache,
     dsptools, rocket_dsp_utils,
     gemmini, icenet, tracegen, cva6, nvdla, sodor, ibex, fft_generator,
-    constellation, mempress, barf, shuttle, caliptra_aes)
+    constellation, mempress, barf, shuttle, caliptra_aes, rerocc)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(
     libraryDependencies ++= Seq(
@@ -250,6 +250,11 @@ lazy val nvdla = (project in file("generators/nvdla"))
 
 lazy val caliptra_aes = (project in file("generators/caliptra-aes-acc"))
   .dependsOn(rocketchip, rocc_acc_utils, testchipip)
+  .settings(libraryDependencies ++= rocketLibDeps.value)
+  .settings(commonSettings)
+
+lazy val rerocc = (project in file("generators/rerocc"))
+  .dependsOn(rocketchip)
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)
 

--- a/generators/chipyard/src/main/scala/DigitalTop.scala
+++ b/generators/chipyard/src/main/scala/DigitalTop.scala
@@ -39,6 +39,7 @@ class DigitalTop(implicit p: Parameters) extends ChipyardSystem
   with chipyard.clocking.CanHaveClockTap // Enables optionally adding a clock tap output port
   with fftgenerator.CanHavePeripheryFFT // Enables optionally having an MMIO-based FFT block
   with constellation.soc.CanHaveGlobalNoC // Support instantiating a global NoC interconnect
+  with rerocc.CanHaveReRoCCTiles // Support tiles that instantiate rerocc-attached accelerators
 {
   override lazy val module = new DigitalTopModule(this)
 }

--- a/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/RoCCAcceleratorConfigs.scala
@@ -48,3 +48,22 @@ class AES256ECBRocketConfig extends Config(
   new freechips.rocketchip.subsystem.WithNBigCores(1) ++
   new chipyard.config.WithSystemBusWidth(256) ++
   new chipyard.config.AbstractConfig)
+
+class ReRoCCTestConfig extends Config(
+  new rerocc.WithReRoCC ++
+  new chipyard.config.WithCharacterCountRoCC ++                // rerocc tile4 is charcnt
+  new chipyard.config.WithAccumulatorRoCC ++                   // rerocc tile3 is accum
+  new chipyard.config.WithAccumulatorRoCC ++                   // rerocc tile2 is accum
+  new chipyard.config.WithAccumulatorRoCC ++                   // rerocc tile1 is accum
+  new chipyard.config.WithAccumulatorRoCC ++                   // rerocc tile0 is accum
+  new freechips.rocketchip.subsystem.WithNBigCores(1) ++
+  new chipyard.config.AbstractConfig)
+
+class ReRoCCManyGemminiConfig extends Config(
+  new rerocc.WithReRoCC ++
+  new gemmini.LeanGemminiConfig ++                              // rerocc tile3 is gemmini
+  new gemmini.LeanGemminiConfig ++                              // rerocc tile2 is gemmini
+  new gemmini.LeanGemminiConfig ++                              // rerocc tile1 is gemmini
+  new gemmini.LeanGemminiConfig ++                              // rerocc tile0 is gemmini
+  new freechips.rocketchip.subsystem.WithNBigCores(4) ++        // 4 rocket cores
+  new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/fragments/RoCCFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/RoCCFragments.scala
@@ -43,3 +43,17 @@ class WithMultiRoCCGemmini[T <: Data : Arithmetic, U <: Data, V <: Data](
     }))
   }
 })
+
+class WithAccumulatorRoCC(op: OpcodeSet = OpcodeSet.custom1) extends Config((site, here, up) => {
+  case BuildRoCC => up(BuildRoCC) ++ Seq((p: Parameters) => {
+    val accumulator = LazyModule(new AccumulatorExample(op, n = 4)(p))
+    accumulator
+  })
+})
+
+class WithCharacterCountRoCC(op: OpcodeSet = OpcodeSet.custom2) extends Config((site, here, up) => {
+  case BuildRoCC => up(BuildRoCC) ++ Seq((p: Parameters) => {
+    val counter = LazyModule(new CharacterCountExample(op)(p))
+    counter
+  })
+})


### PR DESCRIPTION
ReRocC (Remote RoCC) is a ISA extension, communication protocol, and RTL implementation of a system which enables physical disaggregation of RoCC accelerators and software accelerator Muxing, all while preserving most existing interfaces for RoCC accelerators.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
