### PR TITLE
REFACTOR: rearrange gitsubmodule list to match directory order

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,96 +1,90 @@
-[submodule "generators/rocket-chip"]
-	path = generators/rocket-chip
-	url = https://github.com/chipsalliance/rocket-chip.git
-[submodule "generators/testchipip"]
-	path = generators/testchipip
-	url = https://github.com/ucb-bar/testchipip.git
-[submodule "tools/barstools"]
-	path = tools/barstools
-	url = https://github.com/ucb-bar/barstools.git
-[submodule "tools/torture"]
-	path = tools/torture
-	url = https://github.com/ucb-bar/riscv-torture.git
-[submodule "generators/boom"]
-	path = generators/boom
-	url = https://github.com/riscv-boom/riscv-boom.git
-[submodule "generators/hwacha"]
-	path = generators/hwacha
-	url = https://github.com/ucb-bar/hwacha.git
-[submodule "sims/firesim"]
-	path = sims/firesim
-	url = https://github.com/firesim/firesim.git
-[submodule "generators/icenet"]
-	path = generators/icenet
-	url = https://github.com/firesim/icenet.git
-[submodule "tools/dsptools"]
-	path = tools/dsptools
-	url = https://github.com/ucb-bar/dsptools.git
-[submodule "generators/sha3"]
-	path = generators/sha3
-	url = https://github.com/ucb-bar/sha3.git
-[submodule "vlsi/hammer-mentor-plugins"]
-	path = vlsi/hammer-mentor-plugins
-	url = https://github.com/ucb-bar/hammer-mentor-plugins.git
-[submodule "tools/axe"]
-	path = tools/axe
-	url = https://github.com/CTSRD-CHERI/axe.git
-[submodule "software/spec2017"]
-	path = software/spec2017
-	url = https://github.com/ucb-bar/spec2017-workload.git
-[submodule "software/coremark"]
-	path = software/coremark
-	url = https://github.com/ucb-bar/coremark-workload.git
-[submodule "generators/gemmini"]
-	path = generators/gemmini
-	url = https://github.com/ucb-bar/gemmini
-[submodule "software/firemarshal"]
-	path = software/firemarshal
-	url = https://github.com/firesim/FireMarshal.git
-[submodule "generators/cva6"]
-	path = generators/cva6
-	url = https://github.com/ucb-bar/cva6-wrapper.git
-[submodule "tools/DRAMSim2"]
-	path = tools/DRAMSim2
-	url = https://github.com/firesim/DRAMSim2.git
-[submodule "generators/nvdla"]
-	path = generators/nvdla
-	url = https://github.com/ucb-bar/nvdla-wrapper.git
-[submodule "software/nvdla-workload"]
-	path = software/nvdla-workload
-	url = https://github.com/ucb-bar/nvdla-workload.git
-[submodule "software/baremetal-ide"]
-	path = software/baremetal-ide
-	url = https://github.com/ucb-bar/Baremetal-IDE.git
-[submodule "generators/riscv-sodor"]
-	path = generators/riscv-sodor
-	url = https://github.com/ucb-bar/riscv-sodor.git
 [submodule "fpga/fpga-shells"]
 	path = fpga/fpga-shells
 	url = https://github.com/chipsalliance/rocket-chip-fpga-shells.git
-[submodule "tools/rocket-dsp-utils"]
-	path = tools/rocket-dsp-utils
-	url = https://github.com/ucb-bar/rocket-dsp-utils
-[submodule "generators/ibex"]
-	path = generators/ibex
-	url = https://github.com/ucb-bar/ibex-wrapper
+[submodule "generators/bar-fetchers"]
+	path = generators/bar-fetchers
+	url = https://github.com/ucb-bar/bar-fetchers.git
+[submodule "generators/boom"]
+	path = generators/boom
+	url = https://github.com/riscv-boom/riscv-boom.git
+[submodule "generators/caliptra-aes-acc"]
+	path = generators/caliptra-aes-acc
+	url = https://github.com/ucb-bar/caliptra-aes-acc
+[submodule "generators/constellation"]
+	path = generators/constellation
+	url = https://github.com/ucb-bar/constellation.git
+[submodule "generators/cva6"]
+	path = generators/cva6
+	url = https://github.com/ucb-bar/cva6-wrapper.git
 [submodule "generators/fft-generator"]
 	path = generators/fft-generator
 	url = https://github.com/ucb-bar/FFTGenerator.git
