### PR TITLE
Remove legacy SFC flags

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -181,7 +181,6 @@ SFC_MFC_TARGETS = \
 	$(MFC_BB_MODS_FILELIST) \
 	$(GEN_COLLATERAL_DIR)
 
-SFC_REPL_SEQ_MEM = --infer-rw --repl-seq-mem -c:$(MODEL):-o:$(SFC_SMEMS_CONF)
 MFC_BASE_LOWERING_OPTIONS ?= emittedLineLength=2048,noAlwaysComb,disallowLocalVariables,verifLabels,disallowPortDeclSharing,locationInfoStyle=wrapInAtSquareBracket
 
 # DOC include start: FirrtlCompiler
@@ -219,7 +218,6 @@ $(SFC_MFC_TARGETS) &: $(TAPEOUT_CLASSPATH_TARGETS) $(FIRRTL_FILE) $(FINAL_ANNO_F
 		--split-verilog \
 		-o $(GEN_COLLATERAL_DIR) \
 		$(SFC_FIRRTL_FILE)
-	-mv $(SFC_SMEMS_CONF) $(MFC_SMEMS_CONF) 2> /dev/null
 	$(SED) -i 's/.*/& /' $(MFC_SMEMS_CONF) # need trailing space for SFC macrocompiler
 	touch $(MFC_BB_MODS_FILELIST) # if there are no BB's then the file might not be generated, instead always generate it
 # DOC include end: FirrtlCompiler

--- a/common.mk
+++ b/common.mk
@@ -217,7 +217,6 @@ $(SFC_MFC_TARGETS) &: $(TAPEOUT_CLASSPATH_TARGETS) $(FIRRTL_FILE) $(FINAL_ANNO_F
 		--annotation-file $(FINAL_ANNO_FILE) \
 		--log-level $(FIRRTL_LOGLEVEL) \
 		--allow-unrecognized-annotations)
-	-mv $(SFC_FIRRTL_BASENAME).lo.fir $(SFC_FIRRTL_FILE) 2> /dev/null # Optionally change file type when SFC generates LowFIRRTL
 	firtool \
 		--format=fir \
 		--export-module-hierarchy \

--- a/common.mk
+++ b/common.mk
@@ -198,19 +198,18 @@ MFC_BASE_LOWERING_OPTIONS ?= emittedLineLength=2048,noAlwaysComb,disallowLocalVa
 # DOC include start: FirrtlCompiler
 # There are two possible cases for this step. In the first case, SFC
 # compiles Chisel to CHIRRTL, and MFC compiles CHIRRTL to Verilog. Otherwise,
-# when custom FIRRTL transforms are included or if a Fixed type is used within
-# the dut, SFC compiles Chisel to LowFIRRTL and MFC compiles it to Verilog.
+# when custom FIRRTL transforms are included
+# SFC compiles Chisel to LowFIRRTL and MFC compiles it to Verilog.
 # Users can indicate to the Makefile of custom FIRRTL transforms by setting the
 # "ENABLE_CUSTOM_FIRRTL_PASS" variable.
 #
-# hack: lower to low firrtl if Fixed types are found
 # hack: when using dontTouch, io.cpu annotations are not removed by SFC,
 # hence we remove them manually by using jq before passing them to firtool
 
 $(SFC_LEVEL) $(EXTRA_FIRRTL_OPTIONS) &: $(FIRRTL_FILE)
 ifeq (,$(ENABLE_CUSTOM_FIRRTL_PASS))
-	echo $(if $(shell grep "Fixed<" $(FIRRTL_FILE)), low, none) > $(SFC_LEVEL)
-	echo "$(EXTRA_BASE_FIRRTL_OPTIONS)" $(if $(shell grep "Fixed<" $(FIRRTL_FILE)), "$(SFC_REPL_SEQ_MEM)",) > $(EXTRA_FIRRTL_OPTIONS)
+	echo none > $(SFC_LEVEL)
+	echo "$(EXTRA_BASE_FIRRTL_OPTIONS)" > $(EXTRA_FIRRTL_OPTIONS)
 else
 	echo low > $(SFC_LEVEL)
 	echo "$(EXTRA_BASE_FIRRTL_OPTIONS)" "$(SFC_REPL_SEQ_MEM)" > $(EXTRA_FIRRTL_OPTIONS)

--- a/common.mk
+++ b/common.mk
@@ -161,9 +161,9 @@ define mfc_extra_anno_contents
 endef
 export mfc_extra_anno_contents
 export sfc_extra_low_transforms_anno_contents
-$(EXTRA_ANNO_FILE) $(MFC_EXTRA_ANNO_FILE) &: $(ANNO_FILE)
+$(FINAL_ANNO_FILE) $(MFC_EXTRA_ANNO_FILE) &: $(ANNO_FILE)
 	echo "$$mfc_extra_anno_contents" > $(MFC_EXTRA_ANNO_FILE)
-	jq -s '[.[][]]' $(ANNO_FILE) $(MFC_EXTRA_ANNO_FILE) > $(EXTRA_ANNO_FILE)
+	jq -s '[.[][]]' $(ANNO_FILE) $(MFC_EXTRA_ANNO_FILE) > $(FINAL_ANNO_FILE)
 
 .PHONY: firrtl
 firrtl: $(FIRRTL_FILE) $(FINAL_ANNO_FILE)
@@ -192,10 +192,6 @@ ifeq (,$(ENABLE_YOSYS_FLOW))
 else
 	echo "$(MFC_BASE_LOWERING_OPTIONS),disallowPackedArrays" > $@
 endif
-
-$(FINAL_ANNO_FILE): $(EXTRA_ANNO_FILE)
-	cat $(EXTRA_ANNO_FILE) > $@
-	touch $@
 
 $(SFC_MFC_TARGETS) &: $(TAPEOUT_CLASSPATH_TARGETS) $(FIRRTL_FILE) $(FINAL_ANNO_FILE) $(MFC_LOWERING_OPTIONS)
 	rm -rf $(GEN_COLLATERAL_DIR)

--- a/common.mk
+++ b/common.mk
@@ -16,7 +16,6 @@ HELP_COMPILATION_VARIABLES += \
 "   EXTRA_SIM_LDFLAGS         = additional LDFLAGS for building simulators" \
 "   EXTRA_SIM_SOURCES         = additional simulation sources needed for simulator" \
 "   EXTRA_SIM_REQS            = additional make requirements to build the simulator" \
-"   ENABLE_CUSTOM_FIRRTL_PASS = if set, enable custom firrtl passes (SFC lowers to LowFIRRTL & MFC converts to Verilog)" \
 "   ENABLE_YOSYS_FLOW         = if set, add compilation flags to enable the vlsi flow for yosys(tutorial flow)" \
 "   EXTRA_CHISEL_OPTIONS      = additional options to pass to the Chisel compiler" \
 "   EXTRA_BASE_FIRRTL_OPTIONS = additional options to pass to the Scala FIRRTL compiler" \
@@ -200,20 +199,13 @@ MFC_BASE_LOWERING_OPTIONS ?= emittedLineLength=2048,noAlwaysComb,disallowLocalVa
 # compiles Chisel to CHIRRTL, and MFC compiles CHIRRTL to Verilog. Otherwise,
 # when custom FIRRTL transforms are included
 # SFC compiles Chisel to LowFIRRTL and MFC compiles it to Verilog.
-# Users can indicate to the Makefile of custom FIRRTL transforms by setting the
-# "ENABLE_CUSTOM_FIRRTL_PASS" variable.
 #
 # hack: when using dontTouch, io.cpu annotations are not removed by SFC,
 # hence we remove them manually by using jq before passing them to firtool
 
 $(SFC_LEVEL) $(EXTRA_FIRRTL_OPTIONS) &: $(FIRRTL_FILE)
-ifeq (,$(ENABLE_CUSTOM_FIRRTL_PASS))
 	echo none > $(SFC_LEVEL)
 	echo "$(EXTRA_BASE_FIRRTL_OPTIONS)" > $(EXTRA_FIRRTL_OPTIONS)
-else
-	echo low > $(SFC_LEVEL)
-	echo "$(EXTRA_BASE_FIRRTL_OPTIONS)" "$(SFC_REPL_SEQ_MEM)" > $(EXTRA_FIRRTL_OPTIONS)
-endif
 
 $(MFC_LOWERING_OPTIONS):
 	mkdir -p $(dir $@)

--- a/common.mk
+++ b/common.mk
@@ -202,7 +202,9 @@ $(SFC_MFC_TARGETS) &: $(TAPEOUT_CLASSPATH_TARGETS) $(FIRRTL_FILE) $(FINAL_ANNO_F
 		--input-file $(FIRRTL_FILE) \
 		--annotation-file $(FINAL_ANNO_FILE) \
 		--log-level $(FIRRTL_LOGLEVEL) \
+		-X none \
 		--allow-unrecognized-annotations)
+	-mv $(SFC_FIRRTL_BASENAME).lo.fir $(SFC_FIRRTL_FILE)
 	firtool \
 		--format=fir \
 		--export-module-hierarchy \

--- a/common.mk
+++ b/common.mk
@@ -159,19 +159,10 @@ define mfc_extra_anno_contents
 	}
 ]
 endef
