### PR TITLE
Set harness clock to default clk freq | Use combined clk frag.

### DIFF
--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -137,12 +137,8 @@ class AbstractConfig extends Config(
     Seq("sbus", "mbus", "pbus", "fbus", "cbus", "obus", "implicit", "clock_tap"),
     Seq("tile"))) ++
 
-  new chipyard.config.WithPeripheryBusFrequency(500.0) ++           /** Default 500 MHz pbus */
-  new chipyard.config.WithMemoryBusFrequency(500.0) ++              /** Default 500 MHz mbus */
-  new chipyard.config.WithControlBusFrequency(500.0) ++             /** Default 500 MHz cbus */
-  new chipyard.config.WithSystemBusFrequency(500.0) ++              /** Default 500 MHz sbus */
-  new chipyard.config.WithFrontBusFrequency(500.0) ++               /** Default 500 MHz fbus */
-  new chipyard.config.WithOffchipBusFrequency(500.0) ++             /** Default 500 MHz obus */
+  new chipyard.config.WithUniformBusFrequencies(500.0) ++           /** Default 500 MHz {p,s,f,c,o,m}bus **/
+  new chipyard.harness.WithHarnessBinderClockFreqMHz(500.0) ++      /** Default harness clock to bus clocks **/
   new chipyard.config.WithInheritBusFrequencyAssignments ++         /** Unspecified clocks within a bus will receive the bus frequency if set */
   new chipyard.config.WithNoSubsystemClockIO ++                     /** drive the subsystem diplomatic clocks from ChipTop instead of using implicit clocks */
 


### PR DESCRIPTION
Use the nicer `WithUniformBusFrequencies` fragment which sets all the buses to the same clock. Additionally set the harness clock to the same frequency (otherwise the harness clock is set to 100MHz by default).

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
