### PR TITLE
Add configuration for MegaBoom that uses SimBlockDevice

### DIFF
--- a/generators/chipyard/src/main/scala/config/BoomConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/BoomConfigs.scala
@@ -62,6 +62,12 @@ class dmiMediumBoomV3CosimConfig extends Config(
   new boom.v3.common.WithNMediumBooms(1) ++
   new chipyard.config.AbstractConfig)
 
+class SimBlockDeviceMegaBoomV3Config extends Config(
+  new chipyard.harness.WithSimBlockDevice ++                     // drive block-device IOs with SimBlockDevice
+  new testchipip.iceblk.WithBlockDevice ++                       // add block-device module to peripherybus
+  new boom.v3.common.WithNMegaBooms(1) ++                        // mega boom config
+  new chipyard.config.WithSystemBusWidth(128) ++
+  new chipyard.config.AbstractConfig)
 
 // ---------------------
 // BOOM V4 Configs
@@ -115,4 +121,11 @@ class dmiMediumBoomV4CosimConfig extends Config(
   new chipyard.harness.WithSerialTLTiedOff ++                    // don't attach anythint to serial-tl
   new chipyard.config.WithDMIDTM ++                              // have debug module expose a clocked DMI port
   new boom.v4.common.WithNMediumBooms(1) ++
+  new chipyard.config.AbstractConfig)
+
+class SimBlockDeviceMegaBoomV4Config extends Config(
+  new chipyard.harness.WithSimBlockDevice ++                     // drive block-device IOs with SimBlockDevice
+  new testchipip.iceblk.WithBlockDevice ++                       // add block-device module to peripherybus
+  new boom.v4.common.WithNMegaBooms(1) ++                        // mega boom config
+  new chipyard.config.WithSystemBusWidth(128) ++
   new chipyard.config.AbstractConfig)


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

This PR adds the configuration combining the MegaBoom and SimBlockDevice for running Linux inside Verilator simulation.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [x] Other enhancement

<!-- choose one -->
**Impact**:
- [x] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [x] Did you state the type-of-change/impact?
- [x] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