-[submodule "toolchains/riscv-tools/riscv-tests"]
-	path = toolchains/riscv-tools/riscv-tests
-	url = https://github.com/riscv-software-src/riscv-tests.git
-[submodule "toolchains/riscv-tools/riscv-pk"]
-	path = toolchains/riscv-tools/riscv-pk
-	url = https://github.com/riscv-software-src/riscv-pk.git
-[submodule "toolchains/riscv-tools/riscv-openocd"]
-	path = toolchains/riscv-tools/riscv-openocd
-	url = https://github.com/riscv/riscv-openocd.git
-[submodule "toolchains/riscv-tools/riscv-isa-sim"]
-	path = toolchains/riscv-tools/riscv-isa-sim
-	url = https://github.com/riscv-software-src/riscv-isa-sim.git
-[submodule "toolchains/riscv-tools/riscv-tools-feedstock"]
-	path = toolchains/riscv-tools/riscv-tools-feedstock
-	url = https://github.com/ucb-bar/riscv-tools-feedstock.git
+[submodule "generators/gemmini"]
+	path = generators/gemmini
+	url = https://github.com/ucb-bar/gemmini
+[submodule "generators/hardfloat"]
+	path = generators/hardfloat
+	url = https://github.com/ucb-bar/berkeley-hardfloat.git
+[submodule "generators/hwacha"]
+	path = generators/hwacha
+	url = https://github.com/ucb-bar/hwacha.git
+[submodule "generators/ibex"]
+	path = generators/ibex
+	url = https://github.com/ucb-bar/ibex-wrapper
+[submodule "generators/icenet"]
+	path = generators/icenet
+	url = https://github.com/firesim/icenet.git
+[submodule "generators/mempress"]
+	path = generators/mempress
+	url = https://github.com/ucb-bar/mempress.git
+[submodule "generators/nvdla"]
+	path = generators/nvdla
+	url = https://github.com/ucb-bar/nvdla-wrapper.git
+[submodule "generators/riscv-sodor"]
+	path = generators/riscv-sodor
+	url = https://github.com/ucb-bar/riscv-sodor.git
+[submodule "generators/rocc-acc-utils"]
+	path = generators/rocc-acc-utils
+	url = https://github.com/ucb-bar/rocc-acc-utils
+[submodule "generators/rocket-chip"]
+	path = generators/rocket-chip
+	url = https://github.com/chipsalliance/rocket-chip.git
+[submodule "generators/rocket-chip-blocks"]
+	path = generators/rocket-chip-blocks
+	url = https://github.com/chipsalliance/rocket-chip-blocks.git
+[submodule "generators/rocket-chip-inclusive-cache"]
+	path = generators/rocket-chip-inclusive-cache
+	url = https://github.com/chipsalliance/rocket-chip-inclusive-cache.git
+[submodule "generators/sha3"]
+	path = generators/sha3
+	url = https://github.com/ucb-bar/sha3.git
+[submodule "shuttle"]
+	path = generators/shuttle
+	url = https://github.com/ucb-bar/shuttle.git
+[submodule "generators/testchipip"]
+	path = generators/testchipip
+	url = https://github.com/ucb-bar/testchipip.git
+[submodule "sims/firesim"]
+	path = sims/firesim
+	url = https://github.com/firesim/firesim.git
+[submodule "software/baremetal-ide"]
+	path = software/baremetal-ide
+	url = https://github.com/ucb-bar/Baremetal-IDE.git
+[submodule "software/coremark"]
+	path = software/coremark
+	url = https://github.com/ucb-bar/coremark-workload.git
+[submodule "software/embench/embench-iot"]
+	path = software/embench/embench-iot
+	url = https://github.com/embench/embench-iot.git
+[submodule "software/firemarshal"]
+	path = software/firemarshal
+	url = https://github.com/firesim/FireMarshal.git
+[submodule "software/nvdla-workload"]
+	path = software/nvdla-workload
+	url = https://github.com/ucb-bar/nvdla-workload.git
+[submodule "software/spec2017"]
+	path = software/spec2017
+	url = https://github.com/ucb-bar/spec2017-workload.git
 [submodule "toolchains/esp-tools/esp-tools-feedstock"]
 	path = toolchains/esp-tools/esp-tools-feedstock
 	url = https://github.com/ucb-bar/esp-tools-feedstock.git
@@ -106,48 +100,54 @@
 [submodule "toolchains/libgloss"]
 	path = toolchains/libgloss
 	url = https://github.com/ucb-bar/libgloss-htif.git
