### PR TITLE
Add WithUniformBusFrequencies | Fix UARTTSI HarnessBinder

### DIFF
--- a/fpga/src/main/scala/arty/Configs.scala
+++ b/fpga/src/main/scala/arty/Configs.scala
@@ -24,7 +24,7 @@ class WithArtyTweaks extends Config(
 
   new chipyard.harness.WithHarnessBinderClockFreqMHz(32) ++
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
-  new chipyard.config.WithUniformBusFrequency(32) ++
+  new chipyard.config.WithUniformBusFrequencies(32) ++
   new testchipip.serdes.WithNoSerialTL ++
   new testchipip.soc.WithNoScratchpads
 )

--- a/fpga/src/main/scala/arty/Configs.scala
+++ b/fpga/src/main/scala/arty/Configs.scala
@@ -24,11 +24,7 @@ class WithArtyTweaks extends Config(
 
   new chipyard.harness.WithHarnessBinderClockFreqMHz(32) ++
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
-  new chipyard.config.WithSystemBusFrequency(32) ++
-  new chipyard.config.WithFrontBusFrequency(32) ++
-  new chipyard.config.WithControlBusFrequency(32) ++
-  new chipyard.config.WithPeripheryBusFrequency(32) ++
-  new chipyard.config.WithControlBusFrequency(32) ++
+  new chipyard.config.WithUniformBusFrequency(32) ++
   new testchipip.serdes.WithNoSerialTL ++
   new testchipip.soc.WithNoScratchpads
 )

