### PR TITLE
rh: pinned firesim submodule commit to f2 compatible

### DIFF
--- a/sims/firesim-staging/sample_config_build_recipes.yaml
+++ b/sims/firesim-staging/sample_config_build_recipes.yaml
@@ -2,199 +2,199 @@
 
 # Quad-core, Rocket-based recipes
 # REQUIRED FOR TUTORIALS
-firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.QuadRocketConfig
-    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 90
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_rocket_quadcore_nic_l2_llc4mb_ddr3: # rh: ran into some bitstream issue
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.QuadRocketConfig
+#    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 90
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # NB: This has a faster host-clock frequency than the NIC-based design, because
 # its uncore runs at half rate relative to the tile.
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
+    PLATFORM: f2
     TARGET_PROJECT: firesim
     TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.QuadRocketConfig
-    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
+    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
     deploy_quintuplet: null
     platform_config_args:
         fpga_frequency: 140
         build_strategy: TIMING
     post_build_hook: null
     metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Single-core, BOOM-based recipes
 # REQUIRED FOR TUTORIALS
-firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.LargeBoomV3Config
-    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 65
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_boom_singlecore_nic_l2_llc4mb_ddr3: # rh: ran into some bitstream issue
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.LargeBoomV3Config
+#    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 65
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # NB: This has a faster host-clock frequency than the NIC-based design, because
 # its uncore runs at half rate relative to the tile.
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
+    PLATFORM: f2
     TARGET_PROJECT: firesim
     TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomV3Config
-    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
+    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
     deploy_quintuplet: null
     platform_config_args:
         fpga_frequency: 65
         build_strategy: TIMING
     post_build_hook: null
     metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Single-core, CVA6-based recipes
-firesim_cva6_singlecore_no_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.CVA6Config
-    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 90
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+# firesim_cva6_singlecore_no_nic_l2_llc4mb_ddr3: # rh: untested for now
+#     PLATFORM: f2
+#     TARGET_PROJECT: firesim
+#     TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#     DESIGN: FireSim
+#     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.CVA6Config
+#     PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#     deploy_quintuplet: null
+#     platform_config_args:
+#         fpga_frequency: 90
+#         build_strategy: TIMING
+#     post_build_hook: null
+#     metasim_customruntimeconfig: null
+#     bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Single-core, Rocket-based recipes with Gemmini
-firesim_rocket_singlecore_gemmini_no_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
-    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 110
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_rocket_singlecore_gemmini_no_nic_l2_llc4mb_ddr3: # rh: untested for now
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimConfigTweaks_chipyard.GemminiRocketConfig
+#    PLATFORM_CONFIG: WithAutoILA_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 110
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # RAM Optimizations enabled by adding _MCRams PLATFORM_CONFIG string
-firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3_ramopts:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomV3Config
-    PLATFORM_CONFIG: WithAutoILA_MCRams_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 90
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3_ramopts: # rh: ran into some bitstream issue
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimTestChipConfigTweaks_chipyard.LargeBoomV3Config
+#    PLATFORM_CONFIG: WithAutoILA_MCRams_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 90
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Supernode configurations -- multiple instances of an SoC in a single simulator
-firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithNIC_SupernodeFireSimRocketConfig
-    PLATFORM_CONFIG: WithAutoILA_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 85
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_supernode_rocket_singlecore_nic_l2_lbp: # rh: untested for now
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithNIC_SupernodeFireSimRocketConfig
+#    PLATFORM_CONFIG: WithAutoILA_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 85
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Additional Tutorial Config
 firesim_rocket_singlecore_no_nic_l2_lbp:
-    PLATFORM: f1
+    PLATFORM: f2
     TARGET_PROJECT: firesim
     TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
     DESIGN: FireSim
     TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.RocketConfig
-    PLATFORM_CONFIG: BaseF1Config
+    PLATFORM_CONFIG: BaseF2Config
     deploy_quintuplet: null
     platform_config_args:
         fpga_frequency: 90
         build_strategy: TIMING
     post_build_hook: null
     metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Additional Tutorial Config
-firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
-    PLATFORM_CONFIG: FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 65
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3: # rh: untested for now
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithNIC_WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
+#    PLATFORM_CONFIG: FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 65
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Additional Tutorial Config
-firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
-    PLATFORM_CONFIG: FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 65
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3: # rh: untested for now
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketConfig
+#    PLATFORM_CONFIG: FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 65
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Additional Tutorial Config
-firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketPrintfConfig
-    PLATFORM_CONFIG: WithPrintfSynthesis_FRFCFS16GBQuadRankLLC4MB_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 30
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf: # rh: untested for now
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: WithDefaultFireSimBridges_WithFireSimHighPerfConfigTweaks_chipyard.Sha3RocketPrintfConfig
+#    PLATFORM_CONFIG: WithPrintfSynthesis_FRFCFS16GBQuadRankLLC4MB_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 30
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Additional Xilinx Vitis/XRT-only Config
 vitis_firesim_rocket_singlecore_no_nic:
