### PR TITLE
firechip: add direct JTAG bridge

### DIFF
--- a/generators/firechip/LICENSE.Berkeley
+++ b/generators/firechip/LICENSE.Berkeley
@@ -1,0 +1,24 @@
+Copyright (c) 2012-2014, The Regents of the University of California
+(Regents).  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the Regents nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/generators/firechip/bridgeinterfaces/src/main/scala/JTAG.scala
+++ b/generators/firechip/bridgeinterfaces/src/main/scala/JTAG.scala
@@ -1,0 +1,23 @@
+// See LICENSE for license details.
+
+package firechip.bridgeinterfaces
+
+import chisel3._
+
+// TCK is a Bool (not a Clock) so that HostPort can channelize it as a regular
+// data signal. The bridge stub casts it to Clock when connecting to the
+// target's JTAGChipIO.
+class JTAGBridgeTargetIO extends Bundle {
+  val jtag = new JTAGBridgePortIO
+  val clock = Input(Clock())
+  val reset = Input(Bool())
+}
+
+class JTAGBridgePortIO extends Bundle {
+  val TCK = Output(Bool())
+  val TMS = Output(Bool())
+  val TDI = Output(Bool())
+  val TDO = Input(Bool())
+}
+
+case class JTAGBridgeParams()

--- a/generators/firechip/bridgestubs/src/main/cc/bridges/jtagbridge.cc
+++ b/generators/firechip/bridgestubs/src/main/cc/bridges/jtagbridge.cc
@@ -1,0 +1,60 @@
+// See LICENSE for license details.
+
+#include "bridges/jtagbridge.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+char jtagbridge_t::KIND;
+
+static const int DEFAULT_RBB_PORT = 25000;
+static const char PORT_ARG_PREFIX[] = "+jtag_rbb_port=";
+
+jtagbridge_t::jtagbridge_t(simif_t &simif,
+                           const JTAGBRIDGEMODULE_struct &mmio_addrs,
+                           int jtagno,
+                           const std::vector<std::string> &args)
+    : bridge_driver_t(simif, &KIND),
+      mmio_addrs_(mmio_addrs),
+      rbb_(nullptr),
+      rbb_port_(DEFAULT_RBB_PORT + jtagno) {
+  for (const auto &arg : args) {
+    if (arg.find(PORT_ARG_PREFIX) == 0) {
+      rbb_port_ = std::atoi(arg.c_str() + strlen(PORT_ARG_PREFIX));
+    }
+  }
+}
+
+jtagbridge_t::~jtagbridge_t() { delete rbb_; }
+
+void jtagbridge_t::init() {
+  rbb_ = new remote_bitbang_t((uint16_t)rbb_port_);
+  std::cout << "[JTAGBridge] remote_bitbang listening on port " << rbb_port_
+            << std::endl;
+}
+
+// Semantics of one bridge tick:
+//   - Consumes exactly one remote_bitbang command byte from the client (a pin
+//     update '0'..'7', a 'R' TDO sample, or 'Q'); this advances the target by
+//     one token.
+//   - Reads the sampled TDO from the target (one MMIO read) and writes back the
+//     TCK/TMS/TDI pin state the client requested (three MMIO writes).
+// A single tick is therefore one pin update or one TDO sample, NOT a complete
+// JTAG bit: a full bit takes at least a TCK-low and a TCK-high command, plus a
+// separate 'R' when the client wants to read TDO. The remote_bitbang client owns
+// all TAP sequencing and samples TDO (via 'R') at the point it considers stable
+// (conventionally while TCK is low, before driving the next rising edge).
+void jtagbridge_t::tick() {
+  if (!rbb_)
+    return;
+
+  unsigned char tck = 0, tms = 0, tdi = 0, trstn = 0;
+  unsigned char tdo = (unsigned char)read(mmio_addrs_.tdo);
+
+  rbb_->tick(&tck, &tms, &tdi, &trstn, tdo);
+
+  write(mmio_addrs_.tck, tck);
+  write(mmio_addrs_.tms, tms);
+  write(mmio_addrs_.tdi, tdi);
+}

