### PR TITLE
Add dependabot to auto-update submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  # submit a PR for bumping submodules daily (for selected submodules).
+  # updates a submodule to the latest commit on the branch given in .gitmodules.
+  # if branch not given, then it defaults to the main/master branch.
+  - package-ecosystem: gitsubmodule
+    schedule:
+      interval: "daily"
+    directory: /
+    # ignore certain submodules
+    ignore:
+      - dependency-name: "generators/gemmini"
+      - dependency-name: "generators/rocket-chip"
+      - dependency-name: "generators/rocket-chip-blocks"
+      - dependency-name: "generators/rocket-chip-inclusive-cache"
+      - dependency-name: "toolchains/riscv-tools/riscv-tests"
+      - dependency-name: "toolchains/riscv-tools/riscv-tools-feedstock"


### PR DESCRIPTION
Opening this to spawn discussion on how/should we use this to update submodules. I think this is nice, but we should 1. configure how often it checks for things and 2. what it should update v.s. what we should do ourselves. In any case, the PRs that it opens still have to be manually approved (see FireSims PRs from dependabot: https://github.com/firesim/firesim/pulls)

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
