### PR TITLE
Add full-config-finder: finds eligible CONFIG targets

### DIFF
--- a/.github/workflows/chipyard-full-flow.yml
+++ b/.github/workflows/chipyard-full-flow.yml
@@ -106,6 +106,7 @@ jobs:
           source env.sh
           cd sims/verilator
           make find-config-fragments
+          make find-configs
       - name: Run smoke test
         run: |
           cd ${{ env.REMOTE_WORK_DIR }}

--- a/common.mk
+++ b/common.mk
@@ -58,6 +58,7 @@ HELP_COMMANDS += \
 "   firrtl                      = generate intermediate firrtl files from chisel elaboration" \
 "   run-tests                   = run all assembly and benchmark tests" \
 "   launch-sbt                  = start sbt terminal" \
+"   find-configs                = list Chipyard Config classes (eligible CONFIG=)" \
 "   find-config-fragments       = list all config. fragments" \
 "   check-submodule-status      = check that all submodules in generators/ have been initialized"
 
@@ -440,6 +441,10 @@ endef
 .PHONY: find-config-fragments
 find-config-fragments:
 	$(call run_scala_main,chipyard,chipyard.ConfigFinder,)
+
+.PHONY: find-configs
+find-configs:
+	$(call run_scala_main,chipyard,chipyard.ChipyardConfigFinder,)
 
 .PHONY: help
 help:

--- a/docs/Customization/Keys-Traits-Configs.rst
+++ b/docs/Customization/Keys-Traits-Configs.rst
@@ -79,4 +79,5 @@ We can use this config fragment when composing our configs.
 Chipyard Config Fragments
 -------------------------
 
-For discoverability, users can run ``make find-config-fragments`` to see a list of config. fragments.
+For discoverability, users can run ``make find-configs`` to list Chipyard ``Config`` classes eligible for ``CONFIG=...`` (defaults to package ``chipyard``). Only classes whose names end with ``Config`` are shown.
+To see reusable building blocks, run ``make find-config-fragments`` to list config fragments.

--- a/docs/Simulation/Software-RTL-Simulation.rst
+++ b/docs/Simulation/Software-RTL-Simulation.rst
@@ -154,6 +154,17 @@ Therefore, in order to simulate a simple Rocket-based example system we can use:
     make SUB_PROJECT=yourproject
     ./simulator-<yourproject>-<yourconfig> ...
 
+Listing available configs
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To discover available Chipyard configs that can be passed as ``CONFIG=...`` (under the default ``CONFIG_PACKAGE=chipyard``), run:
+
+.. code-block:: shell
+
+    make find-configs
+
+This lists Chipyard classes that extend ``Config``. Only classes whose names end with ``Config`` are shown.
+
 
 Finally, in the ``generated-src/<...>-<package>-<config>/`` directory resides all of the collateral while the generated Verilog source files resides in ``generated-src/<...>-<package>-<config>/gen-collateral`` for the build/simulation.
 Specifically, for ``CONFIG=RocketConfig`` the SoC top-level (``TOP``) Verilog file is ``ChipTop.sv`` while the (``Model``) file is ``TestHarness.sv``.

--- a/generators/chipyard/src/main/scala/ConfigFinder.scala
+++ b/generators/chipyard/src/main/scala/ConfigFinder.scala
@@ -17,3 +17,28 @@ object ConfigFinder {
         }
     }
 }
+
+/**
+  * Lists only Chipyard configs suitable for use with make CONFIG=<Class>.
+  * Filters to classes in the `chipyard` package hierarchy that extend Config.
+  */
+object ChipyardConfigFinder {
+    def main(args: Array[String]) = {
+        val reflections = new Reflections()
+        val classes = reflections.get(SubTypes.of(classOf[Config]).asClass()).asScala
+        val chipyardOnly = classes
+          .map(_.getName)
+          .filter { n =>
+            val isChipyard = n.startsWith("chipyard.")
+            val notExamples = !n.startsWith("chipyard.example.")
+            val notHarness = !n.startsWith("chipyard.harness.")
+            val notIOBinders = !n.startsWith("chipyard.iobinders.")
+            val notConfigPkg = !n.startsWith("chipyard.config.")
+            val endsWithConfig = n.split("\\.").lastOption.exists(_.endsWith("Config"))
+            isChipyard && notExamples && notHarness && notIOBinders && notConfigPkg && endsWithConfig
+          }
+          .map(n => n.stripPrefix("chipyard."))
+        val sorted = SortedSet[String]() ++ chipyardOnly
+        sorted.foreach(println)
+    }
+}


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