--- a/generators/firechip/bridgestubs/src/main/cc/bridges/jtagbridge.h
+++ b/generators/firechip/bridgestubs/src/main/cc/bridges/jtagbridge.h
@@ -1,0 +1,41 @@
+// See LICENSE for license details.
+
+#ifndef __JTAGBRIDGE_H
+#define __JTAGBRIDGE_H
+
+#include "bridges/remote_bitbang.h"
+#include "core/bridge_driver.h"
+#include "core/simif.h"
+
+#include <string>
+#include <vector>
+
+struct JTAGBRIDGEMODULE_struct {
+  uint64_t tck;
+  uint64_t tms;
+  uint64_t tdi;
+  uint64_t tdo;
+};
+
+class jtagbridge_t final : public bridge_driver_t {
+public:
+  static char KIND;
+
+  jtagbridge_t(simif_t &simif,
+               const JTAGBRIDGEMODULE_struct &mmio_addrs,
+               int jtagno,
+               const std::vector<std::string> &args);
+  ~jtagbridge_t();
+
+  virtual void init() override;
+  virtual void tick() override;
+  virtual bool terminate() override { return rbb_ && rbb_->done(); }
+  virtual int exit_code() override { return rbb_ ? rbb_->exit_code() : 0; }
+
+private:
+  const JTAGBRIDGEMODULE_struct mmio_addrs_;
+  remote_bitbang_t *rbb_;
+  int rbb_port_;
+};
+
+#endif // __JTAGBRIDGE_H

