### PR TITLE
Fix clock name and macro paths for Sky130 VLSI flow

### DIFF
--- a/vlsi/example-asap7.yml
+++ b/vlsi/example-asap7.yml
@@ -17,7 +17,7 @@ vlsi.inputs.power_spec_type: "cpf"
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_uncore_clock", period: "1ns", uncertainty: "0.1ns"}
+  {name: "clock_uncore", period: "1ns", uncertainty: "0.1ns"}
 ]
 
 # Generate Make include to aid in flow

--- a/vlsi/example-design.yml
+++ b/vlsi/example-design.yml
@@ -10,7 +10,7 @@ vlsi.inputs.power_spec_type: "cpf"
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_uncore_clock", period: "2ns", uncertainty: "0.1ns"}
+  {name: "clock_uncore", period: "2ns", uncertainty: "0.1ns"}
 ]
 
 # Specify pin properties

--- a/vlsi/example-designs/sky130-commercial.yml
+++ b/vlsi/example-designs/sky130-commercial.yml
@@ -2,7 +2,7 @@
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_uncore_clock", period: "30ns", uncertainty: "2ns"}
+  {name: "clock_uncore", period: "30ns", uncertainty: "2ns"}
 ]
 
 # Placement Constraints

--- a/vlsi/example-designs/sky130-openroad-rockettile.yml
+++ b/vlsi/example-designs/sky130-openroad-rockettile.yml
@@ -1,7 +1,7 @@
 # Override configurations in ../example-sky130.yml and example-designs
 
 # Specify clock signals
-# Rocket/RocketTile names clock signal "clock" instead of "clock_uncore_clock"
+# Rocket/RocketTile names clock signal "clock" instead of "clock_uncore"
 vlsi.inputs.clocks: [
   {name: "clock", period: "30ns", uncertainty: "3ns"}
 ]
@@ -22,7 +22,7 @@ vlsi.inputs.placement_constraints:
       bottom: 10
 
   # Place SRAM memory instances
-    # data cache
+  # data cache
   - path: "RocketTile/dcache/data/data_arrays_0/data_arrays_0_ext/mem_0_0"
     type: hardmacro
     x: 50
@@ -47,3 +47,4 @@ vlsi.inputs.placement_constraints:
     x: 50
     y: 2100
     orientation: r90
+

--- a/vlsi/example-designs/sky130-openroad.yml
+++ b/vlsi/example-designs/sky130-openroad.yml
@@ -3,7 +3,7 @@
 # Specify clock signals
 # Relax the clock period for OpenROAD to meet timing
 vlsi.inputs.clocks: [
-  {name: "clock_uncore_clock", period: "50ns", uncertainty: "2ns"}
+  {name: "clock_uncore", period: "50ns", uncertainty: "2ns"}
 ]
 
 # Flow parameters that yield a routable design with reasonable timing
@@ -54,36 +54,27 @@ vlsi.inputs.placement_constraints:
       bottom: 10
 
   # Place SRAM memory instances
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/dcache/data/data_arrays_0_0/data_arrays_0_0_ext/mem_0_0"
+  # data cache
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/dcache/data/data_arrays_0/data_arrays_0_ext/mem_0_0"
     type: hardmacro
     x: 50
     y: 50
     orientation: r90
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/dcache/data/data_arrays_0_1/data_arrays_0_0_ext/mem_0_0"
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/dcache/data/data_arrays_0/data_arrays_0_ext/mem_1_0"
     type: hardmacro
     x: 50
-    y: 450
-    orientation: r90
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/dcache/data/data_arrays_0_2/data_arrays_0_0_ext/mem_0_0"
-    type: hardmacro
-    x: 50
-    y: 850
-    orientation: r90
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/dcache/data/data_arrays_0_3/data_arrays_0_0_ext/mem_0_0"
-    type: hardmacro
-    x: 50
-    y: 1250
+    y: 800
     orientation: r90
 
   # tag array
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/frontend/icache/tag_array_0/tag_array_0_ext/mem_0_0"
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/frontend/icache/tag_array_0/tag_array_0_ext/mem_0_0"
     type: hardmacro
     x: 50
     y: 1600
     orientation: r90
 
   # instruction cache
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/frontend/icache/data_arrays_0_0/data_arrays_0_0_0_ext/mem_0_0"
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/frontend/icache/data_arrays_0_0/data_arrays_0_0_ext/mem_0_0"
     type: hardmacro
     x: 50
     y: 2100

--- a/vlsi/example-designs/sky130-rocket.yml
+++ b/vlsi/example-designs/sky130-rocket.yml
@@ -1,7 +1,7 @@
 # Override configurations in ../example-sky130.yml and example-designs
 
 # Specify clock signals
-# Rocket/RocketTile names clock signal "clock" instead of "clock_uncore_clock"
+# Rocket/RocketTile names clock signal "clock" instead of "clock_uncore"
 vlsi.inputs.clocks: [
   {name: "clock", period: "5ns", uncertainty: "1ns"}
 ]

--- a/vlsi/example-sky130.yml
+++ b/vlsi/example-sky130.yml
@@ -20,7 +20,7 @@ vlsi.inputs.power_spec_type: "cpf"
 
 # Specify clock signals
 vlsi.inputs.clocks: [
-  {name: "clock_uncore_clock", period: "20ns", uncertainty: "1ns"}
+  {name: "clock_uncore", period: "20ns", uncertainty: "1ns"}
 ]
 
 # Generate Make include to aid in flow
@@ -42,27 +42,27 @@ vlsi.inputs.placement_constraints:
       bottom: 10
 
   # Place SRAM memory instances
-    # data cache
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/dcache/data/data_arrays_0/data_arrays_0_ext/mem_0_0"
+  # data cache
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/dcache/data/data_arrays_0/data_arrays_0_ext/mem_0_0"
     type: hardmacro
     x: 50
     y: 50
     orientation: r90
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/dcache/data/data_arrays_0/data_arrays_0_ext/mem_1_0"
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/dcache/data/data_arrays_0/data_arrays_0_ext/mem_1_0"
     type: hardmacro
     x: 50
     y: 800
     orientation: r90
 
   # tag array
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/frontend/icache/tag_array_0/tag_array_0_ext/mem_0_0"
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/frontend/icache/tag_array_0/tag_array_0_ext/mem_0_0"
     type: hardmacro
     x: 50
     y: 1600
     orientation: r90
 
   # instruction cache
-  - path: "ChipTop/system/tile_prci_domain/tile_reset_domain_tile/frontend/icache/data_arrays_0_0/data_arrays_0_0_ext/mem_0_0"
+  - path: "ChipTop/system/tile_prci_domain/element_reset_domain_rockettile/frontend/icache/data_arrays_0_0/data_arrays_0_0_ext/mem_0_0"
     type: hardmacro
     x: 50
     y: 2100


### PR DESCRIPTION
As usual, the clock name and SRAM macro paths have changed in chipyard designs. After these fixes commercial flow works, but OpenROAD is stuck on global placement so another fix is required for that.

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [x] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [x] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
