### PR TITLE
Update MultiHarnessBinders to connect differently typed ports + Ignore TLMonitors on DigitalTop scope

### DIFF
--- a/generators/chipyard/src/main/scala/System.scala
+++ b/generators/chipyard/src/main/scala/System.scala
@@ -80,9 +80,10 @@ trait CanHaveMasterTLMemPort { this: BaseSubsystem =>
     }
   }).toList.flatten)
 
+  // disable inwards monitors from node since the class with this trait (i.e. DigitalTop)
+  // doesn't provide an implicit clock to those monitors
   mbus.coupleTo(s"memory_controller_port_named_$portName") {
-    (memTLNode
-      :*= TLBuffer()
+    (DisableMonitors { implicit p => memTLNode :*= TLBuffer() }
       :*= TLSourceShrinker(1 << idBits)
       :*= TLWidthWidget(mbus.beatBytes)
       :*= _)


### PR DESCRIPTION
- Fixes issue where MultiHarnessBinders couldn't attach two ports of a different type. This matters cases where a the `Port` object might be slightly different from source to sink. 
- Fixes case where `TLMonitor` might not get an implicit clock from the `DigitalTop` module causing an obscure error during elaboration. This fix isn't needed for the AXI4 ports since there is no AXI4 monitor implementation in RC yet, thus no monitors are created for them.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
