### PR TITLE
Fix spec2026 submodule for CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -165,4 +165,4 @@
 	url = https://github.com/ucb-bar/radiance.git
 [submodule "software/spec2026"]
 	path = software/spec2026
-	url = git@github.com:ucb-bar/spec2026-workload.git
+	url = https://github.com/ucb-bar/spec2026-workload.git

--- a/scripts/init-submodules-no-riscv-tools-nolog.sh
+++ b/scripts/init-submodules-no-riscv-tools-nolog.sh
@@ -199,6 +199,7 @@ cd "$RDIR"
             software/coremark \
             software/firemarshal \
             software/spec2017 \
+            software/spec2026 \
             software/zephyrproject/zephyr \
             tools/dsptools \
             tools/rocket-dsp-utils \


### PR DESCRIPTION
Treats spec2026 workload as the 2017 to avoid the CI failing

<!--
First, please ensure that the title of your PR is sufficient to include in the next changelog.
Refer to https://github.com/ucb-bar/chipyard/releases for examples and feel free to ask reviewers for help.

Then, make sure to label your PR with one of the changelog:<section> labels to indicate which section
of the changelog should contain this PR's title:
  changelog:added
  changelog:changed
  changelog:fixed
  changelog:removed

If you feel that this PR should not be included in the changelog, you must still label it with
changelog:omit

Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

**Related PRs / Issues**:
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [x] Bug fix
- [ ] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] RTL change
- [ ] Software change (RISC-V software)
- [ ] Build system change
- [x] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [x] Did you set `main` as the base branch?
- [ ] Is this PR's title suitable for inclusion in the changelog and have you added a `changelog:<topic>` label?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] Did you mark the PR with a `changelog:` label?
- [ ] (If applicable) Did you update the conda `.conda-lock.yml` file if you updated the conda requirements file?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you add a test demonstrating the PR?
<!-- Do this if this PR is a bugfix that should be applied to the latest release -->
- [ ] (If applicable) Did you mark the PR as `Please Backport`?


**CI Help**:
Add the following labels to modify the CI for a set of features.
Generally, a label added only affect subsequent changes to the PR (i.e. new commits, force pushing, closing/reopening).
See `ci:*` for full list of labels:
- `ci:fpga-deploy` - Run FPGA-based E2E testing
- `ci:local-fpga-buildbitstream-deploy` - Build local FPGA bitstreams for platforms that are released
- `ci:disable` - Disable CI
