### PR TITLE
Update generate-conda-lockfiles.sh

### DIFF
--- a/scripts/generate-conda-lockfiles.sh
+++ b/scripts/generate-conda-lockfiles.sh
@@ -10,6 +10,11 @@ if [ ! -d "$REQS_DIR" ]; then
   exit 1
 fi
 
+if ! conda-lock --version | grep $(grep "conda-lock" $REQS_DIR/chipyard-base.yaml | sed 's/^ \+-.*=//'); then
+  echo "Invalid conda-lock version, make sure you're calling this script with the sourced chipyard env.sh"
+  exit 1
+fi
+
 for TOOLCHAIN_TYPE in riscv-tools; do
     # note: lock file must end in .conda-lock.yml - see https://github.com/conda-incubator/conda-lock/issues/154
     LOCKFILE=$REQS_DIR/conda-lock-reqs/conda-requirements-$TOOLCHAIN_TYPE-linux-64.conda-lock.yml


### PR DESCRIPTION
Prevent `scripts/generate-conda-lockfiles.sh` from being run without the correct `conda-lock` version. Otherwise, there might be a mismatch in what the lockfile has and what `conda-lock` expects.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?
