### PR TITLE
Added new configs and harness binders for the VCU118 to use the UART TSI connection in the same way as the Arty

### DIFF
--- a/fpga/src/main/scala/vcu118/Configs.scala
+++ b/fpga/src/main/scala/vcu118/Configs.scala
@@ -39,6 +39,12 @@ class WithSystemModifications extends Config((site, here, up) => {
   case SerialTLKey => Nil // remove serialized tl port
 })
 
+class WithSystemModificationsBareMetal extends Config((site, here, up) => {
+  case DTSTimebase => BigInt((1e6).toLong)
+  case ExtMem => up(ExtMem, site).map(x => x.copy(master = x.master.copy(size = site(VCU118DDRSize)))) // set extmem to DDR size
+  case SerialTLKey => Nil // remove serialized tl port
+})
+
 // DOC include start: AbstractVCU118 and Rocket
 class WithVCU118Tweaks extends Config(
   // clocking
@@ -63,6 +69,37 @@ class WithVCU118Tweaks extends Config(
   new freechips.rocketchip.subsystem.WithNMemoryChannels(1)
 )
 
+class WithVCU118TweaksBareMetal extends Config(
+  //Support for bare metal UART/TSI programs
+  new WithVCU118UARTTSI ++
+  new testchipip.tsi.WithUARTTSIClient ++
+  // clocking
+  new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
+  new chipyard.clocking.WithPassthroughClockGenerator ++
+  new chipyard.config.WithMemoryBusFrequency(100) ++
+  new chipyard.config.WithSystemBusFrequency(100) ++
+  new chipyard.config.WithControlBusFrequency(100) ++
+  new chipyard.config.WithPeripheryBusFrequency(100) ++
+  new chipyard.config.WithControlBusFrequency(100) ++
+  new WithFPGAFrequency(100) ++ // default 100MHz freq
+  // harness binders
+  new WithUART ++
+  new WithSPISDCard ++
+  new WithDDRMem ++
+  // other configuration
+  new WithDefaultPeripherals ++
+  new chipyard.config.WithTLBackingMemory ++ // use TL backing memory
+  new WithSystemModificationsBareMetal ++ // setup busses, setup ext. mem. size
+  new chipyard.config.WithNoDebug ++ // remove debug module
+  new freechips.rocketchip.subsystem.WithoutTLMonitors ++
+  new freechips.rocketchip.subsystem.WithNMemoryChannels(1)
+)
+
+class RocketVCU118BareMetalConfig extends Config(
+  new WithVCU118TweaksBareMetal ++
+  new chipyard.RocketConfig
+)
+
 class RocketVCU118Config extends Config(
   new WithVCU118Tweaks ++
   new chipyard.RocketConfig
@@ -72,6 +109,12 @@ class RocketVCU118Config extends Config(
 class BoomVCU118Config extends Config(
   new WithFPGAFrequency(50) ++
   new WithVCU118Tweaks ++
+  new chipyard.MegaBoomConfig
+)
+
+class BoomVCU118BareMetalConfig extends Config(
+  new WithFPGAFrequency(50) ++
+  new WithVCU118TweaksBareMetal ++
   new chipyard.MegaBoomConfig
 )
 


### PR DESCRIPTION
Issues: The non-TSI UART pins map to the same as the TSI pins, so I moved them to unused pins on the PMOD connectors, but this required modification of fpga-shells. Also, the LEDs do not work for the TSI connection yet.