### PR TITLE
Add I2C peripheral example

### DIFF
--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -22,6 +22,7 @@ class AbstractConfig extends Config(
   new chipyard.harness.WithSimDMI ++                               /** add SimJTAG if DMI exposed */
   new chipyard.harness.WithGPIOPinsTiedOff ++                      /** tie-off chiptop GPIO-pins, if GPIO-punchthrough is used */
   new chipyard.harness.WithGPIOTiedOff ++                          /** tie-off chiptop GPIOs, if GPIOs are present */
+  new chipyard.harness.WithI2CTiedOff ++                           /** tie-off i2c ports if present */
   new chipyard.harness.WithSimSPIFlashModel ++                     /** add simulated SPI flash memory, if SPI is enabled */
   new chipyard.harness.WithSimAXIMMIO ++                           /** add SimAXIMem for axi4 mmio port, if enabled */
   new chipyard.harness.WithTieOffInterrupts ++                     /** tie-off interrupt ports, if present */

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -19,6 +19,12 @@ class SmallSPIFlashRocketConfig extends Config(
   new freechips.rocketchip.rocket.WithNHugeCores(1) ++
   new chipyard.config.AbstractConfig)
 
+class I2CRocketConfig extends Config(
+  new chipyard.harness.WithI2CTiedOff ++                    // Tie off the I2C port in the harness
+  new chipyard.config.WithI2C ++                            // Add I2C peripheral
+  new freechips.rocketchip.rocket.WithNHugeCores(1) ++
+  new chipyard.config.AbstractConfig)
+
 class SimBlockDeviceRocketConfig extends Config(
   new chipyard.harness.WithSimBlockDevice ++                // drive block-device IOs with SimBlockDevice
   new testchipip.iceblk.WithBlockDevice ++                  // add block-device module to peripherybus

--- a/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/PeripheralDeviceConfigs.scala
@@ -77,12 +77,15 @@ class dmiCospikeCheckpointingRocketConfig extends Config(
 
 
 class ManyPeripheralsRocketConfig extends Config(
+  new chipyard.harness.WithI2CTiedOff ++                    // Tie off the I2C port in the harness
+  new chipyard.harness.WithSimSPIFlashModel(true) ++         // add the SPI flash model in the harness (read-only)
+  new chipyard.harness.WithSimBlockDevice ++                 // drive block-device IOs with SimBlockDevice
+
   new testchipip.iceblk.WithBlockDevice ++                   // add block-device module to peripherybus
   new testchipip.soc.WithOffchipBusClient(MBUS) ++           // OBUS provides backing memory to the MBUS
   new testchipip.soc.WithOffchipBus ++                       // OBUS must exist for serial-tl to master off-chip memory
   new testchipip.serdes.WithSerialTLMem(isMainMemory=true) ++ // set lbwif memory base to DRAM_BASE, use as main memory
-  new chipyard.harness.WithSimSPIFlashModel(true) ++         // add the SPI flash model in the harness (read-only)
-  new chipyard.harness.WithSimBlockDevice ++                 // drive block-device IOs with SimBlockDevice
+  new chipyard.config.WithI2C ++                             // Add I2C peripheral
   new chipyard.config.WithPeripheryTimer ++                  // add the pwm timer device
   new chipyard.config.WithSPIFlash ++                        // add the SPI flash controller
   new freechips.rocketchip.subsystem.WithDefaultMMIOPort ++  // add default external master port

--- a/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/HarnessBinders.scala
@@ -75,6 +75,12 @@ class WithSimSPIFlashModel(rdOnly: Boolean = true) extends HarnessBinder({
   }
 })
 
+class WithI2CTiedOff extends HarnessBinder({
+  case (th: HasHarnessInstantiators, port: I2CPort, chipId: Int) => {
+    port.io <> DontCare
+  }
+})
+
 class WithSimBlockDevice extends HarnessBinder({
   case (th: HasHarnessInstantiators, port: BlockDevicePort, chipId: Int) => {
     val sim_blkdev = Module(new SimBlockDevice(port.params))

--- a/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
+++ b/generators/chipyard/src/main/scala/iobinders/IOBinders.scala
@@ -206,7 +206,7 @@ class WithI2CPunchthrough extends OverrideIOBinder({
     val ports = system.i2c.zipWithIndex.map { case (i2c, i) =>
       val io_i2c = IO(i2c.cloneType).suggestName(s"i2c_$i")
       io_i2c <> i2c
-      I2CPort(() => i2c)
+      I2CPort(() => io_i2c)
     }
     (ports, Nil)
   }


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
