### PR TITLE
EXT_FILELISTS and EXT_INCDIR APIs for including external verilog projects

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -310,8 +310,13 @@ $(MODEL_SMEMS_FILE) $(MODEL_SMEMS_FIR) &: $(TAPEOUT_CLASSPATH_TARGETS) $(MODEL_S
 # note: {MODEL,TOP}_BB_MODS_FILELIST is added as a req. so that the files get generated,
 #       however it is really unneeded since ALL_MODS_FILELIST includes all BB files
 ########################################################################################
-$(sim_common_files): $(sim_files) $(ALL_MODS_FILELIST) $(TOP_SMEMS_FILE) $(MODEL_SMEMS_FILE) $(BB_MODS_FILELIST)
-	sort -u $(sim_files) $(ALL_MODS_FILELIST) | grep -v '.*\.\(svh\|h\)$$' > $@
+$(sim_common_files): $(sim_files) $(ALL_MODS_FILELIST) $(TOP_SMEMS_FILE) $(MODEL_SMEMS_FILE) $(BB_MODS_FILELIST) $(EXT_FILELISTS)
+ifneq (,$(EXT_FILELISTS))
+	cat $(EXT_FILELISTS) > $@
+else
+	rm -f $@
+endif
+	sort -u $(sim_files) $(ALL_MODS_FILELIST) | grep -v '.*\.\(svh\|h\)$$' >> $@
 	echo "$(TOP_SMEMS_FILE)" >> $@
 	echo "$(MODEL_SMEMS_FILE)" >> $@
 

--- a/scripts/insert-includes.py
+++ b/scripts/insert-includes.py
@@ -34,7 +34,8 @@ def process(inF, outF):
             # for each include found, search through all dirs and replace if found, error if not
             for num, line in enumerate(inFile, 1):
                 match = re.match(r"^ *`include +\"(.*)\"", line)
-                if match:
+                if match and match.group(1) != "uvm_macros.svh":
+                    print("[INFO] Replacing includes for {}".format(match.group(1)))
                     # search for include and replace
                     found = False
                     for d in incDirs:

--- a/scripts/insert-includes.py
+++ b/scripts/insert-includes.py
@@ -42,6 +42,7 @@ def process(inF, outF):
                         potentialIncFileName = d + "/" + match.group(1)
                         if os.path.exists(potentialIncFileName):
                             found = True
+                            print("[INFO] Found missing include in {}".format(potentialIncFileName))
                             with open(potentialIncFileName, 'r') as incFile:
                                 for iline in incFile:
                                     outFile.write(iline)

--- a/sims/vcs/vcs.mk
+++ b/sims/vcs/vcs.mk
@@ -51,6 +51,7 @@ VCS_NONCC_OPTS = \
 	-sverilog +systemverilogext+.sv+.svi+.svh+.svt -assert svaext +libext+.sv \
 	+v2k +verilog2001ext+.v95+.vt+.vp +libext+.v \
 	-debug_pp \
+	-top $(TB) \
 	+incdir+$(GEN_COLLATERAL_DIR) \
 	$(addprefix +incdir+,$(EXT_INCDIRS))
 

--- a/sims/vcs/vcs.mk
+++ b/sims/vcs/vcs.mk
@@ -51,7 +51,8 @@ VCS_NONCC_OPTS = \
 	-sverilog +systemverilogext+.sv+.svi+.svh+.svt -assert svaext +libext+.sv \
 	+v2k +verilog2001ext+.v95+.vt+.vp +libext+.v \
 	-debug_pp \
-	+incdir+$(GEN_COLLATERAL_DIR)
+	+incdir+$(GEN_COLLATERAL_DIR) \
+	$(addprefix +incdir+,$(EXT_INCDIRS))
 
 VCS_PREPROC_DEFINES = \
 	+define+VCS

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -154,6 +154,7 @@ VERILATOR_NONCC_OPTS = \
 	$(VERILATOR_PREPROC_DEFINES) \
 	--top-module $(TB) \
 	--vpi \
+	$(addprefix +incdir+,$(EXT_INCDIRS)) \
 	-f $(sim_common_files)
 
 #----------------------------------------------------------------------------------------

--- a/variables.mk
+++ b/variables.mk
@@ -213,6 +213,12 @@ BB_MODS_FILELIST ?= $(build_dir)/$(long_name).bb.f
 # all module files to include (top, model, bb included)
 ALL_MODS_FILELIST ?= $(build_dir)/$(long_name).all.f
 
+# external filelists. Users, or project-supplied make fragments can append filelists
+# with absolute paths here
+EXT_FILELISTS ?=
+# external verilog incdirs. Users, or project-supplied make fragments can append to this
+EXT_INCDIRS ?=
+
 BOOTROM_FILES   ?= bootrom.rv64.img bootrom.rv32.img
 BOOTROM_TARGETS ?= $(addprefix $(build_dir)/, $(BOOTROM_FILES))
 


### PR DESCRIPTION
External projects which may not want to provide their sources as a blackbox resource, can instead append to these Makefile variables.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