@@ -213,36 +213,36 @@ vitis_firesim_rocket_singlecore_no_nic:
     bit_builder_recipe: bit-builder-recipes/vitis.yaml
 
 # Additional Tutorial Config
-firesim_gemmini_rocket_singlecore_no_nic:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: FireSimLeanGemminiRocketConfig
-    PLATFORM_CONFIG: BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 30 # AJG: conservative for now, later sweep for higher frequency
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_gemmini_rocket_singlecore_no_nic: # rh: untested for now
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: FireSimLeanGemminiRocketConfig
+#    PLATFORM_CONFIG: BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 30 # AJG: conservative for now, later sweep for higher frequency
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Additional Tutorial Config
-firesim_gemmini_printf_rocket_singlecore_no_nic:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: FireSimLeanGemminiPrintfRocketConfig
-    PLATFORM_CONFIG: WithPrintfSynthesis_BaseF1Config
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 10 # AJG: conservative for now, later sweep for higher frequency
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#firesim_gemmini_printf_rocket_singlecore_no_nic: # rh: untested for now
+#    PLATFORM: f2
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: FireSimLeanGemminiPrintfRocketConfig
+#    PLATFORM_CONFIG: WithPrintfSynthesis_BaseF2Config
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 10 # AJG: conservative for now, later sweep for higher frequency
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f2.yaml
 
 # Additional Xilinx Alveo U250-only Configs
 alveo_u250_firesim_rocket_singlecore_no_nic:
@@ -389,70 +389,70 @@ nitefury_firesim_rocket_singlecore_no_nic:
 ################################################################################################
 # Fast-mode : pull out a RocketTile out from your SoC
 ################################################################################################
-f1_rocket_split_soc_fast:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: FireSimRocketConfig
-    PLATFORM_CONFIG: RocketTileF1PCIMBase
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 90
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
-
-f1_rocket_split_tile_fast:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: FireSimRocketConfig
-    PLATFORM_CONFIG: RocketTileF1PCIMPartition0
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 90
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#f1_rocket_split_soc_fast: # rh: untested for now
+#    PLATFORM: f1
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: FireSimRocketConfig
+#    PLATFORM_CONFIG: RocketTileF1PCIMBase
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 90
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#
+#f1_rocket_split_tile_fast:
+#    PLATFORM: f1
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: FireSimRocketConfig
+#    PLATFORM_CONFIG: RocketTileF1PCIMPartition0
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 90
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f1.yaml
 # DOC include end: F1 Rocket Partition Build Recipe
 
 # DOC include start: F1 Exact Rocket Partition Build Recipe
 ################################################################################################
 # Exact-mode : pull out a RocketTile out from your SoC
 ################################################################################################
-f1_firesim_rocket_soc_exact:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: FireSimRocketConfig
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    PLATFORM_CONFIG: ExactMode_RocketTileF1PCIMBase
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 90
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
-
-f1_firesim_rocket_tile_exact:
-    PLATFORM: f1
-    TARGET_PROJECT: firesim
-    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
-    DESIGN: FireSim
-    TARGET_CONFIG: FireSimRocketConfig
-    PLATFORM_CONFIG: ExactMode_RocketTileF1PCIMPartition0
-    deploy_quintuplet: null
-    platform_config_args:
-        fpga_frequency: 90
-        build_strategy: TIMING
-    post_build_hook: null
-    metasim_customruntimeconfig: null
-    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#f1_firesim_rocket_soc_exact:
+#    PLATFORM: f1
+#    TARGET_PROJECT: firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: FireSimRocketConfig
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    PLATFORM_CONFIG: ExactMode_RocketTileF1PCIMBase
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 90
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f1.yaml
+#
+#f1_firesim_rocket_tile_exact:
+#    PLATFORM: f1
+#    TARGET_PROJECT: firesim
+#    TARGET_PROJECT_MAKEFRAG: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    DESIGN: FireSim
+#    TARGET_CONFIG: FireSimRocketConfig
+#    PLATFORM_CONFIG: ExactMode_RocketTileF1PCIMPartition0
+#    deploy_quintuplet: null
+#    platform_config_args:
+#        fpga_frequency: 90
+#        build_strategy: TIMING
+#    post_build_hook: null
+#    metasim_customruntimeconfig: null
+#    bit_builder_recipe: bit-builder-recipes/f1.yaml
 # DOC include end: F1 Exact Rocket Partition Build Recipe
 
 ##############################################################################