--- a/fpga/src/main/scala/arty100t/Configs.scala
+++ b/fpga/src/main/scala/arty100t/Configs.scala
@@ -33,12 +33,7 @@ class WithArty100TTweaks(freqMHz: Double = 50) extends Config(
   new testchipip.tsi.WithUARTTSIClient ++
   new chipyard.harness.WithSerialTLTiedOff ++
   new chipyard.harness.WithHarnessBinderClockFreqMHz(freqMHz) ++
-  new chipyard.config.WithMemoryBusFrequency(freqMHz) ++
-  new chipyard.config.WithFrontBusFrequency(freqMHz) ++
-  new chipyard.config.WithSystemBusFrequency(freqMHz) ++
-  new chipyard.config.WithPeripheryBusFrequency(freqMHz) ++
-  new chipyard.config.WithControlBusFrequency(freqMHz) ++
-  new chipyard.config.WithOffchipBusFrequency(freqMHz) ++
+  new chipyard.config.WithUniformBusFrequency(freqMHz) ++
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
   new chipyard.config.WithTLBackingMemory ++ // FPGA-shells converts the AXI to TL for us

--- a/fpga/src/main/scala/arty100t/Configs.scala
+++ b/fpga/src/main/scala/arty100t/Configs.scala
@@ -33,7 +33,7 @@ class WithArty100TTweaks(freqMHz: Double = 50) extends Config(
   new testchipip.tsi.WithUARTTSIClient ++
   new chipyard.harness.WithSerialTLTiedOff ++
   new chipyard.harness.WithHarnessBinderClockFreqMHz(freqMHz) ++
-  new chipyard.config.WithUniformBusFrequency(freqMHz) ++
+  new chipyard.config.WithUniformBusFrequencies(freqMHz) ++
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
   new chipyard.config.WithTLBackingMemory ++ // FPGA-shells converts the AXI to TL for us

--- a/fpga/src/main/scala/nexysvideo/Configs.scala
+++ b/fpga/src/main/scala/nexysvideo/Configs.scala
@@ -29,7 +29,7 @@ class WithNexysVideoTweaks(freqMHz: Double = 50) extends Config(
   new testchipip.tsi.WithUARTTSIClient ++
   new chipyard.harness.WithSerialTLTiedOff ++
   new chipyard.harness.WithHarnessBinderClockFreqMHz(freqMHz) ++
-  new chipyard.config.WithUniformBusFrequency(freqMHz) ++
+  new chipyard.config.WithUniformBusFrequencies(freqMHz) ++
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
   new chipyard.config.WithNoDebug ++ // no jtag

--- a/fpga/src/main/scala/nexysvideo/Configs.scala
+++ b/fpga/src/main/scala/nexysvideo/Configs.scala
@@ -29,12 +29,7 @@ class WithNexysVideoTweaks(freqMHz: Double = 50) extends Config(
   new testchipip.tsi.WithUARTTSIClient ++
   new chipyard.harness.WithSerialTLTiedOff ++
   new chipyard.harness.WithHarnessBinderClockFreqMHz(freqMHz) ++
-  new chipyard.config.WithMemoryBusFrequency(freqMHz) ++
-  new chipyard.config.WithFrontBusFrequency(freqMHz) ++
-  new chipyard.config.WithSystemBusFrequency(freqMHz) ++
-  new chipyard.config.WithPeripheryBusFrequency(freqMHz) ++
-  new chipyard.config.WithControlBusFrequency(freqMHz) ++
-  new chipyard.config.WithOffchipBusFrequency(freqMHz) ++
+  new chipyard.config.WithUniformBusFrequency(freqMHz) ++
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
   new chipyard.config.WithNoDebug ++ // no jtag

--- a/fpga/src/main/scala/vc707/Configs.scala
+++ b/fpga/src/main/scala/vc707/Configs.scala
@@ -42,11 +42,7 @@ class WithVC707Tweaks extends Config (
   // clocking
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
-  new chipyard.config.WithMemoryBusFrequency(50.0) ++
-  new chipyard.config.WithSystemBusFrequency(50.0) ++
-  new chipyard.config.WithPeripheryBusFrequency(50.0) ++
-  new chipyard.config.WithControlBusFrequency(50.0) ++
-  new chipyard.config.WithFrontBusFrequency(50.0) ++
+  new chipyard.config.WithUniformBusFrequency(50.0) ++
 
   new chipyard.harness.WithHarnessBinderClockFreqMHz(50) ++
   new WithFPGAFrequency(50) ++ // default 50MHz freq

--- a/fpga/src/main/scala/vc707/Configs.scala
+++ b/fpga/src/main/scala/vc707/Configs.scala
@@ -42,7 +42,7 @@ class WithVC707Tweaks extends Config (
   // clocking
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
-  new chipyard.config.WithUniformBusFrequency(50.0) ++
+  new chipyard.config.WithUniformBusFrequencies(50.0) ++
 
   new chipyard.harness.WithHarnessBinderClockFreqMHz(50) ++
   new WithFPGAFrequency(50) ++ // default 50MHz freq

--- a/fpga/src/main/scala/vcu118/Configs.scala
+++ b/fpga/src/main/scala/vcu118/Configs.scala
@@ -44,7 +44,7 @@ class WithVCU118Tweaks extends Config(
   // clocking
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
-  new chipyard.config.WithUniformBusFrequency(100) ++
+  new chipyard.config.WithUniformBusFrequencies(100) ++
   new WithFPGAFrequency(100) ++ // default 100MHz freq
   // harness binders
   new WithUART ++

--- a/fpga/src/main/scala/vcu118/Configs.scala
+++ b/fpga/src/main/scala/vcu118/Configs.scala
@@ -44,11 +44,7 @@ class WithVCU118Tweaks extends Config(
   // clocking
   new chipyard.harness.WithAllClocksFromHarnessClockInstantiator ++
   new chipyard.clocking.WithPassthroughClockGenerator ++
-  new chipyard.config.WithMemoryBusFrequency(100) ++
-  new chipyard.config.WithSystemBusFrequency(100) ++
-  new chipyard.config.WithControlBusFrequency(100) ++
-  new chipyard.config.WithPeripheryBusFrequency(100) ++
-  new chipyard.config.WithControlBusFrequency(100) ++
+  new chipyard.config.WithUniformBusFrequency(100) ++
   new WithFPGAFrequency(100) ++ // default 100MHz freq
   // harness binders
   new WithUART ++

--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -102,7 +102,7 @@ class ChipBringupHostConfig extends Config(
   // Set up clocks of the bringup system
   //=============================
   new chipyard.clocking.WithPassthroughClockGenerator ++ // pass all the clocks through, since this isn't a chip
-  new chipyard.config.WithUniformBusFrequency(75.0) ++   // run all buses of this system at 75 MHz
+  new chipyard.config.WithUniformBusFrequencies(75.0) ++   // run all buses of this system at 75 MHz
 
   // Base is the no-cores config
   new chipyard.NoCoresConfig)

--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -102,12 +102,7 @@ class ChipBringupHostConfig extends Config(
   // Set up clocks of the bringup system
   //=============================
   new chipyard.clocking.WithPassthroughClockGenerator ++ // pass all the clocks through, since this isn't a chip
-  new chipyard.config.WithFrontBusFrequency(75.0) ++     // run all buses of this system at 75 MHz
-  new chipyard.config.WithMemoryBusFrequency(75.0) ++
-  new chipyard.config.WithPeripheryBusFrequency(75.0) ++
-  new chipyard.config.WithSystemBusFrequency(75.0) ++
-  new chipyard.config.WithControlBusFrequency(75.0) ++
-  new chipyard.config.WithOffchipBusFrequency(75.0) ++
+  new chipyard.config.WithUniformBusFrequency(75.0) ++   // run all buses of this system at 75 MHz
 
   // Base is the no-cores config
   new chipyard.NoCoresConfig)

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -88,6 +88,6 @@ class ManyPeripheralsRocketConfig extends Config(
 class UARTTSIRocketConfig extends Config(
   new chipyard.harness.WithSerialTLTiedOff ++
   new testchipip.tsi.WithUARTTSIClient ++
-  new chipyard.config.WithUniformBusFrequency(2) ++
+  new chipyard.config.WithUniformBusFrequencies(2) ++
   new freechips.rocketchip.rocket.WithNHugeCores(1) ++         // single rocket-core
   new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -50,15 +50,6 @@ class MMIORocketConfig extends Config(
   new freechips.rocketchip.rocket.WithNHugeCores(1) ++
   new chipyard.config.AbstractConfig)
 
-class LBWIFRocketConfig extends Config(
-  new chipyard.config.WithOffchipBusFrequency(500) ++
-  new testchipip.soc.WithOffchipBusClient(MBUS) ++
-  new testchipip.soc.WithOffchipBus ++
-  new testchipip.serdes.WithSerialTLMem(isMainMemory=true) ++ // set lbwif memory base to DRAM_BASE, use as main memory
-  new freechips.rocketchip.subsystem.WithNoMemPort ++         // remove AXI4 backing memory
-  new freechips.rocketchip.rocket.WithNHugeCores(1) ++
-  new chipyard.config.AbstractConfig)
-
 // DOC include start: DmiRocket
 class dmiRocketConfig extends Config(
   new chipyard.harness.WithSerialTLTiedOff ++                    // don't attach anything to serial-tl

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -97,8 +97,6 @@ class ManyPeripheralsRocketConfig extends Config(
 class UARTTSIRocketConfig extends Config(
   new chipyard.harness.WithSerialTLTiedOff ++
   new testchipip.tsi.WithUARTTSIClient ++
-  new chipyard.config.WithMemoryBusFrequency(10) ++
-  new chipyard.config.WithFrontBusFrequency(10) ++
-  new chipyard.config.WithPeripheryBusFrequency(10) ++
+  new chipyard.config.WithUniformBusFrequency(2) ++
   new freechips.rocketchip.rocket.WithNHugeCores(1) ++         // single rocket-core
   new chipyard.config.AbstractConfig)

--- a/generators/chipyard/src/main/scala/config/SpikeConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/SpikeConfigs.scala
@@ -25,12 +25,7 @@ class SpikeFastUARTConfig extends Config(
   new chipyard.WithNSpikeCores(1) ++
   new chipyard.config.WithUART(txEntries=128, rxEntries=128) ++   // Spike sim requires a larger UART FIFO buffer,
   new chipyard.config.WithNoUART() ++                             // so we overwrite the default one
-  new chipyard.config.WithPeripheryBusFrequency(2) ++             // configured to be as fast as possible
-  new chipyard.config.WithMemoryBusFrequency(2) ++
-  new chipyard.config.WithControlBusFrequency(2) ++
-  new chipyard.config.WithSystemBusFrequency(2) ++
-  new chipyard.config.WithFrontBusFrequency(2) ++
-  new chipyard.config.WithOffchipBusFrequency(2) ++
+  new chipyard.config.WithUniformBusFrequency(2) ++               // configured to be as fast as possible
   new chipyard.config.AbstractConfig)
 
 // No L2 and a ludicrous L1D

--- a/generators/chipyard/src/main/scala/config/SpikeConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/SpikeConfigs.scala
@@ -25,7 +25,7 @@ class SpikeFastUARTConfig extends Config(
   new chipyard.WithNSpikeCores(1) ++
   new chipyard.config.WithUART(txEntries=128, rxEntries=128) ++   // Spike sim requires a larger UART FIFO buffer,
   new chipyard.config.WithNoUART() ++                             // so we overwrite the default one
-  new chipyard.config.WithUniformBusFrequency(2) ++               // configured to be as fast as possible
+  new chipyard.config.WithUniformBusFrequencies(2) ++               // configured to be as fast as possible
   new chipyard.config.AbstractConfig)
 
 // No L2 and a ludicrous L1D

--- a/generators/chipyard/src/main/scala/config/TracegenConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/TracegenConfigs.scala
@@ -15,7 +15,7 @@ class AbstractTraceGenConfig extends Config(
   new chipyard.clocking.WithClockGroupsCombinedByName(("uncore", Seq("sbus"), Nil)) ++
   new chipyard.config.WithTracegenSystem ++
   new chipyard.config.WithNoSubsystemClockIO ++
-  new chipyard.config.WithUniformBusFrequency(1000.0) ++
+  new chipyard.config.WithUniformBusFrequencies(1000.0) ++
   new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
   new freechips.rocketchip.groundtest.GroundTestBaseConfig)
 

--- a/generators/chipyard/src/main/scala/config/TracegenConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/TracegenConfigs.scala
@@ -15,10 +15,7 @@ class AbstractTraceGenConfig extends Config(
   new chipyard.clocking.WithClockGroupsCombinedByName(("uncore", Seq("sbus"), Nil)) ++
   new chipyard.config.WithTracegenSystem ++
   new chipyard.config.WithNoSubsystemClockIO ++
-  new chipyard.config.WithMemoryBusFrequency(1000.0) ++
-  new chipyard.config.WithControlBusFrequency(1000.0) ++
-  new chipyard.config.WithSystemBusFrequency(1000.0) ++
-  new chipyard.config.WithPeripheryBusFrequency(1000.0) ++
+  new chipyard.config.WithUniformBusFrequency(1000.0) ++
   new freechips.rocketchip.subsystem.WithCoherentBusTopology ++
   new freechips.rocketchip.groundtest.GroundTestBaseConfig)
 

--- a/generators/chipyard/src/main/scala/config/fragments/ClockingFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/ClockingFragments.scala
@@ -110,7 +110,7 @@ class WithControlBusFrequency(freqMHz: Double) extends Config((site, here, up) =
 class WithOffchipBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
   case OffchipBusKey => up(OffchipBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).toLong)))
 })
-class WithUniformBusFrequency(freqMHz: Double) extends Config(
+class WithUniformBusFrequencies(freqMHz: Double) extends Config(
   new WithPeripheryBusFrequency(freqMHz) ++
   new WithSystemBusFrequency(freqMHz) ++
   new WithFrontBusFrequency(freqMHz) ++

--- a/generators/chipyard/src/main/scala/config/fragments/ClockingFragments.scala
+++ b/generators/chipyard/src/main/scala/config/fragments/ClockingFragments.scala
@@ -110,6 +110,14 @@ class WithControlBusFrequency(freqMHz: Double) extends Config((site, here, up) =
 class WithOffchipBusFrequency(freqMHz: Double) extends Config((site, here, up) => {
   case OffchipBusKey => up(OffchipBusKey, site).copy(dtsFrequency = Some(BigInt((freqMHz * 1e6).toLong)))
 })
+class WithUniformBusFrequency(freqMHz: Double) extends Config(
+  new WithPeripheryBusFrequency(freqMHz) ++
+  new WithSystemBusFrequency(freqMHz) ++
+  new WithFrontBusFrequency(freqMHz) ++
+  new WithControlBusFrequency(freqMHz) ++
+  new WithOffchipBusFrequency(freqMHz) ++
+  new WithMemoryBusFrequency(freqMHz)
+)
 
 class WithRationalMemoryBusCrossing extends WithSbusToMbusCrossingType(RationalCrossing(Symmetric))
 class WithAsynchrousMemoryBusCrossing extends WithSbusToMbusCrossingType(AsynchronousCrossing())

--- a/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
@@ -270,9 +270,9 @@ class WithDriveChipIdPin extends HarnessBinder({
 })
 
 class WithSimUARTToUARTTSI extends HarnessBinder({
-  case (th: HasHarnessInstantiators, port: UARTPort, chipId: Int) => {
-    UARTAdapter.connect(Seq(port.io),
-      baudrate=port.io.c.initBaudRate,
+  case (th: HasHarnessInstantiators, port: UARTTSIPort, chipId: Int) => {
+    UARTAdapter.connect(Seq(port.io.uart),
+      baudrate=port.io.uart.c.initBaudRate,
       clockFrequency=th.getHarnessBinderClockFreqHz.toInt,
       forcePty=true)
   }


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
