### PR TITLE
Don't specify a nondefault CMAKE_RUNTIME_OUTPUT_DIRECTORY

### DIFF
--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -29,8 +29,7 @@ run_binary () {
 }
 
 build_tests() {
-    cmake $LOCAL_CHIPYARD_DIR/tests/ -S $LOCAL_CHIPYARD_DIR/tests/ -B $LOCAL_CHIPYARD_DIR/tests/build/ -D CMAKE_BUILD_TYPE=Debug
-    cmake --build $LOCAL_CHIPYARD_DIR/tests/build/ --target all
+    (cd $LOCAL_CHIPYARD_DIR/tests && cmake . && make)
 }
 
 case $1 in

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,8 +32,6 @@ set(CMAKE_OBJCOPY       "${TOOLCHAIN_PREFIX}objcopy")
 set(CMAKE_OBJDUMP       "${TOOLCHAIN_PREFIX}objdump")
 set(CMAKE_SIZE          "${TOOLCHAIN_PREFIX}size")
 
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY     "${CMAKE_BINARY_DIR}/..")
 set(CMAKE_EXECUTABLE_SUFFIX            ".riscv")
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,8 +96,8 @@ add_custom_target(dump ALL)
 # Function to add disassembly target for an executable
 function(add_dump_target target_name)
     add_custom_target(${target_name}-dump
-        BYPRODUCTS ${CMAKE_SOURCE_DIR}/${target_name}.dump
-        COMMAND ${CMAKE_OBJDUMP} -D $<TARGET_FILE:${target_name}> > ${CMAKE_SOURCE_DIR}/${target_name}.dump
+        BYPRODUCTS ${CMAKE_BINARY_DIR}/${target_name}.dump
+        COMMAND ${CMAKE_OBJDUMP} -D $<TARGET_FILE:${target_name}> > ${CMAKE_BINARY_DIR}/${target_name}.dump
         DEPENDS ${target_name}
         COMMENT "Generating disassembly for ${target_name}"
     )


### PR DESCRIPTION
Tests should be compiled into whatever the build directory is

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