-[submodule "generators/constellation"]
-	path = generators/constellation
-	url = https://github.com/ucb-bar/constellation.git
-[submodule "generators/mempress"]
-	path = generators/mempress
-	url = https://github.com/ucb-bar/mempress.git
-[submodule "tools/cde"]
-	path = tools/cde
-	url = https://github.com/chipsalliance/cde.git
-[submodule "software/embench/embench-iot"]
-	path = software/embench/embench-iot
-	url = https://github.com/embench/embench-iot.git
-[submodule "shuttle"]
-	path = generators/shuttle
-	url = https://github.com/ucb-bar/shuttle.git
-[submodule "generators/bar-fetchers"]
-	path = generators/bar-fetchers
-	url = https://github.com/ucb-bar/bar-fetchers.git
-[submodule "tools/fixedpoint"]
-	path = tools/fixedpoint
-	url = https://github.com/ucb-bar/fixedpoint.git
-[submodule "generators/hardfloat"]
-	path = generators/hardfloat
-	url = https://github.com/ucb-bar/berkeley-hardfloat.git
-[submodule "generators/caliptra-aes-acc"]
-	path = generators/caliptra-aes-acc
-	url = https://github.com/ucb-bar/caliptra-aes-acc
-[submodule "generators/rocc-acc-utils"]
-	path = generators/rocc-acc-utils
-	url = https://github.com/ucb-bar/rocc-acc-utils
-[submodule "tools/install-circt"]
-	path = tools/install-circt
-	url = https://github.com/circt/install-circt/
+[submodule "toolchains/riscv-tools/riscv-isa-sim"]
+	path = toolchains/riscv-tools/riscv-isa-sim
+	url = https://github.com/riscv-software-src/riscv-isa-sim.git
+[submodule "toolchains/riscv-tools/riscv-openocd"]
+	path = toolchains/riscv-tools/riscv-openocd
+	url = https://github.com/riscv/riscv-openocd.git
+[submodule "toolchains/riscv-tools/riscv-pk"]
+	path = toolchains/riscv-tools/riscv-pk
+	url = https://github.com/riscv-software-src/riscv-pk.git
 [submodule "toolchains/riscv-tools/riscv-spike-devices"]
 	path = toolchains/riscv-tools/riscv-spike-devices
 	url = https://github.com/ucb-bar/spike-devices.git
-[submodule "generators/rocket-chip-blocks"]
-	path = generators/rocket-chip-blocks
-	url = https://github.com/chipsalliance/rocket-chip-blocks.git
-[submodule "generators/rocket-chip-inclusive-cache"]
-	path = generators/rocket-chip-inclusive-cache
-	url = https://github.com/chipsalliance/rocket-chip-inclusive-cache.git
+[submodule "toolchains/riscv-tools/riscv-tests"]
+	path = toolchains/riscv-tools/riscv-tests
+	url = https://github.com/riscv-software-src/riscv-tests.git
+[submodule "toolchains/riscv-tools/riscv-tools-feedstock"]
+	path = toolchains/riscv-tools/riscv-tools-feedstock
+	url = https://github.com/ucb-bar/riscv-tools-feedstock.git
+[submodule "tools/DRAMSim2"]
+	path = tools/DRAMSim2
+	url = https://github.com/firesim/DRAMSim2.git
+[submodule "tools/axe"]
+	path = tools/axe
+	url = https://github.com/CTSRD-CHERI/axe.git
+[submodule "tools/barstools"]
+	path = tools/barstools
+	url = https://github.com/ucb-bar/barstools.git
+[submodule "tools/cde"]
+	path = tools/cde
+	url = https://github.com/chipsalliance/cde.git
 [submodule "tools/circt"]
 	path = tools/circt
 	url = https://github.com/llvm/circt.git
+[submodule "tools/dsptools"]
+	path = tools/dsptools
+	url = https://github.com/ucb-bar/dsptools.git
+[submodule "tools/fixedpoint"]
+	path = tools/fixedpoint
+	url = https://github.com/ucb-bar/fixedpoint.git
+[submodule "tools/install-circt"]
+	path = tools/install-circt
+	url = https://github.com/circt/install-circt/
+[submodule "tools/rocket-dsp-utils"]
+	path = tools/rocket-dsp-utils
+	url = https://github.com/ucb-bar/rocket-dsp-utils
+[submodule "tools/torture"]
+	path = tools/torture
+	url = https://github.com/ucb-bar/riscv-torture.git
+[submodule "vlsi/hammer-mentor-plugins"]
+	path = vlsi/hammer-mentor-plugins
+	url = https://github.com/ucb-bar/hammer-mentor-plugins.git


### PR DESCRIPTION
Rearranges the submodule entries in `.gitmodules` to match the order of appearance in file directory. This should allow adding / removing submodules easier and should not affect anything.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