-define sfc_extra_low_transforms_anno_contents
-[
-	{
-		"class": "firrtl.stage.RunFirrtlTransformAnnotation",
-		"transform": "tapeout.transforms.ExtraLowTransforms"
-	}
-]
-endef
 export mfc_extra_anno_contents
 export sfc_extra_low_transforms_anno_contents
-$(EXTRA_ANNO_FILE) $(MFC_EXTRA_ANNO_FILE) $(SFC_EXTRA_ANNO_FILE) &: $(ANNO_FILE)
+$(EXTRA_ANNO_FILE) $(MFC_EXTRA_ANNO_FILE) &: $(ANNO_FILE)
 	echo "$$mfc_extra_anno_contents" > $(MFC_EXTRA_ANNO_FILE)
-	echo "$$sfc_extra_low_transforms_anno_contents" > $(SFC_EXTRA_ANNO_FILE)
 	jq -s '[.[][]]' $(ANNO_FILE) $(MFC_EXTRA_ANNO_FILE) > $(EXTRA_ANNO_FILE)
 
 .PHONY: firrtl
@@ -202,7 +193,7 @@ else
 	echo "$(MFC_BASE_LOWERING_OPTIONS),disallowPackedArrays" > $@
 endif
 
-$(FINAL_ANNO_FILE): $(EXTRA_ANNO_FILE) $(SFC_EXTRA_ANNO_FILE)
+$(FINAL_ANNO_FILE): $(EXTRA_ANNO_FILE)
 	cat $(EXTRA_ANNO_FILE) > $@
 	touch $@
 

