### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/scripts/uniquify-module-names.py
+++ b/scripts/uniquify-module-names.py
@@ -110,7 +110,7 @@ def generate_copy(c, sfx):
   new_file = os.path.join(args.gcpath, new_file)
 
   shutil.copy(cur_file, new_file)
-  bash(f"{SED} -i 's/module\( \+\){cur_name}/module\\1{new_name}/' {new_file}")
+  bash(rf"{SED} -i 's/module\( \+\){cur_name}/module\1{new_name}/' {new_file}")
   return new_file
 
 def bfs_uniquify_modules(tree, common_fnames, verilog_module_filename):
@@ -137,7 +137,7 @@ def bfs_uniquify_modules(tree, common_fnames, verilog_module_filename):
         new_file = generate_copy(cur_file, MODEL_SFX)
         if parent is not None and ((parent, mod) not in updated_submodule):
           parent_file = os.path.join(args.gcpath, verilog_module_filename[parent])
-          bash(f"{SED} -i 's/\( \*\){mod}\( \+\)/\\1{mod}_{MODEL_SFX}\\2/' {parent_file}")
+          bash(rf"{SED} -i 's/\( \*\){mod}\( \+\)/\1{mod}_{MODEL_SFX}\2/' {parent_file}")
           updated_submodule.add((parent, mod))
 
         # add the uniquified module to the verilog_modul_filename dict


### PR DESCRIPTION
In Python 3.12, these show up as SyntaxWarning messages.

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
