### PR TITLE
[cd] Bump CIRCT from firtool-1.75.0 to firtool-1.82.0

### DIFF
--- a/conda-reqs/circt.json
+++ b/conda-reqs/circt.json
@@ -1,3 +1,3 @@
 {
-  "version": "firtool-1.75.0"
+  "version": "firtool-1.82.0"
 }


### PR DESCRIPTION
[cd] Bump CIRCT from firtool-1.75.0 to firtool-1.82.0


This is an automated commit generated by the `circt/update-circt` GitHub
Action.

There were no commits that were cherry-picked from the ci/ci-circt-nightly branch.

#### Release Notes

Bump CIRCT from `firtool-1.75.0` to `firtool-1.82.0`.

Release notes for new CIRCT versions can be found at the following links:

  - [ESIRuntime-0.0.3](null)
  - [ESIRuntime-0.0.4](null)
  - [ESIRuntime-0.0.5](null)
  - [ESIRuntime-0.0.6](null)
  - [ESIRuntime-0.0.7](null)
  - [ESIRuntime-0.0.8](null)
  - [ESIRuntime-0.0.9](null)
  - [firtool-1.75.0](https://github.com/llvm/circt/releases/tag/firtool-1.75.0)
  - [firtool-1.76.0](https://github.com/llvm/circt/releases/tag/firtool-1.76.0)
  - [firtool-1.77.0](https://github.com/llvm/circt/releases/tag/firtool-1.77.0)
  - [firtool-1.78.0](https://github.com/llvm/circt/releases/tag/firtool-1.78.0)
  - [firtool-1.78.1](https://github.com/llvm/circt/releases/tag/firtool-1.78.1)
  - [firtool-1.79.0](https://github.com/llvm/circt/releases/tag/firtool-1.79.0)
  - [firtool-1.80.0](https://github.com/llvm/circt/releases/tag/firtool-1.80.0)
  - [firtool-1.80.1](https://github.com/llvm/circt/releases/tag/firtool-1.80.1)
  - [firtool-1.81.0](https://github.com/llvm/circt/releases/tag/firtool-1.81.0)
  - [firtool-1.81.1](https://github.com/llvm/circt/releases/tag/firtool-1.81.1)
  - [firtool-1.82.0](https://github.com/llvm/circt/releases/tag/firtool-1.82.0)
  - [pycde-0.4.0](null)
  - [pycde-0.5.0](null)
  - [pycde-0.5.1](null)
