### PR TITLE
Fix classpath_cache bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -324,6 +324,6 @@ lazy val fpga_shells = (project in file("./fpga/fpga-shells"))
   .settings(libraryDependencies ++= rocketLibDeps.value)
   .settings(commonSettings)
 
-lazy val fpga_platforms = (project in file("./fpga"))
+lazy val chipyard_fpga = (project in file("./fpga"))
   .dependsOn(chipyard, fpga_shells)
   .settings(commonSettings)

--- a/common.mk
+++ b/common.mk
@@ -119,13 +119,13 @@ $(BOOTROM_TARGETS): $(build_dir)/bootrom.%.img: $(TESTCHIP_RSRCS_DIR)/testchipip
 #########################################################################################
 # compile scala jars
 #########################################################################################
-$(CHIPYARD_CLASSPATH) &: $(CHIPYARD_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(CHIPYARD_VLOG_SOURCES)
+$(GENERATOR_CLASSPATH) &: $(CHIPYARD_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(CHIPYARD_VLOG_SOURCES)
 	$(CHECK_SUBMODULES_COMMAND)
 	mkdir -p $(dir $@)
-	$(call run_sbt_assembly,$(SBT_PROJECT),$(CHIPYARD_CLASSPATH))
+	$(call run_sbt_assembly,$(SBT_PROJECT),$(GENERATOR_CLASSPATH))
 
 # order only dependency between sbt runs needed to avoid concurrent sbt runs
-$(TAPEOUT_CLASSPATH) &: $(TAPEOUT_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(TAPEOUT_VLOG_SOURCES) | $(CHIPYARD_CLASSPATH)
+$(TAPEOUT_CLASSPATH) &: $(TAPEOUT_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(TAPEOUT_VLOG_SOURCES) | $(GENERATOR_CLASSPATH)
 	mkdir -p $(dir $@)
 	$(call run_sbt_assembly,tapeout,$(TAPEOUT_CLASSPATH))
 
@@ -133,9 +133,9 @@ $(TAPEOUT_CLASSPATH) &: $(TAPEOUT_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(TAPEO
 # verilog generation pipeline
 #########################################################################################
 # AG: must re-elaborate if cva6 sources have changed... otherwise just run firrtl compile
-$(FIRRTL_FILE) $(ANNO_FILE) $(CHISEL_LOG_FILE) &: $(CHIPYARD_CLASSPATH) $(EXTRA_GENERATOR_REQS)
+$(FIRRTL_FILE) $(ANNO_FILE) $(CHISEL_LOG_FILE) &: $(GENERATOR_CLASSPATH) $(EXTRA_GENERATOR_REQS)
 	mkdir -p $(build_dir)
-	(set -o pipefail && $(call run_jar_scala_main,$(CHIPYARD_CLASSPATH),$(GENERATOR_PACKAGE).Generator,\
+	(set -o pipefail && $(call run_jar_scala_main,$(GENERATOR_CLASSPATH),$(GENERATOR_PACKAGE).Generator,\
 		--target-dir $(build_dir) \
 		--name $(long_name) \
 		--top-module $(MODEL_PACKAGE).$(MODEL) \

--- a/common.mk
+++ b/common.mk
@@ -119,13 +119,13 @@ $(BOOTROM_TARGETS): $(build_dir)/bootrom.%.img: $(TESTCHIP_RSRCS_DIR)/testchipip
 #########################################################################################
 # compile scala jars
 #########################################################################################
-$(CHIPYARD_CLASSPATH_TARGETS) &: $(CHIPYARD_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(CHIPYARD_VLOG_SOURCES)
+$(CHIPYARD_CLASSPATH) &: $(CHIPYARD_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(CHIPYARD_VLOG_SOURCES)
 	$(CHECK_SUBMODULES_COMMAND)
 	mkdir -p $(dir $@)
 	$(call run_sbt_assembly,$(SBT_PROJECT),$(CHIPYARD_CLASSPATH))
 
 # order only dependency between sbt runs needed to avoid concurrent sbt runs
-$(TAPEOUT_CLASSPATH_TARGETS) &: $(TAPEOUT_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(TAPEOUT_VLOG_SOURCES) | $(CHIPYARD_CLASSPATH_TARGETS)
+$(TAPEOUT_CLASSPATH) &: $(TAPEOUT_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS) $(TAPEOUT_VLOG_SOURCES) | $(CHIPYARD_CLASSPATH)
 	mkdir -p $(dir $@)
 	$(call run_sbt_assembly,tapeout,$(TAPEOUT_CLASSPATH))
 
@@ -133,7 +133,7 @@ $(TAPEOUT_CLASSPATH_TARGETS) &: $(TAPEOUT_SCALA_SOURCES) $(SCALA_BUILDTOOL_DEPS)
 # verilog generation pipeline
 #########################################################################################
 # AG: must re-elaborate if cva6 sources have changed... otherwise just run firrtl compile
-$(FIRRTL_FILE) $(ANNO_FILE) $(CHISEL_LOG_FILE) &: $(CHIPYARD_CLASSPATH_TARGETS) $(EXTRA_GENERATOR_REQS)
+$(FIRRTL_FILE) $(ANNO_FILE) $(CHISEL_LOG_FILE) &: $(CHIPYARD_CLASSPATH) $(EXTRA_GENERATOR_REQS)
 	mkdir -p $(build_dir)
 	(set -o pipefail && $(call run_jar_scala_main,$(CHIPYARD_CLASSPATH),$(GENERATOR_PACKAGE).Generator,\
 		--target-dir $(build_dir) \
@@ -242,12 +242,12 @@ $(TOP_SMEMS_CONF) $(MODEL_SMEMS_CONF) &:  $(MFC_SMEMS_CONF) $(MFC_MODEL_HRCHY_JS
 
 # This file is for simulation only. VLSI flows should replace this file with one containing hard SRAMs
 TOP_MACROCOMPILER_MODE ?= --mode synflops
-$(TOP_SMEMS_FILE) $(TOP_SMEMS_FIR) &: $(TAPEOUT_CLASSPATH_TARGETS) $(TOP_SMEMS_CONF)
+$(TOP_SMEMS_FILE) $(TOP_SMEMS_FIR) &: $(TAPEOUT_CLASSPATH) $(TOP_SMEMS_CONF)
 	$(call run_jar_scala_main,$(TAPEOUT_CLASSPATH),tapeout.macros.MacroCompiler,-n $(TOP_SMEMS_CONF) -v $(TOP_SMEMS_FILE) -f $(TOP_SMEMS_FIR) $(TOP_MACROCOMPILER_MODE))
 	touch $(TOP_SMEMS_FILE) $(TOP_SMEMS_FIR)
 
 MODEL_MACROCOMPILER_MODE = --mode synflops
-$(MODEL_SMEMS_FILE) $(MODEL_SMEMS_FIR) &: $(TAPEOUT_CLASSPATH_TARGETS) $(MODEL_SMEMS_CONF)
+$(MODEL_SMEMS_FILE) $(MODEL_SMEMS_FIR) &: $(TAPEOUT_CLASSPATH) $(MODEL_SMEMS_CONF)
 	$(call run_jar_scala_main,$(TAPEOUT_CLASSPATH),tapeout.macros.MacroCompiler, -n $(MODEL_SMEMS_CONF) -v $(MODEL_SMEMS_FILE) -f $(MODEL_SMEMS_FIR) $(MODEL_MACROCOMPILER_MODE))
 	touch $(MODEL_SMEMS_FILE) $(MODEL_SMEMS_FIR)
 

--- a/docs/Prototyping/General.rst
+++ b/docs/Prototyping/General.rst
@@ -30,7 +30,7 @@ For example:
 
     # converts to
 
-    make SBT_PROJECT=fpga_platforms MODEL=VCU118FPGATestHarness VLOG_MODEL=VCU118FPGATestHarness MODEL_PACKAGE=chipyard.fpga.vcu118 CONFIG=RocketVCU118Config CONFIG_PACKAGE=chipyard.fpga.vcu118 GENERATOR_PACKAGE=chipyard TB=none TOP=ChipTop BOARD=vcu118 FPGA_BRAND=... bitstream
+    make SBT_PROJECT=chipyard_fpga MODEL=VCU118FPGATestHarness VLOG_MODEL=VCU118FPGATestHarness MODEL_PACKAGE=chipyard.fpga.vcu118 CONFIG=RocketVCU118Config CONFIG_PACKAGE=chipyard.fpga.vcu118 GENERATOR_PACKAGE=chipyard TB=none TOP=ChipTop BOARD=vcu118 FPGA_BRAND=... bitstream
 
 Some ``SUB_PROJECT`` defaults are already defined for use, including ``vcu118`` and ``arty``.
 These default ``SUB_PROJECT``'s setup the necessary test harnesses, packages, and more for the Chipyard make system.

--- a/fpga/Makefile
+++ b/fpga/Makefile
@@ -17,7 +17,7 @@ sim_name := none
 SUB_PROJECT ?= vcu118
 
 ifeq ($(SUB_PROJECT),vc707)
-	SBT_PROJECT       ?= fpga_platforms
+	SBT_PROJECT       ?= chipyard_fpga
 	MODEL             ?= VC707FPGATestHarness
 	VLOG_MODEL        ?= VC707FPGATestHarness
 	MODEL_PACKAGE     ?= chipyard.fpga.vc707
@@ -31,7 +31,7 @@ ifeq ($(SUB_PROJECT),vc707)
 endif
 
 ifeq ($(SUB_PROJECT),vcu118)
-	SBT_PROJECT       ?= fpga_platforms
+	SBT_PROJECT       ?= chipyard_fpga
 	MODEL             ?= VCU118FPGATestHarness
 	VLOG_MODEL        ?= VCU118FPGATestHarness
 	MODEL_PACKAGE     ?= chipyard.fpga.vcu118
@@ -45,7 +45,7 @@ ifeq ($(SUB_PROJECT),vcu118)
 endif
 
 ifeq ($(SUB_PROJECT),nexysvideo)
-	SBT_PROJECT       ?= fpga_platforms
+	SBT_PROJECT       ?= chipyard_fpga
 	MODEL             ?= NexysVideoHarness
 	VLOG_MODEL        ?= NexysVideoHarness
 	MODEL_PACKAGE     ?= chipyard.fpga.nexysvideo
@@ -60,7 +60,7 @@ endif
 
 ifeq ($(SUB_PROJECT),arty35t)
 	# TODO: Fix with Arty
-	SBT_PROJECT       ?= fpga_platforms
+	SBT_PROJECT       ?= chipyard_fpga
 	MODEL             ?= Arty35THarness
 	VLOG_MODEL        ?= Arty35THarness
 	MODEL_PACKAGE     ?= chipyard.fpga.arty
@@ -74,7 +74,7 @@ ifeq ($(SUB_PROJECT),arty35t)
 endif
 ifeq ($(SUB_PROJECT),arty100t)
 	# TODO: Fix with Arty
-	SBT_PROJECT       ?= fpga_platforms
+	SBT_PROJECT       ?= chipyard_fpga
 	MODEL             ?= Arty100THarness
 	VLOG_MODEL        ?= Arty100THarness
 	MODEL_PACKAGE     ?= chipyard.fpga.arty100t

--- a/variables.mk
+++ b/variables.mk
@@ -160,8 +160,8 @@ endif
 
 # classpaths
 CLASSPATH_CACHE ?= $(base_dir)/.classpath_cache
-# The chipyard classpath must contain the Generator main
-CHIPYARD_CLASSPATH ?= $(CLASSPATH_CACHE)/$(SBT_PROJECT).jar
+# The generator classpath must contain the Generator main
+GENERATOR_CLASSPATH ?= $(CLASSPATH_CACHE)/$(SBT_PROJECT).jar
 # The tapeout classpath must contain MacroCompiler
 TAPEOUT_CLASSPATH ?= $(CLASSPATH_CACHE)/tapeout.jar
 

--- a/variables.mk
+++ b/variables.mk
@@ -160,7 +160,9 @@ endif
 
 # classpaths
 CLASSPATH_CACHE ?= $(base_dir)/.classpath_cache
-CHIPYARD_CLASSPATH ?= $(CLASSPATH_CACHE)/chipyard.jar
+# The chipyard classpath must contain the Generator main
+CHIPYARD_CLASSPATH ?= $(CLASSPATH_CACHE)/$(SBT_PROJECT).jar
+# The tapeout classpath must contain MacroCompiler
 TAPEOUT_CLASSPATH ?= $(CLASSPATH_CACHE)/tapeout.jar
 
 # chisel generated outputs

--- a/variables.mk
+++ b/variables.mk
@@ -162,9 +162,6 @@ endif
 CLASSPATH_CACHE ?= $(base_dir)/.classpath_cache
 CHIPYARD_CLASSPATH ?= $(CLASSPATH_CACHE)/chipyard.jar
 TAPEOUT_CLASSPATH ?= $(CLASSPATH_CACHE)/tapeout.jar
-# if *_CLASSPATH is a true java classpath, it can be colon-delimited list of paths (on *nix)
-CHIPYARD_CLASSPATH_TARGETS ?= $(subst :, ,$(CHIPYARD_CLASSPATH))
-TAPEOUT_CLASSPATH_TARGETS ?= $(subst :, ,$(TAPEOUT_CLASSPATH))
 
 # chisel generated outputs
 FIRRTL_FILE ?= $(build_dir)/$(long_name).fir


### PR DESCRIPTION
Previously, the chipyard.jar cache was built with SBT_PROJECT (usually chipyard) as the top-level project. This causes a bug where after building the jar with SBT_PROJECT=chipyard, future fpga compilations (with SBT_PROJECT=fpga_platforms) would fail due to not rebuilding the cache.

This PR updates the build system to build a separate jar for the fpga flow that includes the fpga-specific sources.

This renames `fpga_platforms` to `chipyard_fpga` to make it clearer that that project is an extension of chipyard with fpga configs.

This renames `CHIPYARD_CLASSPATH` to `GENERATOR_CLASSPATH` to make it clearer that the this classpath must contain a `Generator` main to run, but it does not have to be the chipyard project in build.sbt

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
