### PR TITLE
Relax checks for vcs/verilator/xcelium in PATH

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -184,6 +184,11 @@ else
 endif
 
 $(SFC_MFC_TARGETS) &: $(FIRRTL_FILE) $(FINAL_ANNO_FILE) $(MFC_LOWERING_OPTIONS)
+	@# Ensure firtool is available before invoking CIRCT to emit Verilog
+	@command -v firtool >/dev/null 2>&1 || { \
+		echo "Error: firtool (CIRCT) not found in PATH. Install/activate CIRCT before running this target." >&2; \
+		exit 1; \
+	}
 	rm -rf $(GEN_COLLATERAL_DIR)
 	(set -o pipefail && firtool \
 		--format=fir \

--- a/sims/vcs/Makefile
+++ b/sims/vcs/Makefile
@@ -67,11 +67,16 @@ model_dir_debug = $(build_dir)/$(long_name).debug
 #########################################################################################
 # vcs simulator rules
 #########################################################################################
-$(sim): $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS)
+.PHONY: check-vcs
+check-vcs:
+	@command -v vcs >/dev/null 2>&1 \
+		|| { echo "Error: Synopsys VCS not found in PATH. Set up your tool environment before building VCS sims." >&2; exit 1; }
+
+$(sim): $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS) | check-vcs
 	rm -rf $(model_dir)
 	$(VCS) $(VCS_OPTS) $(EXTRA_SIM_SOURCES) -o $@ -Mdir=$(model_dir)
 
-$(sim_debug): $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS)
+$(sim_debug): $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS) | check-vcs
 	rm -rf $(model_dir_debug)
 	$(VCS) $(VCS_OPTS) $(EXTRA_SIM_SOURCES) -o $@ -Mdir=$(model_dir_debug)  \
 	+define+DEBUG -debug_access+all -kdb -lca

--- a/sims/verilator/Makefile
+++ b/sims/verilator/Makefile
@@ -1,9 +1,11 @@
 #########################################################################################
 # verilator makefile
 #########################################################################################
-ifeq ($(shell which verilator),)
-$(error Did not find Verilator in PATH. Make sure all requirements are installed)
-endif
+# Only error if a target actually needs Verilator. Non-Verilator targets (e.g., verilog/help) should not fail.
+.PHONY: check-verilator
+check-verilator:
+	@command -v verilator >/dev/null 2>&1 \
+		|| { echo "Error: Verilator not found in PATH. Install or load it before building Verilator sims." >&2; exit 1; }
 
 #########################################################################################
 # general path variables
@@ -191,13 +193,13 @@ model_mk_debug = $(model_dir_debug)/V$(TB).mk
 #########################################################################################
 # build makefile fragment that builds the verilator sim rules
 #########################################################################################
-$(model_mk): $(sim_common_files) $(EXTRA_SIM_REQS)
+$(model_mk): $(sim_common_files) $(EXTRA_SIM_REQS) | check-verilator
 	rm -rf $(model_dir)
 	mkdir -p $(model_dir)
 	$(VERILATOR) $(VERILATOR_OPTS) $(EXTRA_SIM_SOURCES) -o $(sim) -Mdir $(model_dir)
 	touch $@
 
-$(model_mk_debug): $(sim_common_files) $(EXTRA_SIM_REQS)
+$(model_mk_debug): $(sim_common_files) $(EXTRA_SIM_REQS) | check-verilator
 	rm -rf $(model_dir_debug)
 	mkdir -p $(model_dir_debug)
 	$(VERILATOR) $(VERILATOR_OPTS) +define+DEBUG $(EXTRA_SIM_SOURCES) -o $(sim_debug) $(TRACING_OPTS) -Mdir $(model_dir_debug)

--- a/sims/xcelium/Makefile
+++ b/sims/xcelium/Makefile
@@ -80,8 +80,12 @@ model_dir_debug = $(build_dir)/$(long_name).debug
 #########################################################################################
 # xcelium simulator rules
 #########################################################################################
+.PHONY: check-xcelium
+check-xcelium:
+	@command -v xrun >/dev/null 2>&1 \
+		|| { echo "Error: Cadence Xcelium (xrun) not found in PATH. Set up your tool environment before building Xcelium sims." >&2; exit 1; }
 
-$(sim_workdir): $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS)
+$(sim_workdir): $(sim_common_files) $(dramsim_lib) $(EXTRA_SIM_REQS) | check-xcelium
 	rm -rf $(model_dir)
 	$(XCELIUM) -elaborate $(XCELIUM_OPTS) $(EXTRA_SIM_SOURCES) $(XCELIUM_COMMON_ARGS)
 


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
