### PR TITLE
Add DMI Bridge to FireSim

### DIFF
--- a/generators/firechip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/src/main/scala/BridgeBinders.scala
@@ -86,6 +86,19 @@ class WithTSIBridgeAndHarnessRAMOverSerialTL extends HarnessBinder({
   }
 })
 
+class WithDMIBridge extends HarnessBinder({
+  case (th: FireSim, port: DMIPort, chipId: Int) => {
+    // This assumes that:
+    // If ExtMem for the target is defined, then FASED bridge will be attached
+    // If FASED bridge is attached, loadmem widget is present
+
+    val hasMainMemory = th.chipParameters(th.p(MultiChipIdx))(ExtMem).isDefined
+    val mainMemoryName = Option.when(hasMainMemory)(MainMemoryConsts.globalName(th.p(MultiChipIdx)))
+    val nDMIAddrBits = port.io.dmi.req.bits.addr.getWidth
+    DMIBridge(th.harnessBinderClock, port.io, mainMemoryName, th.harnessBinderReset.asBool, nDMIAddrBits)(th.p)
+  }
+})
+
 class WithNICBridge extends HarnessBinder({
   case (th: FireSim, port: NICPort, chipId: Int) => {
     NICBridge(port.io.clock, port.io.bits)(th.p)
@@ -139,6 +152,7 @@ class WithSuccessBridge extends HarnessBinder({
 // Shorthand to register all of the provided bridges above
 class WithDefaultFireSimBridges extends Config(
   new WithTSIBridgeAndHarnessRAMOverSerialTL ++
+  new WithDMIBridge ++
   new WithNICBridge ++
   new WithUARTBridge ++
   new WithBlockDeviceBridge ++
@@ -152,6 +166,7 @@ class WithDefaultFireSimBridges extends Config(
 // Shorthand to register all of the provided mmio-only bridges above
 class WithDefaultMMIOOnlyFireSimBridges extends Config(
   new WithTSIBridgeAndHarnessRAMOverSerialTL ++
+  new WithDMIBridge ++
   new WithUARTBridge ++
   new WithBlockDeviceBridge ++
   new WithFASEDBridge ++

--- a/generators/firechip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/src/main/scala/TargetConfigs.scala
@@ -271,10 +271,10 @@ class FireSimSmallSystemConfig extends Config(
   new chipyard.RocketConfig)
 
 class FireSimDmiRocketConfig extends Config(
+  new chipyard.harness.WithSerialTLTiedOff ++ // (must be at top) tieoff any bridges that connect to serialTL so only DMI port is connected
   new WithDefaultFireSimBridges ++
   new WithDefaultMemModel ++
   new WithFireSimConfigTweaks ++
-  new testchipip.serdes.WithNoSerialTL ++ // disable serial TL so that only DMI port is connected
   new chipyard.dmiRocketConfig)
 
 //*****************************************************************


### PR DESCRIPTION
Adds a FireSim DMI Bridge for an alternative bringup interface other than TSI.

- Adds a new DMI target config for FireSim for quick testing
- Adds bridge binder for DMI
- Enables DebugModule for all FireSim designs (now that clock gating can be disabled). This matches CY's behavior of always having it.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
