### PR TITLE
Improve naming of Serial-TL PhyParams

### DIFF
--- a/fpga/src/main/scala/arty100t/Configs.scala
+++ b/fpga/src/main/scala/arty100t/Configs.scala
@@ -54,5 +54,5 @@ class NoCoresArty100TConfig extends Config(
 class BringupArty100TConfig extends Config(
   new WithArty100TSerialTLToGPIO ++
   new WithArty100TTweaks(freqMHz = 50) ++
-  new testchipip.serdes.WithSerialTLPHYParams(testchipip.serdes.InternalSyncSerialPhyParams(freqMHz=50)) ++
+  new testchipip.serdes.WithSerialTLPHYParams(testchipip.serdes.DecoupledInternalSyncSerialPhyParams(freqMHz=50)) ++
   new chipyard.ChipBringupHostConfig)

--- a/fpga/src/main/scala/arty100t/HarnessBinders.scala
+++ b/fpga/src/main/scala/arty100t/HarnessBinders.scala
@@ -62,8 +62,8 @@ class WithArty100TSerialTLToGPIO extends HarnessBinder({
     harnessIO match {
       case io: DecoupledPhitIO => {
         val clkIO = io match {
-          case io: InternalSyncPhitIO => IOPin(io.clock_out)
-          case io: ExternalSyncPhitIO => IOPin(io.clock_in)
+          case io: HasClockOut => IOPin(io.clock_out)
+          case io: HasClockIn => IOPin(io.clock_in)
         }
         val packagePinsWithPackageIOs = Seq(
           ("G13", clkIO),
@@ -87,10 +87,10 @@ class WithArty100TSerialTLToGPIO extends HarnessBinder({
 
         // Don't add IOB to the clock, if its an input
         io match {
-          case io: InternalSyncPhitIO => packagePinsWithPackageIOs foreach { case (pin, io) => {
+          case io: DecoupledInternalSyncPhitIO => packagePinsWithPackageIOs foreach { case (pin, io) => {
             artyTh.xdc.addIOB(io)
           }}
-          case io: ExternalSyncPhitIO => packagePinsWithPackageIOs.drop(1).foreach { case (pin, io) => {
+          case io: DecoupledExternalSyncPhitIO => packagePinsWithPackageIOs.drop(1).foreach { case (pin, io) => {
             artyTh.xdc.addIOB(io)
           }}
         }

--- a/fpga/src/main/scala/datastorm/Configs.scala
+++ b/fpga/src/main/scala/datastorm/Configs.scala
@@ -57,5 +57,5 @@ class NoCoresDatastormConfig extends Config(
 class BringupDatastormConfig extends Config(
   new WithDatastormSerialTLToFMC ++
   new WithDatastormTweaks ++
-  new testchipip.serdes.WithSerialTLPHYParams(testchipip.serdes.InternalSyncSerialPhyParams(freqMHz=40)) ++
+  new testchipip.serdes.WithSerialTLPHYParams(testchipip.serdes.DecoupledInternalSyncSerialPhyParams(freqMHz=40)) ++
   new chipyard.ChipBringupHostConfig)

--- a/fpga/src/main/scala/datastorm/HarnessBinders.scala
+++ b/fpga/src/main/scala/datastorm/HarnessBinders.scala
@@ -38,8 +38,8 @@ class WithDatastormSerialTLToFMC extends HarnessBinder({
     harnessIO match {
       case io: DecoupledPhitIO => {
         val clkIO = io match {
-          case io: InternalSyncPhitIO => IOPin(io.clock_out)
-          case io: ExternalSyncPhitIO => IOPin(io.clock_in)
+          case io: HasClockOut => IOPin(io.clock_out)
+          case io: HasClockIn => IOPin(io.clock_in)
         }
         val packagePinsWithPackageIOs = Seq(
           ("PIN_C13", clkIO),

--- a/fpga/src/main/scala/nexysvideo/HarnessBinders.scala
+++ b/fpga/src/main/scala/nexysvideo/HarnessBinders.scala
@@ -57,8 +57,8 @@ class WithNexysVideoSerialTLToGPIO extends HarnessBinder({
     harnessIO match {
       case io: DecoupledPhitIO => {
         val clkIO = io match {
-          case io: InternalSyncPhitIO => IOPin(io.clock_out)
-          case io: ExternalSyncPhitIO => IOPin(io.clock_in)
+          case io: HasClockOut => IOPin(io.clock_out)
+          case io: HasClockIn => IOPin(io.clock_in)
         }
         val packagePinsWithPackageIOs = Seq(
           ("AB22", clkIO),
@@ -82,10 +82,10 @@ class WithNexysVideoSerialTLToGPIO extends HarnessBinder({
 
         // Don't add IOB to the clock, if its an input
         io match {
-          case io: InternalSyncPhitIO => packagePinsWithPackageIOs foreach { case (pin, io) => {
+          case io: DecoupledInternalSyncPhitIO => packagePinsWithPackageIOs foreach { case (pin, io) => {
             nexysTh.xdc.addIOB(io)
           }}
-          case io: ExternalSyncPhitIO => packagePinsWithPackageIOs.drop(1).foreach { case (pin, io) => {
+          case io: DecoupledExternalSyncPhitIO => packagePinsWithPackageIOs.drop(1).foreach { case (pin, io) => {
             nexysTh.xdc.addIOB(io)
           }}
         }

--- a/generators/chipyard/src/main/scala/config/AbstractConfig.scala
+++ b/generators/chipyard/src/main/scala/config/AbstractConfig.scala
@@ -71,7 +71,7 @@ class AbstractConfig extends Config(
   new testchipip.serdes.WithSerialTL(Seq(                           /** add a serial-tilelink interface */
     testchipip.serdes.SerialTLParams(
       client = Some(testchipip.serdes.SerialTLClientParams(totalIdBits=4)), // serial-tilelink interface will master the FBUS, and support 4 idBits
-      phyParams = testchipip.serdes.ExternalSyncSerialPhyParams(phitWidth=32, flitWidth=32) // serial-tilelink interface with 32 lanes
+      phyParams = testchipip.serdes.DecoupledExternalSyncSerialPhyParams(phitWidth=32, flitWidth=32) // serial-tilelink interface with 32 lanes
     )
   )) ++
   new freechips.rocketchip.subsystem.WithNMemoryChannels(1) ++         /** Default 1 AXI-4 memory channels */

--- a/generators/chipyard/src/main/scala/config/ChipConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipConfigs.scala
@@ -31,7 +31,7 @@ class ChipLikeRocketConfig extends Config(
       isMemoryDevice = true
     )),
     client = Some(testchipip.serdes.SerialTLClientParams()),                            // Allow an external manager to probe this chip
-    phyParams = testchipip.serdes.ExternalSyncSerialPhyParams(phitWidth=4, flitWidth=16)   // 4-bit bidir interface, sync'd to an external clock
+    phyParams = testchipip.serdes.DecoupledExternalSyncSerialPhyParams(phitWidth=4, flitWidth=16)   // 4-bit bidir interface, sync'd to an external clock
   ))) ++
 
   new freechips.rocketchip.subsystem.WithNoMemPort ++                                   // Remove axi4 mem port
@@ -78,7 +78,7 @@ class ChipBringupHostConfig extends Config(
       ))
     )),
     client = Some(testchipip.serdes.SerialTLClientParams()),                                        // Allow chip to access this device's memory (DRAM)
-    phyParams = testchipip.serdes.InternalSyncSerialPhyParams(phitWidth=4, flitWidth=16, freqMHz = 75) // bringup platform provides the clock
+    phyParams = testchipip.serdes.DecoupledInternalSyncSerialPhyParams(phitWidth=4, flitWidth=16, freqMHz = 75) // bringup platform provides the clock
   ))) ++
 
   //============================

--- a/generators/chipyard/src/main/scala/config/ChipletConfigs.scala
+++ b/generators/chipyard/src/main/scala/config/ChipletConfigs.scala
@@ -16,7 +16,7 @@ class SymmetricChipletRocketConfig extends Config(
   new testchipip.serdes.WithSerialTL(Seq(
     testchipip.serdes.SerialTLParams(                               // 0th serial-tl is chip-to-bringup-fpga
       client = Some(testchipip.serdes.SerialTLClientParams()),      // bringup serial-tl acts only as a client
-      phyParams = testchipip.serdes.ExternalSyncSerialPhyParams()   // bringup serial-tl is sync'd to external clock
+      phyParams = testchipip.serdes.DecoupledExternalSyncSerialPhyParams()   // bringup serial-tl is sync'd to external clock
     ),
     testchipip.serdes.SerialTLParams(                               // 1st serial-tl is chip-to-chip
       client = Some(testchipip.serdes.SerialTLClientParams()),      // chip-to-chip serial-tl acts as a client
@@ -27,7 +27,7 @@ class SymmetricChipletRocketConfig extends Config(
         )),
         slaveWhere = OBUS
       )),
-      phyParams = testchipip.serdes.SourceSyncSerialPhyParams()     // chip-to-chip serial-tl is symmetric source-sync'd
+      phyParams = testchipip.serdes.CreditedSourceSyncSerialPhyParams() // chip-to-chip serial-tl is symmetric source-sync'd
     ))
   ) ++
   new testchipip.soc.WithOffchipBusClient(SBUS,                     // obus provides path to other chip's memory
@@ -51,7 +51,7 @@ class RocketCoreChipletConfig extends Config(
   new testchipip.serdes.WithSerialTL(Seq(
     testchipip.serdes.SerialTLParams(
       client = Some(testchipip.serdes.SerialTLClientParams()),
-      phyParams = testchipip.serdes.ExternalSyncSerialPhyParams()     // chip-to-chip serial-tl is symmetric source-sync'd
+      phyParams = testchipip.serdes.DecoupledExternalSyncSerialPhyParams()     // chip-to-chip serial-tl is symmetric source-sync'd
     ),
     testchipip.serdes.SerialTLParams(
       manager = Some(testchipip.serdes.SerialTLManagerParams(
@@ -62,7 +62,7 @@ class RocketCoreChipletConfig extends Config(
         slaveWhere = OBUS,
         isMemoryDevice = true
       )),
-      phyParams = testchipip.serdes.SourceSyncSerialPhyParams()
+      phyParams = testchipip.serdes.CreditedSourceSyncSerialPhyParams()
     )
   )) ++
   new testchipip.soc.WithOffchipBusClient(SBUS) ++
@@ -79,7 +79,7 @@ class LLCChipletConfig extends Config(
   new chipyard.harness.WithSerialTLTiedOff ++
   new testchipip.serdes.WithSerialTL(Seq(testchipip.serdes.SerialTLParams(                               // 1st serial-tl is chip-to-chip
     client = Some(testchipip.serdes.SerialTLClientParams(supportsProbe=true)),
-    phyParams = testchipip.serdes.SourceSyncSerialPhyParams()     // chip-to-chip serial-tl is symmetric source-sync'd
+    phyParams = testchipip.serdes.CreditedSourceSyncSerialPhyParams()  // chip-to-chip serial-tl is symmetric source-sync'd
   ))) ++
   new freechips.rocketchip.subsystem.WithExtMemSize((1 << 30) * 4L) ++
   new chipyard.NoCoresConfig

--- a/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
+++ b/generators/chipyard/src/main/scala/example/FlatTestHarness.scala
@@ -47,12 +47,12 @@ class FlatTestHarness(implicit val p: Parameters) extends Module {
 
   // Figure out which clock drives the harness TLSerdes, based on the port type
   val serial_ram_clock = dut.serial_tl_pad match {
-    case io: InternalSyncPhitIO => io.clock_out
-    case io: ExternalSyncPhitIO => clock
+    case io: HasClockOut => io.clock_out
+    case io: HasClockIn => clock
   }
   dut.serial_tl_pad match {
-    case io: ExternalSyncPhitIO => io.clock_in := clock
-    case io: InternalSyncPhitIO =>
+    case io: HasClockIn => io.clock_in := clock
+    case io: HasClockOut =>
   }
 
   dut.serial_tl_pad match {

--- a/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
+++ b/generators/chipyard/src/main/scala/harness/MultiHarnessBinders.scala
@@ -58,12 +58,12 @@ class WithMultiChipSerialTL(chip0: Int, chip1: Int, chip0portId: Int = 0, chip1p
   (p0: SerialTLPort) => p0.portId == chip0portId,
   (p1: SerialTLPort) => p1.portId == chip1portId,
   (th: HasHarnessInstantiators, p0: SerialTLPort, p1: SerialTLPort) => {
-    def connectDecoupledSyncPhitIO(clkSource: InternalSyncPhitIO, clkSink: ExternalSyncPhitIO) = {
+    def connectDecoupledSyncPhitIO(clkSource: DecoupledInternalSyncPhitIO, clkSink: DecoupledExternalSyncPhitIO) = {
       clkSink.clock_in := clkSource.clock_out
       clkSink.in <> clkSource.out
       clkSource.in <> clkSink.out
     }
-    def connectSourceSyncPhitIO(a: SourceSyncPhitIO, b: SourceSyncPhitIO) = {
+    def connectSourceSyncPhitIO(a: CreditedSourceSyncPhitIO, b: CreditedSourceSyncPhitIO) = {
       a.clock_in := b.clock_out
       b.clock_in := a.clock_out
       a.reset_in := b.reset_out
@@ -72,9 +72,9 @@ class WithMultiChipSerialTL(chip0: Int, chip1: Int, chip0portId: Int = 0, chip1p
       b.in := a.out
     }
     (p0.io, p1.io) match {
-      case (io0: InternalSyncPhitIO, io1: ExternalSyncPhitIO) => connectDecoupledSyncPhitIO(io0, io1)
-      case (io0: ExternalSyncPhitIO, io1: InternalSyncPhitIO) => connectDecoupledSyncPhitIO(io1, io0)
-      case (io0: SourceSyncPhitIO  , io1: SourceSyncPhitIO  ) => connectSourceSyncPhitIO   (io0, io1)
+      case (io0: DecoupledInternalSyncPhitIO, io1: DecoupledExternalSyncPhitIO) => connectDecoupledSyncPhitIO(io0, io1)
+      case (io0: DecoupledExternalSyncPhitIO, io1: DecoupledInternalSyncPhitIO) => connectDecoupledSyncPhitIO(io1, io0)
+      case (io0: CreditedSourceSyncPhitIO   , io1: CreditedSourceSyncPhitIO   ) => connectSourceSyncPhitIO   (io0, io1)
     }
   }
 )

--- a/generators/firechip/chip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/chip/src/main/scala/BridgeBinders.scala
@@ -8,7 +8,7 @@ import org.chipsalliance.cde.config.{Config}
 import freechips.rocketchip.diplomacy.{LazyModule}
 import freechips.rocketchip.subsystem._
 import sifive.blocks.devices.uart._
-import testchipip.serdes.{ExternalSyncPhitIO}
+import testchipip.serdes.{DecoupledExternalSyncPhitIO}
 import testchipip.tsi.{SerialRAM}
 
 import chipyard.iocell._
@@ -59,7 +59,7 @@ class WithFireSimIOCellModels extends Config((site, here, up) => {
 class WithTSIBridgeAndHarnessRAMOverSerialTL extends HarnessBinder({
   case (th: FireSim, port: SerialTLPort, chipId: Int) => {
     port.io match {
-      case io: ExternalSyncPhitIO => {
+      case io: DecoupledExternalSyncPhitIO => {
         io.clock_in := th.harnessBinderClock
         val ram = Module(LazyModule(new SerialRAM(port.serdesser, port.params)(port.serdesser.p)).module)
         ram.io.ser.in <> io.out

--- a/generators/firechip/chip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/chip/src/main/scala/TargetConfigs.scala
@@ -251,7 +251,7 @@ class FireSimSmallSystemConfig extends Config(
   new freechips.rocketchip.subsystem.WithExtMemSize(1 << 28) ++
   new testchipip.serdes.WithSerialTL(Seq(testchipip.serdes.SerialTLParams(
     client = Some(testchipip.serdes.SerialTLClientParams(totalIdBits = 4)),
-    phyParams = testchipip.serdes.ExternalSyncSerialPhyParams(phitWidth=32, flitWidth=32)
+    phyParams = testchipip.serdes.DecoupledExternalSyncSerialPhyParams(phitWidth=32, flitWidth=32)
   ))) ++
   new testchipip.iceblk.WithBlockDevice ++
   new chipyard.config.WithUARTInitBaudRate(BigInt(3686400L)) ++


### PR DESCRIPTION
This improves the naming of the Serial-TL parameterization objects to make it clearer what is generated.

The Decoupled{Internal/External}SyncPhy implementation was determined to be deadlocking, although the condition under which deadlock could occur is effectively impossible on real silicon ... deadlock is only possible if both sides fully saturate the channel and run at the same frequency.

This PR adds a loud warning in the generator when building with that form of flow control.... it should still be safe for test chips, as the chip-FPGA link is always throttled by the FPGA, or by the UART-TSI onto the FPGA.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
