### PR TITLE
Switch update-circt action to v1

### DIFF
--- a/.github/workflows/update-circt.yml
+++ b/.github/workflows/update-circt.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update CIRCT
-        uses: circt/update-circt@v1.0.0
+        uses: circt/update-circt@v1
         with:
           user: 'bartender'
           email: 'firesimchipyard@gmail.com'


### PR DESCRIPTION
Change the version of the update-circt action from v1.0.0 to v1.  This pulls in a change from v1.0.1 which fixes a bug where the staging branch was not updated.  (I have no idea if this is being used.)  However, this generally future-proofs the action by having it pull from v1 which is manually updated to match the latest v1 release (pulling in minor and patch changes).