### PR TITLE
Use SV48 when possible

### DIFF
--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -120,6 +120,7 @@ class AbstractConfig extends Config(
 
   // Bus/interconnect settings
   new freechips.rocketchip.subsystem.WithCoherentBusTopology ++     /** hierarchical buses including sbus/mbus/pbus/fbus/cbus/l2 */
+  new chipyard.config.WithSV48IfPossible ++                         /** use sv48 if possible */
 
 
   // ================================================
@@ -134,7 +135,7 @@ class AbstractConfig extends Config(
   new freechips.rocketchip.subsystem.WithDontDriveBusClocksFromSBus ++  /** leave the bus clocks undriven by sbus */
   new freechips.rocketchip.subsystem.WithClockGateModel ++              /** add default EICG_wrapper clock gate model */
   new chipyard.clocking.WithClockGroupsCombinedByName(("uncore",        /** create a "uncore" clock group tieing all the bus clocks together */
-    Seq("sbus", "mbus", "pbus", "fbus", "cbus", "obus", "implicit", "clock_tap"), 
+    Seq("sbus", "mbus", "pbus", "fbus", "cbus", "obus", "implicit", "clock_tap"),
     Seq("tile"))) ++
 
   new chipyard.config.WithPeripheryBusFrequency(500.0) ++           /** Default 500 MHz pbus */

--- a/generators/chipyard/src/main/scala/config/fragments/TileFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/TileFragments.scala
@@ -5,7 +5,7 @@ import chisel3._
 import org.chipsalliance.cde.config.{Field, Parameters, Config}
 import freechips.rocketchip.tile._
 import freechips.rocketchip.subsystem._
-import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams, ICacheParams}
+import freechips.rocketchip.rocket.{RocketCoreParams, MulDivParams, DCacheParams, ICacheParams, PgLevels}
 
 import cva6.{CVA6TileAttachParams}
 import sodor.common.{SodorTileAttachParams}
@@ -125,4 +125,9 @@ class WithRocketBoundaryBuffers(buffers: Option[RocketTileBoundaryBufferParams] 
       boundaryBuffers=buffers
     ))
   }
+})
+
+// Uses SV48 if possible, otherwise default to the Rocket Chip core default
+class WithSV48IfPossible extends Config((site, here, up) => {
+  case PgLevels => if (site(XLen) == 64) 4 /* Sv48 */ else up(PgLevels)
 })


### PR DESCRIPTION
Default to using SV48 for 64b designs. Otherwise, adhere to the RC default (SV32).

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