--- a/generators/firechip/bridgestubs/src/main/cc/bridges/remote_bitbang.cc
+++ b/generators/firechip/bridgestubs/src/main/cc/bridges/remote_bitbang.cc
@@ -1,0 +1,200 @@
+// See LICENSE.Berkeley for license details.
+
+// Generic OpenOCD-compatible remote_bitbang JTAG server. Derived from
+// rocket-chip's src/main/resources/csrc/remote_bitbang.cc (originally from the
+// Berkeley/Spike riscv-isa-sim project). The only functional change from that
+// source is that accept()/execute_command() are non-blocking (they service at
+// most one client action per call and return), which is required by the FireSim
+// bridge tick model; no target- or bridge-specific logic has been added. The
+// referenced LICENSE.Berkeley file is provided at the root of the firechip
+// generator (generators/firechip/LICENSE.Berkeley).
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+#include "remote_bitbang.h"
+
+/////////// remote_bitbang_t
+
+remote_bitbang_t::remote_bitbang_t(uint16_t port) :
+  err(0),
+  socket_fd(0),
+  client_fd(0),
+  recv_start(0),
+  recv_end(0)
+{
+  socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (socket_fd == -1) {
+    fprintf(stderr, "remote_bitbang failed to make socket: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+
+  fcntl(socket_fd, F_SETFL, O_NONBLOCK);
+  int reuseaddr = 1;
+  if (setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
+                 sizeof(int)) == -1) {
+    fprintf(stderr, "remote_bitbang failed setsockopt: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port);
+
+  if (::bind(socket_fd, (struct sockaddr *) &addr, sizeof(addr)) == -1) {
+    fprintf(stderr, "remote_bitbang failed to bind socket: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+
+  if (listen(socket_fd, 1) == -1) {
+    fprintf(stderr, "remote_bitbang failed to listen on socket: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+
+  socklen_t addrlen = sizeof(addr);
+  if (getsockname(socket_fd, (struct sockaddr *) &addr, &addrlen) == -1) {
+    fprintf(stderr, "remote_bitbang getsockname failed: %s (%d)\n",
+            strerror(errno), errno);
+    abort();
+  }
+
+  tck = 1;
+  tms = 1;
+  tdi = 1;
+  trstn = 1;
+  quit = 0;
+
+  fprintf(stderr, "This emulator compiled with JTAG Remote Bitbang client. To enable, use +jtag_rbb_enable=1.\n");
+  fprintf(stderr, "Listening on port %d\n",
+         ntohs(addr.sin_port));
+}
+
+void remote_bitbang_t::accept()
+{
+  client_fd = ::accept(socket_fd, NULL, NULL);
+  if (client_fd == -1) {
+    if (errno == EAGAIN) {
+      // No client waiting; return and let the simulation proceed.
+    } else {
+      fprintf(stderr, "failed to accept on socket: %s (%d)\n", strerror(errno),
+              errno);
+      abort();
+    }
+  } else {
+    fcntl(client_fd, F_SETFL, O_NONBLOCK);
+    fprintf(stderr, "Accepted successfully.\n");
+  }
+}
+
+void remote_bitbang_t::tick(
+                            unsigned char * jtag_tck,
+                            unsigned char * jtag_tms,
+                            unsigned char * jtag_tdi,
+                            unsigned char * jtag_trstn,
+                            unsigned char jtag_tdo
+                            )
+{
+  if (client_fd > 0) {
+    tdo = jtag_tdo;
+    execute_command();
+  } else {
+    // client_fd <= 0 means no client connected; try non-blocking accept
+    this->accept();
+  }
+
+  * jtag_tck = tck;
+  * jtag_tms = tms;
+  * jtag_tdi = tdi;
+  * jtag_trstn = trstn;
+
+}
+
+void remote_bitbang_t::reset(){
+  //trstn = 0;
+}
+
+void remote_bitbang_t::set_pins(char _tck, char _tms, char _tdi){
+  tck = _tck;
+  tms = _tms;
+  tdi = _tdi;
+}
+
+void remote_bitbang_t::execute_command()
+{
+  char command;
+  ssize_t num_read = read(client_fd, &command, sizeof(command));
+  if (num_read == -1) {
+    if (errno == EAGAIN) {
+      // No data available right now; will try on next tick.
+      return;
+    } else {
+      fprintf(stderr, "remote_bitbang failed to read on socket: %s (%d)\n",
+              strerror(errno), errno);
+      abort();
+    }
+  } else if (num_read == 0) {
+    // Client disconnected; go back to accepting new clients.
+    fprintf(stderr, "Remote end disconnected.\n");
+    close(client_fd);
+    client_fd = -1;
+    return;
+  }
+
+  int dosend = 0;
+
+  char tosend = '?';
+
+  switch (command) {
+  case 'B': /* fprintf(stderr, "*BLINK*\n"); */ break;
+  case 'b': /* fprintf(stderr, "_______\n"); */ break;
+  case 'r': reset(); break; // This is wrong. 'r' has other bits that indicated TRST and SRST.
+  case '0': set_pins(0, 0, 0); break;
+  case '1': set_pins(0, 0, 1); break;
+  case '2': set_pins(0, 1, 0); break;
+  case '3': set_pins(0, 1, 1); break;
+  case '4': set_pins(1, 0, 0); break;
+  case '5': set_pins(1, 0, 1); break;
+  case '6': set_pins(1, 1, 0); break;
+  case '7': set_pins(1, 1, 1); break;
+  case 'R': dosend = 1; tosend = tdo ? '1' : '0'; break;
+  case 'Q': quit = 1; break;
+  default:
+    fprintf(stderr, "remote_bitbang got unsupported command '%c'\n",
+            command);
+  }
+
+  if (dosend){
+    while (1) {
+      ssize_t bytes = write(client_fd, &tosend, sizeof(tosend));
+      if (bytes == -1) {
+        fprintf(stderr, "failed to write to socket: %s (%d)\n", strerror(errno), errno);
+        abort();
+      }
+      if (bytes > 0) {
+        break;
+      }
+    }
+  }
+
+  if (quit) {
+    // The remote disconnected.
+    fprintf(stderr, "Remote end disconnected\n");
+    close(client_fd);
+    client_fd = 0;
+  }
+}

--- a/generators/firechip/bridgestubs/src/main/cc/bridges/remote_bitbang.h
+++ b/generators/firechip/bridgestubs/src/main/cc/bridges/remote_bitbang.h
@@ -1,0 +1,68 @@
+// See LICENSE.Berkeley for license details.
+
+// Generic OpenOCD-compatible remote_bitbang JTAG server. Derived from
+// rocket-chip's src/main/resources/csrc/remote_bitbang.{cc,h} (originally from
+// the Berkeley/Spike riscv-isa-sim project). It is intentionally protocol-only:
+// it holds the JTAG pin state (TCK/TMS/TDI/TDO) and speaks the OpenOCD
+// remote_bitbang wire protocol, with no target- or bridge-specific behavior, so
+// it can be shared by the direct JTAG bridge and other host-driven bridges. The
+// referenced LICENSE.Berkeley file is provided at the root of the firechip
+// generator (generators/firechip/LICENSE.Berkeley).
+
+#ifndef REMOTE_BITBANG_H
+#define REMOTE_BITBANG_H
+
+#include <stdint.h>
+#include <sys/types.h>
+
+class remote_bitbang_t
+{
+public:
+  // Create a new server, listening for connections from localhost on the given
+  // port.
+  remote_bitbang_t(uint16_t port);
+
+  // Do a bit of work.
+  void tick(unsigned char * jtag_tck,
+            unsigned char * jtag_tms,
+            unsigned char * jtag_tdi,
+            unsigned char * jtag_trstn,
+            unsigned char jtag_tdo);
+
+  unsigned char done() {return quit;}
+
+  int exit_code() {return err;}
+
+ private:
+
+  int err;
+
+  unsigned char tck;
+  unsigned char tms;
+  unsigned char tdi;
+  unsigned char trstn;
+  unsigned char tdo;
+  unsigned char quit;
+
+  int socket_fd;
+  int client_fd;
+
+  static const ssize_t buf_size = 64 * 1024;
+  char recv_buf[buf_size];
+  ssize_t recv_start, recv_end;
+
+  // Check for a client connecting, and accept if there is one.
+  void accept();
+  // Execute any commands the client has for us.
+  // But we only execute 1 because we need time for the
+  // simulation to run.
+  void execute_command();
+
+  // Reset. Currently does nothing.
+  void reset();
+
+  void set_pins(char _tck, char _tms, char _tdi);
+
+};
+
+#endif

--- a/generators/firechip/bridgestubs/src/main/cc/bridges/test/JTAGModule.cc
+++ b/generators/firechip/bridgestubs/src/main/cc/bridges/test/JTAGModule.cc
@@ -1,0 +1,264 @@
+// See LICENSE for license details.
+
+// Functional smoke test for the direct-JTAG bridge. A host-side remote_bitbang
+// client (running in a helper thread) connects to the bridge's server, drives
+// the target TAP through a Test-Logic-Reset and a Shift-DR, and shifts out the
+// 32-bit IDCODE. The JTAGDUT wires the bridge pins to a real Rocket-Chip JTAG
+// TAP whose only data register is IDCODE (version/part/mfr = 0), so a correct
+// end-to-end path returns exactly 0x00000001. The sequence is run twice to
+// catch dropped, duplicated, or stale commands, then the client disconnects
+// cleanly.
+
+#include "BridgeHarness.h"
+
+#include "bridges/peek_poke.h"
+#include "core/bridge_driver.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+
+namespace {
+
+// Must match jtagbridge_t's default (DEFAULT_RBB_PORT + jtagno, jtagno == 0).
+constexpr int kDefaultRbbPort = 25000;
+constexpr uint32_t kExpectedIdcode = 0x00000001;
+// Wall-clock ceilings so a broken path fails instead of hanging forever.
+constexpr int kConnectTimeoutSec = 30;
+constexpr int kRecvTimeoutSec = 30;
+
+/// Minimal OpenOCD-style remote_bitbang client. One ASCII byte per host op:
+///   '0'..'7' -> set pins, byte = '0' + (tck<<2 | tms<<1 | tdi)
+///   'R'      -> sample TDO, server replies one byte '0'/'1'
+///   'Q'      -> quit
+class RemoteBitbangClient {
+public:
+  bool connect_with_retry(int port) {
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(kConnectTimeoutSec);
+    while (std::chrono::steady_clock::now() < deadline) {
+      fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+      if (fd_ < 0)
+        return fail("socket() failed");
+
+      struct sockaddr_in addr;
+      memset(&addr, 0, sizeof(addr));
+      addr.sin_family = AF_INET;
+      addr.sin_port = htons(port);
+      inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+      if (::connect(fd_, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+        int one = 1;
+        setsockopt(fd_, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+        struct timeval tv;
+        tv.tv_sec = kRecvTimeoutSec;
+        tv.tv_usec = 0;
+        setsockopt(fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        return true;
+      }
+      ::close(fd_);
+      fd_ = -1;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return fail("could not connect to remote_bitbang server");
+  }
+
+  // Drive a full reset + Shift-DR IDCODE read; returns false on I/O failure.
+  bool read_idcode(uint32_t &idcode) {
+    // Test-Logic-Reset: >=5 TCK with TMS high reaches TLR from any state.
+    for (int i = 0; i < 6; i++)
+      if (!clock(1, 0))
+        return false;
+    // TLR -> Run-Test/Idle -> Select-DR -> Capture-DR -> Shift-DR.
+    if (!clock(0, 0) || !clock(1, 0) || !clock(0, 0) || !clock(0, 0))
+      return false;
+    // Shift 32 bits LSB-first; hold TMS low except on the final bit.
+    idcode = 0;
+    for (int i = 0; i < 32; i++) {
+      int bit = 0;
+      if (!shift_bit(/*tms=*/i == 31 ? 1 : 0, /*tdi=*/0, bit))
+        return false;
+      idcode |= (static_cast<uint32_t>(bit) << i);
+    }
+    // Update-DR -> Run-Test/Idle.
+    return clock(1, 0) && clock(0, 0);
+  }
+
+  bool quit() { return send_byte('Q'); }
+
+  void close_socket() {
+    if (fd_ >= 0) {
+      ::close(fd_);
+      fd_ = -1;
+    }
+  }
+
+  const std::string &error() const { return error_; }
+
+private:
+  bool pins(int tck, int tms, int tdi) {
+    const char c = static_cast<char>('0' + ((tck & 1) << 2 | (tms & 1) << 1 | (tdi & 1)));
+    return send_byte(c);
+  }
+
+  bool clock(int tms, int tdi) { return pins(0, tms, tdi) && pins(1, tms, tdi); }
+
+  // In a Shift state: sample TDO while TCK is low, then pulse TCK high.
+  bool shift_bit(int tms, int tdi, int &bit_out) {
+    if (!pins(0, tms, tdi))
+      return false;
+    if (!read_tdo(bit_out))
+      return false;
+    return pins(1, tms, tdi);
+  }
+
+  bool send_byte(char c) {
+    ssize_t n = ::send(fd_, &c, 1, 0);
+    if (n != 1)
+      return fail("send() failed");
+    return true;
+  }
+
+  bool read_tdo(int &bit_out) {
+    if (!send_byte('R'))
+      return false;
+    char reply = 0;
+    ssize_t n = ::recv(fd_, &reply, 1, 0);
+    if (n != 1)
+      return fail("recv() of TDO failed or timed out");
+    bit_out = (reply == '1') ? 1 : 0;
+    return true;
+  }
+
+  bool fail(const char *msg) {
+    if (error_.empty())
+      error_ = std::string(msg) + " (errno=" + std::to_string(errno) + ")";
+    return false;
+  }
+
+  int fd_ = -1;
+  std::string error_;
+};
+
+} // namespace
+
+class JTAGModuleTest final : public BridgeHarness {
+public:
+  JTAGModuleTest(widget_registry_t &registry, const std::vector<std::string> &args)
+      : BridgeHarness(registry, args) {
+    for (const auto &arg : args) {
+      constexpr char kPrefix[] = "+jtag_rbb_port=";
+      if (arg.rfind(kPrefix, 0) == 0)
+        rbb_port_ = std::atoi(arg.c_str() + strlen(kPrefix));
+    }
+  }
+
+  int simulation_run() override {
+    auto &peek_poke = registry.get_widget<peek_poke_t>();
+
+    // Reset the DUT.
+    peek_poke.poke("reset", 1, /*blocking=*/true);
+    peek_poke.step(1, /*blocking=*/true);
+    peek_poke.poke("reset", 0, /*blocking=*/true);
+    peek_poke.step(1, /*blocking=*/true);
+
+    // Advance the target for the duration of the test (non-blocking).
+    peek_poke.step(get_step_limit(), /*blocking=*/false);
+
+    // Run the host JTAG client concurrently with the bridge tick loop.
+    std::thread client([this] { client_body(); });
+
+    unsigned ticks = 0;
+    const unsigned tick_limit = get_tick_limit();
+    while (ticks < tick_limit && !client_done_.load(std::memory_order_acquire) &&
+           !peek_poke.is_done()) {
+      for (auto &bridge : registry.get_all_bridges())
+        bridge->tick();
+      ++ticks;
+    }
+    client.join();
+
+    if (!client_ok_) {
+      fprintf(stderr, "[JTAGModuleTest] FAILED: %s\n", client_error_.c_str());
+      return EXIT_FAILURE;
+    }
+    fprintf(stderr, "[JTAGModuleTest] PASSED: IDCODE=0x%08x read twice\n", idcode0_);
+    return EXIT_SUCCESS;
+  }
+
+private:
+  unsigned get_step_limit() const override { return 2000000; }
+  unsigned get_tick_limit() const override { return 2000000; }
+
+  void client_body() {
+    RemoteBitbangClient client;
+    auto finish = [&](bool ok, const std::string &msg) {
+      client_ok_ = ok;
+      if (!ok)
+        client_error_ = msg.empty() ? client.error() : msg;
+      client.close_socket();
+      client_done_.store(true, std::memory_order_release);
+    };
+
+    if (!client.connect_with_retry(rbb_port_)) {
+      finish(false, client.error());
+      return;
+    }
+
+    uint32_t id0 = 0, id1 = 0;
+    if (!client.read_idcode(id0) || !client.read_idcode(id1)) {
+      finish(false, client.error());
+      return;
+    }
+    idcode0_ = id0;
+    idcode1_ = id1;
+
+    // Clean shutdown regardless of result: tell the server to quit.
+    client.quit();
+
+    if (id0 != id1) {
+      finish(false, "IDCODE not stable across two reads (" + hex(id0) + " vs " + hex(id1) + ")");
+      return;
+    }
+    if ((id0 & 1u) != 1u) {
+      finish(false, "IDCODE LSB is 0 (IEEE 1149.1 requires bit0 == 1): " + hex(id0));
+      return;
+    }
+    if (id0 == 0u || id0 == 0xffffffffu) {
+      finish(false, "IDCODE all-zero/all-one (TAP not responding): " + hex(id0));
+      return;
+    }
+    if (id0 != kExpectedIdcode) {
+      finish(false, "IDCODE " + hex(id0) + " != expected " + hex(kExpectedIdcode));
+      return;
+    }
+    finish(true, "");
+  }
+
+  static std::string hex(uint32_t v) {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "0x%08x", v);
+    return std::string(buf);
+  }
+
+  int rbb_port_ = kDefaultRbbPort;
+  std::atomic<bool> client_done_{false};
+  bool client_ok_ = false;
+  std::string client_error_;
+  uint32_t idcode0_ = 0;
+  uint32_t idcode1_ = 0;
+};
+
+TEST_MAIN(JTAGModuleTest)

--- a/generators/firechip/bridgestubs/src/main/scala/jtag/JTAGBridge.scala
+++ b/generators/firechip/bridgestubs/src/main/scala/jtag/JTAGBridge.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details
+
+package firechip.bridgestubs
+
+import chisel3._
+
+import org.chipsalliance.cde.config.Parameters
+
+import firesim.lib.bridgeutils._
+
+import firechip.bridgeinterfaces._
+import chipyard.iobinders.JTAGChipIO
+
+class JTAGBridge(implicit p: Parameters)
+    extends BlackBox
+    with Bridge[HostPortIO[JTAGBridgeTargetIO]] {
+  val moduleName = "firechip.goldengateimplementations.JTAGBridgeModule"
+  val io = IO(new JTAGBridgeTargetIO)
+  val bridgeIO = HostPort(io)
+  val constructorArg = Some(JTAGBridgeParams())
+  generateAnnotations()
+}
+
+object JTAGBridge {
+  def apply(clock: Clock, port: JTAGChipIO, reset: Bool)(implicit p: Parameters): JTAGBridge = {
+    val ep = Module(new JTAGBridge)
+    ep.io.clock := clock
+    ep.io.reset := reset
+    // Bool -> Clock cast: the target treats this as the JTAG clock domain
+    port.TCK := ep.io.jtag.TCK.asClock
+    port.TMS := ep.io.jtag.TMS
+    port.TDI := ep.io.jtag.TDI
+    ep.io.jtag.TDO := port.TDO
+    // If the JTAGChipIO has a reset, drive it from the bridge reset
+    port.reset.foreach(_ := reset)
+    ep
+  }
+}

--- a/generators/firechip/bridgestubs/src/main/scala/jtag/JTAGModule.scala
+++ b/generators/firechip/bridgestubs/src/main/scala/jtag/JTAGModule.scala
@@ -1,0 +1,48 @@
+// See LICENSE for license details.
+
+package firechip.bridgestubs
+
+import chisel3._
+
+import org.chipsalliance.cde.config.Parameters
+
+import freechips.rocketchip.jtag.{Chain, JtagTapGenerator, JTAGIdcodeBundle}
+
+import firechip.bridgeinterfaces._
+
+/** Smallest self-contained target that exercises the direct-JTAG bridge end to
+  * end. The host-driven TCK/TMS/TDI/TDO pins from [[JTAGBridge]] feed a real
+  * Rocket-Chip JTAG TAP whose only data register is IDCODE. With
+  * version/part/mfr all zero the IDCODE reads back as 0x00000001, giving the
+  * host driver a deterministic value to assert on after a TAP reset and a
+  * Shift-DR of 32 bits. The TAP is clocked by the host-driven TCK, exactly as
+  * in a real design.
+  */
+class JTAGDUT(implicit val p: Parameters) extends Module {
+  val ep = Module(new JTAGBridge)
+  ep.io.clock := clock
+  ep.io.reset := reset.asBool
+
+  // The enclosed TAP must be clocked from TCK (see JtagTapGenerator docs).
+  val tapClock = ep.io.jtag.TCK.asClock
+  withClockAndReset(tapClock, reset) {
+    val idcode = WireInit(0.U.asTypeOf(new JTAGIdcodeBundle()))
+    idcode.always1    := 1.U
+    idcode.version    := 0.U
+    idcode.partNumber := 0.U
+    idcode.mfrId      := 0.U
+
+    // No instructions other than IDCODE; every other IR value maps to BYPASS.
+    // The initial instruction after Test-Logic-Reset is IDCODE, so a bare
+    // Shift-DR returns the IDCODE without shifting the IR first.
+    val tapIO = JtagTapGenerator(irLength = 5, instructions = Map.empty[BigInt, Chain], icode = Some(BigInt(1)))
+    tapIO.idcode.get         := idcode
+    tapIO.jtag.TCK           := tapClock
+    tapIO.jtag.TMS           := ep.io.jtag.TMS
+    tapIO.jtag.TDI           := ep.io.jtag.TDI
+    ep.io.jtag.TDO           := tapIO.jtag.TDO.data
+    tapIO.control.jtag_reset := reset.asAsyncReset
+  }
+}
+
+class JTAGModule(implicit p: Parameters) extends firesim.lib.testutils.PeekPokeHarness(() => new JTAGDUT)

--- a/generators/firechip/bridgestubs/src/test/scala/BridgeSuite.scala
+++ b/generators/firechip/bridgestubs/src/test/scala/BridgeSuite.scala
@@ -94,10 +94,36 @@ class BlockDevTest(targetConfig: BasePlatformConfig)
 
 class BlockDevF1Test extends BlockDevTest(BaseConfigs.F1)
 
+class JTAGTest(targetConfig: BasePlatformConfig) extends BridgeSuite("JTAGModule", "NoConfig", targetConfig) {
+  // Reserve an ephemeral TCP port and release it immediately, then pass it to
+  // both the bridge's remote_bitbang server and the in-simulation client via the
+  // +jtag_rbb_port plusarg. This keeps parallel test jobs from colliding on the
+  // fixed default port; the client retries the connection to cover the window
+  // between release here and the server binding in the simulator.
+  private def freeTcpPort(): Int = {
+    val socket = new java.net.ServerSocket(0)
+    try socket.getLocalPort
+    finally socket.close()
+  }
+
+  override def defineTests(backend: String, debug: Boolean) {
+    it should "read the TAP IDCODE over remote_bitbang" in {
+      // The C++ JTAGModule test embeds the remote_bitbang client: it resets the
+      // TAP, shifts out the 32-bit IDCODE twice, asserts it equals 0x00000001,
+      // and returns a non-zero exit code on any failure.
+      val runResult = run(backend, debug, args = Seq(s"+jtag_rbb_port=${freeTcpPort()}"))
+      assert(runResult == 0)
+    }
+  }
+}
+
+class JTAGF1Test extends JTAGTest(BaseConfigs.F1)
+
 class BridgeTests
     extends Suites(
       new UARTF1Test,
       new BlockDevF1Test,
+      new JTAGF1Test,
       new TracerVF1TestCount1,
       new TracerVF1TestCount6,
       new TracerVF1TestCount7,

--- a/generators/firechip/chip/src/main/scala/BridgeBinders.scala
+++ b/generators/firechip/chip/src/main/scala/BridgeBinders.scala
@@ -99,6 +99,32 @@ class WithDMIBridge extends HarnessBinder({
   }
 })
 
+/** Direct JTAG bridge binder.
+  *
+  * Exposes the target's JTAG DTM pins (TCK/TMS/TDI/TDO) to the host through the
+  * FireSim `JTAGBridge`. The host-side driver (`jtagbridge_t`) runs an
+  * OpenOCD-compatible remote_bitbang server, so an external JTAG client such as
+  * OpenOCD can drive the target TAP for debug.
+  *
+  * Enabling: add this binder to a FireSim config that exposes a `JTAGPort`. See
+  * `FireSimDirectJTAGRocketConfig` for a ready-made Rocket example.
+  *
+  * Runtime: the server listens on TCP port `25000 + <bridge index>` by default;
+  * override it with the `+jtag_rbb_port=<port>` plusarg. Connect OpenOCD with the
+  * `remote_bitbang` adapter driver, e.g.
+  * `adapter driver remote_bitbang; remote_bitbang host localhost; remote_bitbang port 25000`.
+  *
+  * Performance: the remote_bitbang protocol is bit-banged, so each JTAG bit costs
+  * several host operations (TCK low, TCK high, and an optional TDO read) and debug
+  * throughput is low. Default (non-JTAG) behavior is unchanged because the bridge
+  * is opt-in.
+  */
+class WithJTAGBridge extends HarnessBinder({
+  case (th: FireSim, port: JTAGPort, chipId: Int) => {
+    JTAGBridge(th.harnessBinderClock, port.io, th.harnessBinderReset.asBool)(th.p)
+  }
+})
+
 class WithNICBridge extends HarnessBinder({
   case (th: FireSim, port: NICPort, chipId: Int) => {
     NICBridge(port.io.clock, port.io.bits)(th.p)

--- a/generators/firechip/chip/src/main/scala/TargetConfigs.scala
+++ b/generators/firechip/chip/src/main/scala/TargetConfigs.scala
@@ -12,7 +12,7 @@ import freechips.rocketchip.tile._
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.devices.tilelink.{BootROMLocated}
-import freechips.rocketchip.devices.debug.{DebugModuleKey}
+import freechips.rocketchip.devices.debug.{DebugModuleKey, DefaultDebugModuleParams}
 import freechips.rocketchip.diplomacy.{AddressSet}
 import freechips.rocketchip.prci.{AsynchronousCrossing}
 import testchipip.cosim.{TracePortKey}
@@ -247,6 +247,25 @@ class FireSimDmiRocketConfig extends Config(
   new WithDefaultFireSimBridges ++
   new WithFireSimConfigTweaks ++
   new chipyard.dmiRocketConfig)
+
+// Direct JTAG config: exposes the target's JTAG DTM through the FireSim JTAGBridge
+// so a host-side remote_bitbang server (OpenOCD) can drive it. The base
+// chipyard.RocketConfig exposes a JTAG DTM by default (WithJtagDTM in AbstractConfig).
+//
+// WithFireSimConfigTweaks disables the debug module by default (WithNoDebug); this
+// config re-enables it with clock-gating off so the JTAG DTM is present. The stock
+// Rocket JTAG TAP contains negedge-clocked logic, but Golden Gate's FAME-1 transform
+// lowers it to enable-gated posedge logic, so the DTM works on the official rocket-chip
+// revision with no rocket-chip changes required.
+class FireSimDirectJTAGRocketConfig extends Config(
+  new chipyard.harness.WithSerialTLTiedOff ++ // (must be at top) tieoff serialTL so only the JTAG DTM is exposed
+  new WithJTAGBridge ++
+  new WithDefaultFireSimBridges ++
+  new Config((site, here, up) => {
+    case DebugModuleKey => Some(DefaultDebugModuleParams(64).copy(clockGate = false)) // RV64 FireSim targets
+  }) ++
+  new WithFireSimConfigTweaks ++
+  new chipyard.RocketConfig)
 
 //*****************************************************************
 // Boom config, base off chipyard's LargeBoomV3Config

--- a/generators/firechip/goldengateimplementations/src/main/scala/JTAGBridge.scala
+++ b/generators/firechip/goldengateimplementations/src/main/scala/JTAGBridge.scala
@@ -1,0 +1,62 @@
+// See LICENSE for license details
+
+package firechip.goldengateimplementations
+
+import chisel3._
+
+import org.chipsalliance.cde.config.Parameters
+
+import midas.widgets._
+import firesim.lib.bridgeutils._
+
+import firechip.bridgeinterfaces._
+
+// Host-side Golden Gate implementation of the direct JTAG bridge.
+//
+// The host controls the target's JTAG pins over MMIO:
+//   - tck/tms/tdi are write-only registers driven from the host driver
+//   - tdo is a read-only register that captures the target's TDO whenever a
+//     target token is exchanged (`fire`)
+// Each bridge tick exchanges one target token and corresponds to one host
+// remote_bitbang operation (a pin update or a TDO sample), so the host driver
+// fully owns JTAG timing. A token is a single pin/TDO operation, not a complete
+// JTAG bit; a full bit needs at least a TCK-low then TCK-high pin update, with a
+// separate TDO read when the client requests one.
+class JTAGBridgeModule(bridgeParams: JTAGBridgeParams)(implicit p: Parameters)
+    extends BridgeModule[HostPortIO[JTAGBridgeTargetIO]]()(p) {
+  lazy val module = new BridgeModuleImp(this) {
+    val io = IO(new WidgetIO)
+    val hPort = IO(HostPort(new JTAGBridgeTargetIO))
+
+    val target = hPort.hBits.jtag
+
+    val tckReg = RegInit(false.B)
+    val tmsReg = RegInit(true.B)
+    val tdiReg = RegInit(true.B)
+    val tdoReg = Reg(Bool())
+
+    val fire = hPort.toHost.hValid && hPort.fromHost.hReady
+
+    hPort.toHost.hReady := fire
+    hPort.fromHost.hValid := fire
+
+    when(fire) {
+      tdoReg := target.TDO
+    }
+
+    target.TCK := tckReg
+    target.TMS := tmsReg
+    target.TDI := tdiReg
+
+    genWOReg(tckReg, "tck")
+    genWOReg(tmsReg, "tms")
+    genWOReg(tdiReg, "tdi")
+    genROReg(tdoReg, "tdo")
+
+    genCRFile()
+
+    override def genHeader(base: BigInt, memoryRegions: Map[String, BigInt], sb: StringBuilder): Unit = {
+      genConstructor(base, sb, "jtagbridge_t", "jtagbridge")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add an opt-in FireChip bridge that exposes target JTAG through the OpenOCD remote-bitbang protocol.
- Add the host bridge driver and shared Berkeley remote-bitbang server support.
- Add a repository-native bridge test that resets the TAP and reads the IDCODE twice.

## Implementation

The bridge connects the target TCK, TMS, TDI, and TDO pins to a Golden Gate widget. The host driver consumes one remote-bitbang command per bridge tick and advances one target token for each pin update or TDO sample. A complete JTAG bit therefore uses multiple bridge operations.

The bridge is enabled by `WithJTAGBridge` and the provided direct-JTAG FireSim configuration. Default FireChip configurations remain unchanged.

## Testing

- FireChip Scala and test compilation
- Direct-JTAG and default configuration elaboration
- C++ bridge-driver compile and link
- Repository-native Verilator bridge test
- Two successful `0x00000001` IDCODE reads
- OpenOCD 0.12.0 remote-bitbang TAP detection was validated before the final non-protocol cleanup
- Clean default-config regression

The F1 test registration follows the existing upstream BridgeSuite pattern; functional metasim validation was run on the locally supported platform.
