### PR TITLE
small build setup edits to prevent common failures

### DIFF
--- a/conda-reqs/chipyard-extended.yaml
+++ b/conda-reqs/chipyard-extended.yaml
@@ -69,7 +69,7 @@ dependencies:
 
     # hammer packages
     - sty
-    - open_pdks.sky130a
+    # - open_pdks.sky130a
     - pip:
         - hammer-vlsi[asap7]==1.2.0
 

--- a/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
+++ b/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
@@ -6,7 +6,7 @@
 #
 # Install this environment as "YOURENV" with:
 #     conda-lock install -n YOURENV conda-requirements-riscv-tools-linux-64.conda-lock.yml
-# To update a single package to the latest version compatible witfh the version constraints in the source:
+# To update a single package to the latest version compatible with the version constraints in the source:
 #     conda-lock lock  --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
 #     conda-lock -f ../chipyard-base.yaml -f ../chipyard-extended.yaml -f ../docs.yaml -f ../riscv-tools.yaml --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml

--- a/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
+++ b/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
@@ -6,7 +6,7 @@
 #
 # Install this environment as "YOURENV" with:
 #     conda-lock install -n YOURENV conda-requirements-riscv-tools-linux-64.conda-lock.yml
-# To update a single package to the latest version compatible with the version constraints in the source:
+# To update a single package to the latest version compatible witfh the version constraints in the source:
 #     conda-lock lock  --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
 #     conda-lock -f ../chipyard-base.yaml -f ../chipyard-extended.yaml -f ../docs.yaml -f ../riscv-tools.yaml --lockfile conda-requirements-riscv-tools-linux-64.conda-lock.yml
@@ -3849,17 +3849,17 @@ package:
     sha256: bbff8a60f70d5ebab138b564554f28258472e1e63178614562d4feee29d10da2
   category: main
   optional: false
-- name: open_pdks.sky130a
-  version: 1.0.471_0_g97d0844
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.471_0_g97d0844-20240223_100318.tar.bz2
-  hash:
-    md5: 3f9dab167b1bac3a6636f3f4311eb17e
-    sha256: 37736ab56036733eaaff5f8f77a42c98caf75c82bc6b5dae59a727d24eabdd83
-  category: main
-  optional: false
+# - name: open_pdks.sky130a
+#   version: 1.0.471_0_g97d0844
+#   manager: conda
+#   platform: linux-64
+#   dependencies: {}
+#   url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.471_0_g97d0844-20240223_100318.tar.bz2
+#   hash:
+#     md5: 3f9dab167b1bac3a6636f3f4311eb17e
+#     sha256: 37736ab56036733eaaff5f8f77a42c98caf75c82bc6b5dae59a727d24eabdd83
+#   category: main
+#   optional: false
 - name: openapi-schema-validator
   version: 0.6.3
   manager: conda

--- a/scripts/build-setup.sh
+++ b/scripts/build-setup.sh
@@ -190,7 +190,9 @@ if run_step "1"; then
     fi
     echo "Storing main conda environment in $CONDA_ENV_NAME"
 
-    conda-lock install --conda $(which conda) $CONDA_ENV_ARG $LOCKFILE &&
+    conda-lock install --conda $CONDA_EXE $CONDA_ENV_ARG $LOCKFILE &&
+    ## If the above line errors in your environment, you can try the line below
+    # conda-lock install --conda $(which conda) $CONDA_ENV_ARG $LOCKFILE &&
     source $(conda info --base)/etc/profile.d/conda.sh &&
     conda activate $CONDA_ENV_NAME
     exit_if_last_command_failed


### PR DESCRIPTION
**Edit 1**

At some point the `build-setup.sh` line:
```
conda-lock install --conda $CONDA_EXE $CONDA_ENV_ARG $LOCKFILE &&
```
Got changed to:
```
conda-lock install --conda $(which conda) $CONDA_ENV_ARG $LOCKFILE &&
```
Which does not work in all cases (such as BWRC and EDA machines), due to this behavior of `which conda`:
- https://superuser.com/questions/1602014/which-conda-doesnt-output-a-path

As seen in the issues here:
- https://github.com/ucb-bar/chipyard/issues/2016
- https://github.com/ucb-bar/chipyard/issues/2002
- https://github.com/ucb-bar/chipyard/issues/2073

Specifically it causes this build error:
```
Using lockfile for conda: [redacted]/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml
Storing main conda environment in /bwrcq/C/srevi/chipyard-simple-bugs/.conda-env
Usage: conda-lock install [OPTIONS] [LOCK_FILE]
Try 'conda-lock install --help' for help.

Error: Got unexpected extra arguments ({ \local cmd="${1-__missing__}"; case "$cmd" in activate | deactivate) __conda_activate "$@" ;; install | update | upgrade | remove | uninstall) __conda_exe "$@" || \return; __conda_activate reactivate ;; *) __conda_exe "$@" ;; esac } [redacted]/conda-reqs/conda-lock-reqs/conda-requirements-riscv-tools-linux-64.conda-lock.yml)
build-setup.sh: Build script failed with exit code 2 at step 1: Conda environment setup
```

I suggest reverting back to `$CONDA_EXE` (or figure out the reason for the change, but this fix has not failed me so far).

**Edit 2**

The `conda-requirements-riscv-tools-linux-64.conda-lock.yml` contains this dependency (lean version doesn't):
```
- name: open_pdks.sky130a
  version: 1.0.471_0_g97d0844
  manager: conda
  platform: linux-64
  dependencies: {}
  url: https://conda.anaconda.org/litex-hub/noarch/open_pdks.sky130a-1.0.471_0_g97d0844-20240223_100318.tar.bz2
  hash:
    md5: 3f9dab167b1bac3a6636f3f4311eb17e
    sha256: 37736ab56036733eaaff5f8f77a42c98caf75c82bc6b5dae59a727d24eabdd83
  category: main
  optional: false
```

Which I do not believe is complete yet, and it seems most SKY130 flows do not yet make use of it yet anyway.

As seen in the issue here:
- https://github.com/ucb-bar/chipyard/issues/2147

Specifically it causes this build error (x 20):
```
ERROR:root:CondaVerificationError: The package for open_pdks.sky130a located at /[redacted]/conda/pkgs/open_pdks.sky130a-1.0.471_0_g97d0844-20240223_100318
ERROR:root:appears to be corrupted. The path 'share/pdk/sky130A/libs.tech/xschem/xschem_verilog_import/spm.v'
ERROR:root:specified in the package manifest cannot be found.
ERROR:root:
ERROR:root:
```

I suggest commenting it out for now until someone digs into the setup deeper. 

--------

**Related PRs / Issues**:
- https://github.com/ucb-bar/chipyard/issues/2016
- https://github.com/ucb-bar/chipyard/issues/2002
- https://github.com/ucb-bar/chipyard/issues/2073
- https://github.com/ucb-bar/chipyard/issues/2147

**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [X] Build system change
- [ ] Other

**Contributor Checklist**:
- [X] Did you set `main` as the base branch?
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [X] Did you mark the PR with a `changelog:` label?
- [X] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?

Updated `/conda-reqs/chipyard-extended.yaml`, although I didn't have to do that in my other repos so a glance might be useful.

- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
- [ ] (If applicable) Did you mark the PR as `Please Backport`?

**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