--- a/docs/Customization/Firrtl-Transforms.rst
+++ b/docs/Customization/Firrtl-Transforms.rst
@@ -12,7 +12,7 @@ The Scala FIRRTL Compiler and the MLIR FIRRTL Compiler
 ------------------------------------------------------
 In Chipyard, two FIRRTL compilers work together to compile Chisel into Verilog. The Scala FIRRTL compiler (SFC) and the MLIR FIRRTL compiler (MFC).
 They are basically doing the same thing, except that MFC is written in C++ which makes compilation much faster (the generated Verilog will be different). In the default setting, the SFC will compile Chisel into CHIRRTL and MFC will
-compile CHIRRTL into Verilog (as of now, we are using SFC as a backup for cases when MFC doesn't work, e.g., when the design is using Fixed types). By setting the ``ENABLE_CUSTOM_FIRRTL_PASS`` env variable to a non-zero value,
+compile CHIRRTL into Verilog. By setting the ``ENABLE_CUSTOM_FIRRTL_PASS`` env variable to a non-zero value,
 we can make the SFC compile Chisel into LowFIRRTL so that our custom FIRRTL passes are applied.
 
 For more information on MLIR FIRRTL Compiler, please visit https://mlir.llvm.org/ and https://circt.llvm.org/.

--- a/docs/Customization/Firrtl-Transforms.rst
+++ b/docs/Customization/Firrtl-Transforms.rst
@@ -8,11 +8,9 @@ modify Chisel-elaborated RTL.
 As mentioned in Section :ref:`Tools/FIRRTL:firrtl`, transforms are modifications that happen on the FIRRTL IR that can modify a circuit.
 Transforms are a powerful tool to take in the FIRRTL IR that is emitted from Chisel and run analysis or convert the circuit into a new form.
 
-The Scala FIRRTL Compiler and the MLIR FIRRTL Compiler
+The MLIR FIRRTL Compiler
 ------------------------------------------------------
-In Chipyard, two FIRRTL compilers work together to compile Chisel into Verilog. The Scala FIRRTL compiler (SFC) and the MLIR FIRRTL compiler (MFC).
-They are basically doing the same thing, except that MFC is written in C++ which makes compilation much faster (the generated Verilog will be different). In the default setting, the SFC will compile Chisel into CHIRRTL and MFC will
-compile CHIRRTL into Verilog.
+In Chipyard, the LLVM-based MLIR FIRRTL compiler (CIRCT or MFC) compiles Chisel into Verilog.
 
 For more information on MLIR FIRRTL Compiler, please visit https://mlir.llvm.org/ and https://circt.llvm.org/.
 

--- a/docs/Customization/Firrtl-Transforms.rst
+++ b/docs/Customization/Firrtl-Transforms.rst
@@ -12,8 +12,7 @@ The Scala FIRRTL Compiler and the MLIR FIRRTL Compiler
 ------------------------------------------------------
 In Chipyard, two FIRRTL compilers work together to compile Chisel into Verilog. The Scala FIRRTL compiler (SFC) and the MLIR FIRRTL compiler (MFC).
 They are basically doing the same thing, except that MFC is written in C++ which makes compilation much faster (the generated Verilog will be different). In the default setting, the SFC will compile Chisel into CHIRRTL and MFC will
-compile CHIRRTL into Verilog. By setting the ``ENABLE_CUSTOM_FIRRTL_PASS`` env variable to a non-zero value,
-we can make the SFC compile Chisel into LowFIRRTL so that our custom FIRRTL passes are applied.
+compile CHIRRTL into Verilog.
 
 For more information on MLIR FIRRTL Compiler, please visit https://mlir.llvm.org/ and https://circt.llvm.org/.
 

--- a/variables.mk
+++ b/variables.mk
@@ -228,7 +228,6 @@ sim_files              ?= $(build_dir)/sim_files.f
 # single file that contains all files needed for VCS or Verilator simulation (unique and without .h's)
 sim_common_files       ?= $(build_dir)/sim_files.common.f
 
-EXTRA_FIRRTL_OPTIONS ?= $(build_dir)/.extra_firrtl_options
 MFC_LOWERING_OPTIONS ?= $(build_dir)/.mfc_lowering_options
 
 #########################################################################################

--- a/variables.mk
+++ b/variables.mk
@@ -170,7 +170,6 @@ TAPEOUT_CLASSPATH_TARGETS ?= $(subst :, ,$(TAPEOUT_CLASSPATH))
 # chisel generated outputs
 FIRRTL_FILE ?= $(build_dir)/$(long_name).fir
 ANNO_FILE   ?= $(build_dir)/$(long_name).anno.json
-EXTRA_ANNO_FILE ?= $(build_dir)/$(long_name).extra.anno.json
 CHISEL_LOG_FILE ?= $(build_dir)/$(long_name).chisel.log
 
 # chisel anno modification output

--- a/variables.mk
+++ b/variables.mk
@@ -193,7 +193,6 @@ MFC_TOP_SMEMS_JSON = $(GEN_COLLATERAL_DIR)/metadata/seq_mems.json
 MFC_MODEL_SMEMS_JSON = $(GEN_COLLATERAL_DIR)/metadata/tb_seq_mems.json
 
 # macrocompiler smems in/output
-SFC_SMEMS_CONF ?= $(build_dir)/$(long_name).sfc.mems.conf
 TOP_SMEMS_CONF ?= $(build_dir)/$(long_name).top.mems.conf
 TOP_SMEMS_FILE ?= $(GEN_COLLATERAL_DIR)/$(long_name).top.mems.v
 TOP_SMEMS_FIR  ?= $(build_dir)/$(long_name).top.mems.fir

--- a/variables.mk
+++ b/variables.mk
@@ -180,7 +180,6 @@ FINAL_ANNO_FILE ?= $(build_dir)/$(long_name).appended.anno.json
 # scala firrtl compiler (sfc) outputs
 SFC_FIRRTL_BASENAME ?= $(build_dir)/$(long_name).sfc
 SFC_FIRRTL_FILE ?= $(SFC_FIRRTL_BASENAME).fir
-SFC_EXTRA_ANNO_FILE ?= $(build_dir)/$(long_name).extrasfc.anno.json
 SFC_ANNO_FILE ?= $(build_dir)/$(long_name).sfc.anno.json
 
 # firtool compiler outputs

--- a/variables.mk
+++ b/variables.mk
@@ -228,7 +228,6 @@ sim_files              ?= $(build_dir)/sim_files.f
 # single file that contains all files needed for VCS or Verilator simulation (unique and without .h's)
 sim_common_files       ?= $(build_dir)/sim_files.common.f
 
-SFC_LEVEL ?= $(build_dir)/.sfc_level
 EXTRA_FIRRTL_OPTIONS ?= $(build_dir)/.extra_firrtl_options
 MFC_LOWERING_OPTIONS ?= $(build_dir)/.mfc_lowering_options
 


### PR DESCRIPTION
Fixed types are never generated now. Custom SFC passes/flags are not known to be used. Preps the way for chisel6

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
