### PR TITLE
docs: make SKIP_URL_CHECK=1 actually bypass the gh-file-ref URL checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -378,24 +378,25 @@ def gh_file_ref_role(name, rawtext, text, lineno, inliner, options={}, content=[
     
     url = f"{repo_url}/blob/{version}/{text}"
 
-    print(f"Testing GitHub URL {url} exists...")
-    try:
-        status_code = requests.get(url).status_code
-        if status_code != 200:
-            message = f"[Line {lineno}] :{name}:`{text}` produces URL {url} returning status code {status_code}. " \
-                    "Ensure your path is correct and all commits that may have moved or renamed files have been pushed to github.com."
-            print(message)
-            sys.exit(1)  # Exit with error in all environments to catch dead links
-    except requests.exceptions.ConnectionError as e:
-        print(f"Warning: Network error when verifying URL {url}: {e}")
-        print("If you're working offline, you can set the SKIP_URL_CHECK=1 environment variable to bypass URL checks.")
-        if os.environ.get("SKIP_URL_CHECK") != "1":
+    # SKIP_URL_CHECK=1 bypasses the external URL verification entirely so local
+    # and offline docs builds (e.g. the Starlight sync) don't depend on network
+    # access to github.com. CI leaves it unset to keep validating for dead links.
+    if os.environ.get("SKIP_URL_CHECK") != "1":
+        print(f"Testing GitHub URL {url} exists...")
+        try:
+            status_code = requests.get(url).status_code
+            if status_code != 200:
+                message = f"[Line {lineno}] :{name}:`{text}` produces URL {url} returning status code {status_code}. " \
+                        "Ensure your path is correct and all commits that may have moved or renamed files have been pushed to github.com."
+                print(message)
+                sys.exit(1)  # Exit with error in all environments to catch dead links
+        except requests.exceptions.ConnectionError as e:
+            print(f"Warning: Network error when verifying URL {url}: {e}")
+            print("If you're working offline, you can set the SKIP_URL_CHECK=1 environment variable to bypass URL checks.")
             sys.exit(1)
-        else:
-            print("Continuing build with SKIP_URL_CHECK=1")
-    except Exception as e:
-        print(f"Warning: Failed to verify URL {url}: {e}")
-        sys.exit(1)
+        except Exception as e:
+            print(f"Warning: Failed to verify URL {url}: {e}")
+            sys.exit(1)
 
     docutils.parsers.rst.roles.set_classes(options)
     node = docutils.nodes.reference(rawtext, text, refuri=url, **options)


### PR DESCRIPTION
This PR proposes making the documentation build's `SKIP_URL_CHECK=1` escape hatch actually skip the external github.com link checks, so local and offline docs builds no longer depend on network access. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/240. You can sign in with your GitHub ID to claim ownership of the project.

## What this changes

`docs/conf.py` defines the `:gh-file-ref:` role, which verifies every referenced repo path by issuing a live `requests.get()` to `github.com` while Sphinx builds the docs. `SKIP_URL_CHECK=1` is documented as the way to turn those checks off for offline and local work: `docs/README.md` says it "lets the build continue if the custom external URL checks cannot access the network," the role prints "set the SKIP_URL_CHECK=1 environment variable to bypass URL checks," and `docs/scripts/sphinx_to_starlight.py` sets it (`env.setdefault("SKIP_URL_CHECK", "1")`) so the Starlight sync does not need the network.

The problem is that the flag is only consulted inside the `ConnectionError` branch. The `requests.get()` call is still made for every reference regardless of the flag, and a non-200 response or a read timeout still aborts the whole build via `sys.exit(1)` even when `SKIP_URL_CHECK=1` is set. So the documented escape hatch does not actually bypass the checks: `npm run build` / `npm run dev` / the Sphinx preview still reach out to github.com once per reference and remain fragile to anything other than a clean connection failure.

## Reproduction at current `main`

From `docs/`, run the Starlight-sync Sphinx build with the flag set:

```
SKIP_URL_CHECK=1 python -m sphinx -b html . _build/check -q
```

At `e27c656` this still prints `Testing GitHub URL https://github.com/... exists...` and makes a network request for each of the `:gh-file-ref:` references (16 in the sources; 13 in the built pages). In a network-restricted run one of those requests timed out against `github.com` — exactly the situation the flag is supposed to make safe.

## The fix

Guard the entire verification block behind `if os.environ.get("SKIP_URL_CHECK") != "1":` so the flag skips the network access completely, and drop the now-unreachable inner `SKIP_URL_CHECK` conditional in the `ConnectionError` handler. When the flag is unset the behavior is byte-for-byte unchanged, so the dead-link validation your CI relies on (`make -C docs html`, which does not set the flag) still runs and still fails on a genuinely missing path.

## Verification

With the change, the same command above makes zero requests to github.com and completes without touching the network, while an unset flag still performs the check and still exits non-zero on a dead link. I confirmed both directions with a focused check that drives the role directly: with `SKIP_URL_CHECK=1` it returns the reference node without calling `requests.get`, and with the flag unset it performs the request. The Sphinx build was run before and after the change with no new failures (the flag-set build went from 13 network checks to zero; the flag-unset verification path is byte-for-byte unchanged).

## Backward compatibility

The change is opt-in and additive: only the `SKIP_URL_CHECK=1` code path is affected, and only to match its already-documented contract. Builds that do not set the variable (including CI) keep validating links exactly as before.

## How this was managed

This work was tracked on a live board that mirrors this repository's history, imported from your own issues and pull requests (2,286 stories and 26 labels). The specific item for this change is at https://eastagiletracker.com/projects/240/stories/126308, and the full board is at https://eastagiletracker.com/projects/240.

![board](https://raw.githubusercontent.com/eastagiletracker/chipyard/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
