### PR TITLE
Run CI out of larger scratch directory

### DIFF
--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -15,8 +15,9 @@ defaults:
     shell: bash -leo pipefail {0}
 
 env:
-  REMOTE_WORK_DIR: /tmp/cy-ci-shared/cy-${{ github.sha }}
-  JAVA_TMP_DIR: /tmp/cy-${{ github.sha }}-full
+  # temporary directories should be located in /scratch (since it's larger)
+  REMOTE_WORK_DIR: /scratch/buildbot/cy-ci-shared/cy-workdir-${{ github.sha }}
+  JAVA_TMP_DIR: /scratch/buildbot/cy-ci-shared/cy-javatmpdir-${{ github.sha }}
 
 jobs:
   cancel-prior-workflows:


### PR DESCRIPTION
Fixes issue where CI would run out of disk space on `/tmp`. 

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
