### PR TITLE
Disable FPU model optimizations (temporarily)

### DIFF
--- a/generators/firechip/chip/src/main/scala/FireSim.scala
+++ b/generators/firechip/chip/src/main/scala/FireSim.scala
@@ -125,7 +125,8 @@ class FireSim(implicit val p: Parameters) extends RawModule with HasHarnessInsta
         if (p(FireSimMultiCycleRegFile)) ls.totalTiles.values.map {
           case r: RocketTile => {
             annotate(MemModelAnnotation(r.module.core.rocketImpl.rf.rf))
-            r.module.fpuOpt.foreach(fpu => annotate(MemModelAnnotation(fpu.fpuImpl.regfile)))
+            // TODO: currently, fpu mem. model optimizations are broken with model multi-threading so disable for now
+            //r.module.fpuOpt.foreach(fpu => annotate(MemModelAnnotation(fpu.fpuImpl.regfile)))
           }
           case b: BoomTile => {
             val core = b.module.core


### PR DESCRIPTION
See title. Disabled (i.e. commented out) instead of doing an `if(p(FireSimFAME5))` type statement wrapping the problematic annotation since `p(FireSimFAME5)` is always enabled from the target POV (by default added in `BridgeBinders.scala` with `WithFireSimFAME5`). This optimization breaks model multi-threading (for CPU tiles). With this commented out, model multi-threading should work again.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