--- a/sims/firesim-staging/sample_config_hwdb.yaml
+++ b/sims/firesim-staging/sample_config_hwdb.yaml
@@ -6,62 +6,62 @@
 # own images.
 
 # DOCREF START: Example HWDB Entry
-firesim_boom_singlecore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-04de4143495fbdadb
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
+#firesim_boom_singlecore_nic_l2_llc4mb_ddr3: # rh: ran into some bitstream issue
+#    agfi: agfi-04de4143495fbdadb
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
 # DOCREF END: Example HWDB Entry
 firesim_boom_singlecore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0b7484cfa93e064d6
+    agfi: agfi-0dabb9e0a8b83db84
     deploy_quintuplet_override: null
     deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
     custom_runtime_config: null
-firesim_gemmini_printf_rocket_singlecore_no_nic:
-    agfi: agfi-0ace16d35c5758893
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
-firesim_gemmini_rocket_singlecore_no_nic:
-    agfi: agfi-05eec5fb565f7cfa3
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
-firesim_rocket_quadcore_nic_l2_llc4mb_ddr3:
-    agfi: agfi-072cc9daac93249da
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
+#firesim_gemmini_printf_rocket_singlecore_no_nic: # rh: F2 build not yet completed
+#    agfi: agfi-0ace16d35c5758893
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
+#firesim_gemmini_rocket_singlecore_no_nic: # rh: F2 build not yet completed
+#    agfi: agfi-05eec5fb565f7cfa3
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
+#firesim_rocket_quadcore_nic_l2_llc4mb_ddr3: # rh: ran into some bitstream issue
+#    agfi: agfi-072cc9daac93249da
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
 firesim_rocket_quadcore_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0d0cbe59e2914492a
+    agfi: agfi-0043d0e4a1842286e
     deploy_quintuplet_override: null
     deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
     custom_runtime_config: null
 firesim_rocket_singlecore_no_nic_l2_lbp:
-    agfi: agfi-0cfc97258aa8389f0
+    agfi: agfi-0a8cf19c0ba9de994
     deploy_quintuplet_override: null
     deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
     custom_runtime_config: null
-firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3:
-    agfi: agfi-02e4056f9bec5a240
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
-firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3:
-    agfi: agfi-0d8abef077c23a4de
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
-firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf:
-    agfi: agfi-033e840230f51668f
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
-firesim_supernode_rocket_singlecore_nic_l2_lbp:
-    agfi: agfi-0eae0fa36537e2835
-    deploy_quintuplet_override: null
-    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
-    custom_runtime_config: null
+#firesim_rocket_singlecore_sha3_nic_l2_llc4mb_ddr3: # rh: F2 build not yet completed
+#    agfi: agfi-02e4056f9bec5a240
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
+#firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3: # rh: F2 build not yet completed
+#    agfi: agfi-0d8abef077c23a4de
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
+#firesim_rocket_singlecore_sha3_no_nic_l2_llc4mb_ddr3_printf: # rh: F2 build not yet completed
+#    agfi: agfi-033e840230f51668f
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
+#firesim_supernode_rocket_singlecore_nic_l2_lbp: # rh: F2 build not yet completed
+#    agfi: agfi-094bb2d1661a98cf9
+#    deploy_quintuplet_override: null
+#    deploy_makefrag_override: ../../generators/firechip/chip/src/main/makefrag/firesim
+#    custom_runtime_config: null
 vitis_firesim_rocket_singlecore_no_nic:
     bitstream_tar: https://raw.githubusercontent.com/firesim/firesim-public-bitstreams/11ba762decd46c5a933960eae699aaf551d6769f/vitis/vitis_firesim_rocket_singlecore_no_nic.tar.gz
     deploy_quintuplet_override: null


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->
Adding base support for FireSim F2. This commit removes functionality for deprecated Amazon EC2 F1 FPGA instances and replaces it with F2 FPGA instances by pinning the Chipyard submodule checkout to our new FireSim main commit. Existing Chipyard consumers may instead checkout `sims/firesim` main branch, then run `./build-setup --library`. Support for cluster simulations and XDMA forthcoming.

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->
https://github.com/aws/aws-fpga/issues/671
https://github.com/firesim/firesim/pull/1864
https://github.com/firesim/firesim/pull/1868

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [x] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
