### PR TITLE
fix: firechip CTCFireSimConfig to match new CTC changes

### DIFF
--- a/generators/firechip/chip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/chip/src/main/scala/TargetConfigs.scala
@@ -356,7 +356,15 @@ class FireSimLargeBoomSV39CospikeConfig extends Config(
 
 class CTCFireSimConfig extends Config(
   new WithCTCBridge ++
-  new testchipip.ctc.WithCTC(Seq(new testchipip.ctc.CTCParams(onchipAddr = 0x1000000000L, offchipAddr = 0x0L, size = ((1L << 32) - 1), noPhy=true))) ++ 
+  new testchipip.ctc.WithCTC(Seq(new testchipip.ctc.CTCParams(
+    translationParams = testchipip.soc.OutwardAddressTranslatorParams(
+      // Outward CTC: accesses from this chip to offchipAddr+x are interpreted as going off chip via CTC/accesses are routed to CTC.
+      // The translator strips that local off-chip base value before forwarding, so
+      // the other chip receives onchipAddr+x in its normal Chipyard address map.
+      onchipAddr = 0x0L,
+      offchipAddr = 0x1000000000L,
+      size = ((1L << 32) - 1)),
+    phyParams = None))) ++
   new chipyard.iobinders.WithCTCPunchthrough ++ 
   new FireSimRocketConfig
 )


### PR DESCRIPTION
<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

Recent changes (https://github.com/ucb-bar/chipyard/pull/2326 & https://github.com/ucb-bar/chipyard/pull/2331) changed the API for the CTC. However, the firesim CTC config was not changed, which causes 
```
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m/scratch/jfx/fsim-chiplet-bug/generators/
:359:74: unknown parameter name: onchipAddr[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m  new testchipip.ctc.WithCTC(Seq(new testchipi
pAddr = 0x0L, size = ((1L << 32) - 1), noPhy=true))) ++ [0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m
                            ^[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m/scratch/jfx/fsim-chiplet-bug/generators/
:359:103: unknown parameter name: offchipAddr[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m  new testchipip.ctc.WithCTC(Seq(new testchipi
pAddr = 0x0L, size = ((1L << 32) - 1), noPhy=true))) ++ [0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m
                                                         ^[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m/scratch/jfx/fsim-chiplet-bug/generators/
:359:116: unknown parameter name: size[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m  new testchipip.ctc.WithCTC(Seq(new testchipi
pAddr = 0x0L, size = ((1L << 32) - 1), noPhy=true))) ++ [0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m
                                                                      ^[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m/scratch/jfx/fsim-chiplet-bug/generators/
:359:141: unknown parameter name: noPhy[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m  new testchipip.ctc.WithCTC(Seq(new testchipi
pAddr = 0x0L, size = ((1L << 32) - 1), noPhy=true))) ++ [0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m
                                                                                               ^[0m
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0mfour errors found[0m[0J
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0m(Compile / [31mcompileIncremental[0m) 
[localhost] out: [0J[0m[[0m[31merror[0m] [0m[0mTotal time: 54 s, completed Apr 27, 2026, 
[localhost] out: [0J[0Jmake[1]: *** [/scratch/jfx/fsim-chiplet-bug/common.mk:138: /scratch/jfx/
Error 1
```

<img width="3588" height="3948" alt="CleanShot 2026-04-25 at 04 14 59@2x" src="https://github.com/user-attachments/assets/3af89342-c57d-4eaa-be10-03b4d2d635a6" />

The PR adopts the new `OutwardAddressTranslatorParams` API. Of note: if we do not swap the `onchipAddress` and `offchipAddr` (ie keep `onchipAddr = 0x1000000000L` and `offchipAddr = 0x0L` [like before]), we get the following error:

`Caused by: java.lang.IllegalArgumentException: requirement failed: Ports cannot overlap: AddressSet(0x3000, 0xfff) AddressSet(0x0, 0xffffffff)`

The change:
```
onchipAddr = 0x0L,
offchipAddr = 0x1000000000L,
```
means: 
local accesses to `0x1000000000L + x` address gets routed through CTC -- a translation of the address is done before shipping off to a remote chip (which receives 0x0 + x).

We use `OutwardAddressTranslatorParams` (not `InwardAddressTranslatorParams`) as our core is sending an access off-chip, and therefore we want to translate the address before it leaves. `InwardAddressTranslatorParams` is for incoming requests.


Verification:

```
make PLATFORM=xilinx_alveo_u250 TARGET_PROJECT=firesim TARGET_PROJECT_MAKEFRAG=/scratch/jfx/fsim-chiplet-bug/sims/firesim/deploy/../../../generators/firechip/chip/src/main/makefrag/firesim DESIGN=FireSim TARGET_CONFIG=CTCFireSimConfig PLATFORM_CONFIG=BaseXilinxAlveoU250Config replace-rtl
```
runs to completion (until Vivado triggers).

<!-- choose one -->
**Type of change**:
- [X] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [X] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [X] Did you set `main` as the base branch?
- [X] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [X] Did you state the type-of-change/impact?
- [X] Did you delete any extraneous prints/debugging code?
- [No Permissions] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
