### PR TITLE
Fix VLSI CI - Fix conda environment creation

### DIFF
--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -98,6 +98,7 @@ jobs:
           source env.sh
           cd sims/verilator
           make verilog
+
       - name: VLSI test
         run: |
           cd ${{ env.REMOTE_WORK_DIR }}
@@ -106,20 +107,23 @@ jobs:
 
           cd vlsi
 
+          # remove extra channels if put in by default (avoid clashing deps)
+          conda config --remove channels litex-hub || true
+          conda config --remove channels defaults || true
+
           # NOTE: most conda installs are in separate conda envs because they mess up
           #   each other's versions (for no apparent reason) and we need the latest versions
-          conda config --add channels defaults
-          conda config --add channels litex-hub
 
           # installs for example-sky130.yml
-          conda create -y --prefix ./.conda-sky130 open_pdks.sky130a=1.0.457_0_g32e8f23
+          conda create -y --prefix ./.conda-sky130   -c defaults -c litex-hub open_pdks.sky130a=1.0.457_0_g32e8f23
           git clone https://github.com/rahulk29/sram22_sky130_macros.git
+          git -C sram22_sky130_macros checkout 1f20d16
 
           # installs for example-openroad.yml
-          conda create -y --prefix ./.conda-yosys yosys=0.27_4_gb58664d44
-          conda create -y --prefix ./.conda-openroad openroad=2.0_7070_g0264023b6
-          conda create -y --prefix ./.conda-klayout klayout=0.28.5_98_g87e2def28
-          conda create -y --prefix ./.conda-signoff magic=8.3.376_0_g5e5879c netgen=1.5.250_0_g178b172
+          conda create -y --prefix ./.conda-yosys    -c defaults -c litex-hub yosys=0.27_4_gb58664d44
+          conda create -y --prefix ./.conda-openroad -c defaults -c litex-hub openroad=2.0_7070_g0264023b6
+          conda create -y --prefix ./.conda-klayout  -c defaults -c litex-hub klayout=0.28.5_98_g87e2def28
+          conda create -y --prefix ./.conda-signoff  -c defaults -c litex-hub magic=8.3.376_0_g5e5879c netgen=1.5.250_0_g178b172
 
           echo "# Tutorial configs" > tutorial.yml
           echo "# pdk" > tutorial.yml
@@ -137,9 +141,6 @@ jobs:
           echo "# speed up tutorial runs & declutter log output" >> tutorial.yml
           echo "par.openroad.timing_driven: false" >> tutorial.yml
           echo "par.openroad.write_reports: false" >> tutorial.yml
-
-          conda config --remove channels litex-hub
-          conda config --remove channels defaults
 
           export tutorial=sky130-openroad
           export EXTRA_CONFS=tutorial.yml


### PR DESCRIPTION
- Pin SRAM macros repo for SKY130 to a specific commit
- Update VLSI CI conda env creation to use specific channels directly instead of modifying the base environment before/after creating new environments. This avoids CI modifying the base conda environment / making it more robust.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
