### PR TITLE
build-setup.sh: always time each step and print per-step summary table

### DIFF
--- a/scripts/build-setup.sh
+++ b/scripts/build-setup.sh
@@ -53,8 +53,6 @@ usage() {
     echo "  --skip-circt            : Skip CIRCT install (step 10)"
     echo "  --skip-clean            : Skip repository clean-up (step 11)"
 
-    echo "  --time-everything       : Generate per-step timing report"
-
     exit "$1"
 }
 
@@ -67,7 +65,6 @@ SKIP_LIST=()
 BUILD_CIRCT=false
 GLOBAL_ENV_NAME=""
 GITHUB_TOKEN="null"
-TIME_EVERYTHING=false
 
 # getopts does not support long options, and is inflexible
 while [ "$1" != "" ];
@@ -114,8 +111,6 @@ do
             SKIP_LIST+=(10) ;;
         --skip-clean)
             SKIP_LIST+=(11) ;;
-        --time-everything)
-            TIME_EVERYTHING=true ;;
         * )
             error "invalid option $1"
             usage 1 ;;
@@ -148,7 +143,7 @@ function begin_step
     thisStepNum=$1;
     thisStepDesc=$2;
     echo " ========== BEGINNING STEP $thisStepNum: $thisStepDesc =========="
-    if [ "$TIME_EVERYTHING" = true ]; then __STEP_START=$(date +%s); fi
+    __STEP_START=$(date +%s)
 }
 function exit_if_last_command_failed
 {
@@ -158,12 +153,10 @@ function exit_if_last_command_failed
     fi
 }
 record_step_time() {
-    if [ "$TIME_EVERYTHING" = true ]; then
-        local __end=$(date +%s)
-        STEP_IDS+=("$thisStepNum")
-        STEP_DESCS+=("$thisStepDesc")
-        STEP_WALL+=("$((__end-__STEP_START))")
-    fi
+    local __end=$(date +%s)
+    STEP_IDS+=("$thisStepNum")
+    STEP_DESCS+=("$thisStepDesc")
+    STEP_WALL+=("$((__end-__STEP_START))")
 }
 
 # add helper variable pointing to current chipyard top-level dir
@@ -382,7 +375,7 @@ fi
 
 echo "Setup complete!"
 
-if [ "$TIME_EVERYTHING" = true ] && [ "${#STEP_IDS[@]}" -gt 0 ]; then
+if [ "${#STEP_IDS[@]}" -gt 0 ]; then
     echo ""
     printf "Per-step timing (wall seconds)\n"
     printf "%-6s  %-8s  %s\n" "Step" "Seconds" "Description"


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
This PR makes per-step timing unconditional in build-setup.sh. Each step now records start and end times and a summary table is printed at the end of the run and captured in build-setup.log under the header Per-step timing (wall seconds). No external dependencies are added. Timing uses date +%s and simple arrays. Skip semantics and all existing steps are unchanged.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
