### PR TITLE
Update build-toolchain-extra.sh

### DIFF
--- a/scripts/build-toolchain-extra.sh
+++ b/scripts/build-toolchain-extra.sh
@@ -115,6 +115,7 @@ echo '==>  Installing DRAMSim2 Shared Library'
 cd $RDIR
 git submodule update --init tools/DRAMSim2
 cd tools/DRAMSim2
+make clean
 make libdramsim.so
 cp libdramsim.so $RISCV/lib/
 


### PR DESCRIPTION
Re-running the `build-setup` script in the same repo can cause the DRAMSim library build to break unless you add a `make clean` before it.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
