### PR TITLE
Add function trace utils

### DIFF
--- a/scripts/func-trace-utils/Makefile
+++ b/scripts/func-trace-utils/Makefile
@@ -1,0 +1,29 @@
+default: bin.trace bin.trace.interleaved
+
+vmlinux.dump: boards/default/linux/vmlinux
+	riscv64-unknown-elf-objdump -D $< > $@
+
+busybox.dump: wlutil/busybox/busybox_unstripped
+	riscv64-unknown-linux-gnu-objdump -D -S $< > $@
+
+# userspace binary
+USERSPACE_BIN ?=
+bin.dump: $(USERSPACE_BIN)
+	riscv64-unknown-elf-objdump -D -S $< > $@
+
+# logfile from spike or CY RTL sim.
+IN_LOG ?=
+bin.trace: vmlinux.dump busybox.dump bin.dump $(IN_LOG)
+	./create-func-trace.py $^
+	mv $(IN_LOG).functrace $@
+
+bin.trace.interleaved: vmlinux.dump busybox.dump bin.dump $(IN_LOG)
+	./create-func-trace-interleaved.py $^
+	mv $(IN_LOG).functrace $@
+
+.PHONY: dumps
+dumps: busybox.dump bin.dump vmlinux.dump
+
+.PHONY: clean
+clean:
+	rm -rf *.trace*

--- a/scripts/func-trace-utils/create-func-trace-int.py
+++ b/scripts/func-trace-utils/create-func-trace-int.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+back_args = sys.argv[1:]
+files_to_check = back_args[:-1]
+outfile = back_args[-1]
+
+print(f"Checking {files_to_check}")
+
+func_names = {}
+
+for dumpfile in files_to_check:
+    with open(dumpfile, 'r') as ld:
+        for l in ld:
+            match = re.match(r"^([a-fA-F0-9]+) <(.*)>:", l)
+            if match:
+                pc, name = match.groups()
+                if pc in func_names:
+                    func_names[pc] = func_names[pc] + " or " + name
+                else:
+                    func_names[pc] = name
+
+print(f"Got {len(func_names)} functions from files")
+print(f"Creating function trace from {outfile}")
+
+with open(outfile, 'r') as of:
+    with open(outfile + ".functrace", 'w') as wf:
+        lines = of.readlines()
+        tlc = len(lines)
+        lno = 0
+        for l in lines:
+            match = re.search(r"\[1\] pc=\[([a-fA-F0-9]+)\]", l)
+            if match:
+                pc = match.groups()[0]
+                if pc in func_names:
+                    wf.write(f"{pc}: {func_names[pc]}\n")
+                #wf.write(f"{(100*lno/tlc):.1f}: {pc}: {func_names[pc]}\n")
+            else:
+                match = re.search(r": 0x([a-fA-F0-9]+) ", l)
+                if match:
+                    pc = match.groups()[0]
+                    if pc in func_names:
+                        wf.write(f"{pc}: {func_names[pc]}\n")
+                    #wf.write(f"{(100*lno/tlc):.1f}: {pc}: {func_names[pc]}\n")
+            # match = re.search(r": exception.*,", l)
+            # if match:
+            #     wf.write(l)
+
+            # match = re.search(r"\[0\] pc=\[0000000000193f80\]", l)
+            # if match:
+            #     wf.write(l)
+
+            wf.write(l)
+            lno = lno + 1
+
+print(f"Done: {outfile}.functrace")

--- a/scripts/func-trace-utils/create-func-trace.py
+++ b/scripts/func-trace-utils/create-func-trace.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+back_args = sys.argv[1:]
+files_to_check = back_args[:-1]
+outfile = back_args[-1]
+
+print(f"Checking {files_to_check}")
+
+func_names = {}
+
+for dumpfile in files_to_check:
+    with open(dumpfile, 'r') as ld:
+        for l in ld:
+            match = re.match(r"^([a-fA-F0-9]+) <(.*)>:", l)
+            if match:
+                pc, name = match.groups()
+                if pc in func_names:
+                    func_names[pc] = func_names[pc] + " or " + name
+                else:
+                    func_names[pc] = name
+
+print(f"Got {len(func_names)} functions from files")
+print(f"Creating function trace from {outfile}")
+
+with open(outfile, 'r') as of:
+    with open(outfile + ".functrace", 'w') as wf:
+        lines = of.readlines()
+        tlc = len(lines)
+        lno = 0
+        for l in lines:
+            match = re.search(r"\[1\] pc=\[([a-fA-F0-9]+)\]", l)
+            if match:
+                pc = match.groups()[0]
+                if pc in func_names:
+                    wf.write(f"{pc}: {func_names[pc]}\n")
+                #wf.write(f"{(100*lno/tlc):.1f}: {pc}: {func_names[pc]}\n")
+            else:
+                match = re.search(r": 0x([a-fA-F0-9]+) ", l)
+                if match:
+                    pc = match.groups()[0]
+                    if pc in func_names:
+                        wf.write(f"{pc}: {func_names[pc]}\n")
+                    #wf.write(f"{(100*lno/tlc):.1f}: {pc}: {func_names[pc]}\n")
+            #wf.write(l)
+            match = re.search(r": exception.*,", l)
+            if match:
+                wf.write(l)
+
+            match = re.search(r"\[0\] pc=\[0000000000193f80\]", l)
+            if match:
+                wf.write(l)
+            lno = lno + 1
+
+print(f"Done: {outfile}.functrace")


### PR DESCRIPTION
Adding some simple utilities to inline function names into a Chipyard or Spike output log. Needs to be cleaned + deduped.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
