### PR TITLE
Add example rocket-chip-blocks timer integration

### DIFF
--- a/generators/chipyard/src/main/scala/DigitalTop.scala
+++ b/generators/chipyard/src/main/scala/DigitalTop.scala
@@ -22,6 +22,7 @@ class DigitalTop(implicit p: Parameters) extends ChipyardSystem
   with testchipip.serdes.CanHavePeripheryTLSerial // Enables optionally adding the backing memory and serial adapter
   with testchipip.soc.CanHavePeripheryChipIdPin // Enables optional pin to set chip id for multi-chip configs
   with sifive.blocks.devices.i2c.HasPeripheryI2C // Enables optionally adding the sifive I2C
+  with sifive.blocks.devices.timer.HasPeripheryTimer // Enables optionally adding the timer device
   with sifive.blocks.devices.pwm.HasPeripheryPWM // Enables optionally adding the sifive PWM
   with sifive.blocks.devices.uart.HasPeripheryUART // Enables optionally adding the sifive UART
   with sifive.blocks.devices.gpio.HasPeripheryGPIO // Enables optionally adding the sifive GPIOs

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -75,6 +75,7 @@ class ManyPeripheralsRocketConfig extends Config(
   new testchipip.serdes.WithSerialTLMem(isMainMemory=true) ++ // set lbwif memory base to DRAM_BASE, use as main memory
   new chipyard.harness.WithSimSPIFlashModel(true) ++         // add the SPI flash model in the harness (read-only)
   new chipyard.harness.WithSimBlockDevice ++                 // drive block-device IOs with SimBlockDevice
+  new chipyard.config.WithPeripheryTimer ++                  // add the pwm timer device
   new chipyard.config.WithSPIFlash ++                        // add the SPI flash controller
   new freechips.rocketchip.subsystem.WithDefaultMMIOPort ++  // add default external master port
   new freechips.rocketchip.subsystem.WithDefaultSlavePort ++ // add default external slave port

--- a/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/PeripheralFragments.scala
@@ -16,6 +16,7 @@ import sifive.blocks.devices.gpio._
 import sifive.blocks.devices.uart._
 import sifive.blocks.devices.spi._
 import sifive.blocks.devices.i2c._
+import sifive.blocks.devices.timer._
 
 import testchipip._
 
@@ -167,4 +168,8 @@ class WithNoBusErrorDevices extends Config((site, here, up) => {
   case PeripheryBusKey => up(PeripheryBusKey).copy(errorDevice = None)
   case MemoryBusKey => up(MemoryBusKey).copy(errorDevice = None)
   case FrontBusKey => up(FrontBusKey).copy(errorDevice = None)
+})
+
+class WithPeripheryTimer(timerParams: TimerParams = TimerParams(0x4000)) extends Config((site, here, up) => {
+  case PeripheryTimerKey => Seq(timerParams)
 })


### PR DESCRIPTION
Some people use this block, so it should be in the regressions.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
